### PR TITLE
feat: create household_members junction table (task-012)

### DIFF
--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -18,7 +18,8 @@ INSERT INTO schema_migrations (version, name, applied_at)
 VALUES 
   ('000', 'create_migrations_table', NOW()),
   ('001', 'create_users_table', NOW()),
-  ('011', 'create_households_table', NOW())
+  ('011', 'create_households_table', NOW()),
+  ('012', 'create_household_members_table', NOW())
 ON CONFLICT (version) DO NOTHING;
 
 -- Users table for authentication (supports email/password and OAuth)
@@ -48,6 +49,19 @@ CREATE TABLE IF NOT EXISTS households (
   created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
+
+-- Household members junction table (user-household many-to-many with roles)
+CREATE TABLE IF NOT EXISTS household_members (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  household_id UUID NOT NULL REFERENCES households(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  role VARCHAR(50) NOT NULL CHECK (role IN ('admin', 'parent', 'child')),
+  joined_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE(household_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_household_members_household ON household_members(household_id);
+CREATE INDEX IF NOT EXISTS idx_household_members_user ON household_members(user_id);
 
 -- Sample items table (for testing)
 CREATE TABLE IF NOT EXISTS items (

--- a/docker/postgres/migrations/012_create_household_members_table.sql
+++ b/docker/postgres/migrations/012_create_household_members_table.sql
@@ -1,0 +1,36 @@
+-- Migration: 012_create_household_members_table
+-- Description: Create household_members junction table for user-household many-to-many relationships with roles
+-- Date: 2025-12-14
+-- Related Task: task-012-create-household-members-table
+-- Author: Database Agent
+
+BEGIN;
+
+-- Create household_members junction table
+-- Implements many-to-many relationship between users and households
+-- Supports role-based permissions (admin, parent, child)
+CREATE TABLE IF NOT EXISTS household_members (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  household_id UUID NOT NULL REFERENCES households(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  role VARCHAR(50) NOT NULL CHECK (role IN ('admin', 'parent', 'child')),
+  joined_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE(household_id, user_id)
+);
+
+-- Index for "get all members of household" queries
+CREATE INDEX IF NOT EXISTS idx_household_members_household ON household_members(household_id);
+
+-- Index for "get all households for user" queries
+CREATE INDEX IF NOT EXISTS idx_household_members_user ON household_members(user_id);
+
+-- Record migration
+INSERT INTO schema_migrations (version, name, applied_at)
+VALUES ('012', 'create_household_members_table', NOW())
+ON CONFLICT (version) DO NOTHING;
+
+COMMIT;
+
+-- ROLLBACK NOTES (for reference, not executed):
+-- To rollback this migration, create 012_down.sql in migrations/rollback/ directory:
+-- DROP TABLE IF EXISTS household_members CASCADE;

--- a/tasks/items/task-012-create-household-members-table.md
+++ b/tasks/items/task-012-create-household-members-table.md
@@ -4,11 +4,13 @@
 - **ID**: task-012
 - **Feature**: feature-002 - Multi-Tenant Database Schema
 - **Epic**: epic-001 - Multi-Tenant Foundation
-- **Status**: pending
+- **Status**: completed
 - **Priority**: critical
 - **Created**: 2025-12-14
+- **Completed**: 2025-12-14
 - **Assigned Agent**: database
 - **Estimated Duration**: 3-4 hours
+- **Actual Duration**: 0.5 hours
 
 ## Description
 Create the household_members junction table that implements the many-to-many relationship between users and households. Users can belong to multiple households with different roles (admin, parent, child). This table enables separated parents to manage multiple families, role-based permissions, and household access control.
@@ -23,15 +25,15 @@ Create the household_members junction table that implements the many-to-many rel
 - Test all constraints and indexes
 
 ## Acceptance Criteria
-- [ ] Migration file created (012_create_household_members_table.sql)
-- [ ] Table has id (UUID PK), household_id (FK), user_id (FK), role (CHECK constraint), joined_at
-- [ ] Foreign keys to households and users with CASCADE delete
-- [ ] UNIQUE constraint on (household_id, user_id)
-- [ ] CHECK constraint: role IN ('admin', 'parent', 'child')
-- [ ] Index on household_id: idx_household_members_household
-- [ ] Index on user_id: idx_household_members_user
-- [ ] Migration tested with INSERT attempts (valid and invalid)
-- [ ] init.sql updated
+- [x] Migration file created (012_create_household_members_table.sql)
+- [x] Table has id (UUID PK), household_id (FK), user_id (FK), role (CHECK constraint), joined_at
+- [x] Foreign keys to households and users with CASCADE delete
+- [x] UNIQUE constraint on (household_id, user_id)
+- [x] CHECK constraint: role IN ('admin', 'parent', 'child')
+- [x] Index on household_id: idx_household_members_household
+- [x] Index on user_id: idx_household_members_user
+- [x] Migration tested with INSERT attempts (valid and invalid)
+- [x] init.sql updated
 
 ## Dependencies
 - task-011: Households table must exist
@@ -116,10 +118,26 @@ EOF
 
 ## Progress Log
 - [2025-12-14 00:20] Task created from feature-002 breakdown
+- [2025-12-14 01:10] Status changed to in-progress
+- [2025-12-14 01:15] Migration file 012_create_household_members_table.sql created
+- [2025-12-14 01:20] Updated init.sql with household_members table and indexes
+- [2025-12-14 01:25] Migration applied successfully
+- [2025-12-14 01:30] Table structure verified - all columns and types correct
+- [2025-12-14 01:35] UNIQUE constraint tested - duplicate prevented successfully
+- [2025-12-14 01:40] CHECK constraint tested - invalid role 'guest' rejected
+- [2025-12-14 01:45] CASCADE delete tested - member deleted when household deleted
+- [2025-12-14 01:50] Migration recorded in schema_migrations (version 012)
+- [2025-12-14 01:55] Idempotency confirmed - safe to run multiple times
+- [2025-12-14 02:00] All acceptance criteria met, status changed to completed
 
 ## Related Files
 - `docker/postgres/migrations/012_create_household_members_table.sql`
 - `docker/postgres/init.sql`
 
 ## Lessons Learned
-[To be filled after completion]
+- Foreign key constraints with CASCADE delete work seamlessly
+- UNIQUE constraint on composite key (household_id, user_id) prevents duplicates
+- CHECK constraint validates role values at database level
+- Comprehensive constraint testing caught edge cases early
+- Actual time (0.5h) much faster than estimated (3-4h) - clear specs help
+- Two indexes created for bidirectional queries (household→members, user→households)


### PR DESCRIPTION
## Overview
Implements task-012: Create household_members junction table for user-household many-to-many relationships with role-based permissions.

## Changes
- Created migration file 012_create_household_members_table.sql
- Added household_members table with foreign keys to households and users
- Implemented role-based access (admin, parent, child) with CHECK constraint
- Added UNIQUE constraint on (household_id, user_id) to prevent duplicates
- Created indexes on household_id and user_id for query performance
- Updated init.sql with complete table definition

## Table Schema
`
CREATE TABLE household_members (
  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
  household_id UUID NOT NULL REFERENCES households(id) ON DELETE CASCADE,
  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
  role VARCHAR(50) NOT NULL CHECK (role IN ('admin', 'parent', 'child')),
  joined_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
  UNIQUE(household_id, user_id)
);
`

## Testing
All constraints verified:
- UNIQUE: Duplicate (household_id, user_id) rejected
- CHECK: Invalid role rejected (tested with 'guest')
- CASCADE: Member automatically deleted when household deleted
- Foreign keys: Invalid references prevented
- Migration recorded in schema_migrations (version 012)
- Idempotency confirmed

## Indexes
- idx_household_members_household: For householdmembers queries
- idx_household_members_user: For userhouseholds queries

## Acceptance Criteria
All 9 acceptance criteria met

## Next Steps
After merge:
- Move task-012 to done/ folder
- Start task-013: Create children table

## Related
- Task: task-012-create-household-members-table.md
- Feature: feature-002-multi-tenant-schema.md
- Epic: epic-001-multi-tenant-foundation.md