### PR TITLE
feat: create children table (task-013)

### DIFF
--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -19,7 +19,8 @@ VALUES
   ('000', 'create_migrations_table', NOW()),
   ('001', 'create_users_table', NOW()),
   ('011', 'create_households_table', NOW()),
-  ('012', 'create_household_members_table', NOW())
+  ('012', 'create_household_members_table', NOW()),
+  ('013', 'create_children_table', NOW())
 ON CONFLICT (version) DO NOTHING;
 
 -- Users table for authentication (supports email/password and OAuth)
@@ -63,6 +64,18 @@ CREATE TABLE IF NOT EXISTS household_members (
 CREATE INDEX IF NOT EXISTS idx_household_members_household ON household_members(household_id);
 CREATE INDEX IF NOT EXISTS idx_household_members_user ON household_members(user_id);
 
+-- Children table (profiles for household task assignments)
+CREATE TABLE IF NOT EXISTS children (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  household_id UUID NOT NULL REFERENCES households(id) ON DELETE CASCADE,
+  name VARCHAR(255) NOT NULL,
+  birth_year INTEGER,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_children_household ON children(household_id);
+
 -- Sample items table (for testing)
 CREATE TABLE IF NOT EXISTS items (
   id SERIAL PRIMARY KEY,
@@ -94,6 +107,11 @@ EXECUTE FUNCTION update_updated_at_column();
 
 CREATE TRIGGER update_households_updated_at
 BEFORE UPDATE ON households
+FOR EACH ROW
+EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_children_updated_at
+BEFORE UPDATE ON children
 FOR EACH ROW
 EXECUTE FUNCTION update_updated_at_column();
 

--- a/docker/postgres/migrations/013_create_children_table.sql
+++ b/docker/postgres/migrations/013_create_children_table.sql
@@ -1,0 +1,31 @@
+-- Migration: 013_create_children_table
+-- Description: Create children table scoped to households for child profiles used in task assignments
+-- Date: 2025-12-14
+-- Related Task: task-013-create-children-table
+-- Author: Database Agent
+
+BEGIN;
+
+-- Create children table
+CREATE TABLE IF NOT EXISTS children (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  household_id UUID NOT NULL REFERENCES households(id) ON DELETE CASCADE,
+  name VARCHAR(255) NOT NULL,
+  birth_year INTEGER,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Index for household-scoped queries
+CREATE INDEX IF NOT EXISTS idx_children_household ON children(household_id);
+
+-- Record migration
+INSERT INTO schema_migrations (version, name, applied_at)
+VALUES ('013', 'create_children_table', NOW())
+ON CONFLICT (version) DO NOTHING;
+
+COMMIT;
+
+-- ROLLBACK NOTES (for reference, not executed):
+-- To rollback this migration, create 013_down.sql in migrations/rollback/ directory:
+-- DROP TABLE IF EXISTS children CASCADE;

--- a/tasks/items/task-011-create-households-table.md
+++ b/tasks/items/task-011-create-households-table.md
@@ -1,0 +1,121 @@
+# Task: Create Households Table
+
+## Metadata
+- **ID**: task-011
+- **Feature**: feature-002 - Multi-Tenant Database Schema
+- **Epic**: epic-001 - Multi-Tenant Foundation
+- **Status**: completed
+- **Priority**: critical
+- **Created**: 2025-12-14
+- **Completed**: 2025-12-14
+- **Assigned Agent**: database
+- **Estimated Duration**: 2-3 hours
+- **Actual Duration**: 0.5 hours
+
+## Description
+Create the households table which serves as the primary tenant identifier in the multi-tenant architecture. This table is the foundation for data isolation, with all other tables referencing household_id to ensure proper data scoping. Every query must filter by household_id to prevent data leaks between families.
+
+## Requirements
+- Create households table with UUID primary key
+- Include name, created_at, updated_at columns
+- Use gen_random_uuid() for automatic UUID generation
+- Create migration file following project conventions
+- Test migration up and down (idempotent)
+- Update init.sql for fresh installs
+
+## Acceptance Criteria
+- [x] Migration file created in `docker/postgres/migrations/` with proper naming (011_create_households_table.sql)
+- [x] Households table has id (UUID PK), name (VARCHAR 255 NOT NULL), created_at, updated_at
+- [x] Migration uses IF NOT EXISTS for idempotency
+- [x] Migration records itself in schema_migrations table
+- [x] Migration tested locally (up and down)
+- [x] init.sql updated with households table
+- [x] Migration follows project conventions from migrations/README.md
+
+## Dependencies
+- PostgreSQL 17 database running
+- Migration system from task-001 (already complete)
+- Users table from feature-001 (already complete)
+
+## Technical Notes
+
+### Table Schema
+```sql
+CREATE TABLE IF NOT EXISTS households (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### Migration File Structure
+- Use TEMPLATE.sql as starting point
+- Name: `011_create_households_table.sql`
+- Wrap in BEGIN/COMMIT transaction
+- Record in schema_migrations
+- Make idempotent with IF NOT EXISTS
+
+### Testing Commands
+```bash
+# Apply migration
+docker exec -i st44-db psql -U postgres -d st44 < docker/postgres/migrations/011_create_households_table.sql
+
+# Verify
+docker exec -it st44-db psql -U postgres -d st44 -c "\d households"
+docker exec -it st44-db psql -U postgres -d st44 -c "SELECT * FROM schema_migrations ORDER BY version;"
+```
+
+## Affected Areas
+- [x] Database (PostgreSQL)
+- [ ] Backend (Fastify/Node.js)
+- [ ] Frontend (Angular)
+- [ ] Infrastructure (Docker/Nginx)
+- [ ] CI/CD
+- [x] Documentation
+
+## Implementation Plan
+
+### Research Phase
+- [x] Review migration system documentation
+- [x] Review existing migrations (001-010)
+- [x] Understand households table requirements
+
+### Implementation Steps
+1. Create migration file `011_create_households_table.sql`
+2. Add CREATE TABLE IF NOT EXISTS households with proper columns
+3. Add migration tracking INSERT INTO schema_migrations
+4. Wrap in BEGIN/COMMIT transaction
+5. Test migration locally
+6. Update init.sql with households table
+7. Verify table structure with \d command
+
+### Testing Strategy
+- Apply migration and verify table created
+- Check schema_migrations entry
+- Verify column types and constraints
+- Test migration idempotency (run twice)
+- Verify init.sql includes new table
+
+## Progress Log
+- [2025-12-14 00:20] Task created from feature-002 breakdown
+- [2025-12-14 00:30] Status changed to in-progress
+- [2025-12-14 00:35] Migration file 011_create_households_table.sql created
+- [2025-12-14 00:40] Updated init.sql with households table and trigger
+- [2025-12-14 00:45] Migration applied successfully to database
+- [2025-12-14 00:50] Table structure verified - id (UUID PK), name (VARCHAR 255), created_at, updated_at
+- [2025-12-14 00:55] Migration recorded in schema_migrations (version 011)
+- [2025-12-14 01:00] Idempotency tested - migration can be run multiple times safely
+- [2025-12-14 01:05] All acceptance criteria met, status changed to completed
+
+## Related Files
+- `docker/postgres/migrations/011_create_households_table.sql` - Migration file
+- `docker/postgres/init.sql` - Fresh install script
+- `docker/postgres/migrations/README.md` - Migration conventions
+
+## Lessons Learned
+- Migration creation was straightforward following TEMPLATE.sql conventions
+- IF NOT EXISTS clause ensures idempotent migrations
+- Including triggers in init.sql maintains consistency with migration files
+- Testing with information_schema.columns provides clear verification
+- Actual time (0.5h) was much faster than estimated (2-3h) due to clear specifications

--- a/tasks/items/task-012-create-household-members-table.md
+++ b/tasks/items/task-012-create-household-members-table.md
@@ -1,0 +1,143 @@
+# Task: Create Household Members Junction Table
+
+## Metadata
+- **ID**: task-012
+- **Feature**: feature-002 - Multi-Tenant Database Schema
+- **Epic**: epic-001 - Multi-Tenant Foundation
+- **Status**: completed
+- **Priority**: critical
+- **Created**: 2025-12-14
+- **Completed**: 2025-12-14
+- **Assigned Agent**: database
+- **Estimated Duration**: 3-4 hours
+- **Actual Duration**: 0.5 hours
+
+## Description
+Create the household_members junction table that implements the many-to-many relationship between users and households. Users can belong to multiple households with different roles (admin, parent, child). This table enables separated parents to manage multiple families, role-based permissions, and household access control.
+
+## Requirements
+- Create household_members table with proper foreign keys
+- Support three roles: admin, parent, child
+- Enforce unique constraint (one user per household)
+- Add indexes on household_id and user_id for performance
+- Include joined_at timestamp for audit trail
+- Create migration file following conventions
+- Test all constraints and indexes
+
+## Acceptance Criteria
+- [x] Migration file created (012_create_household_members_table.sql)
+- [x] Table has id (UUID PK), household_id (FK), user_id (FK), role (CHECK constraint), joined_at
+- [x] Foreign keys to households and users with CASCADE delete
+- [x] UNIQUE constraint on (household_id, user_id)
+- [x] CHECK constraint: role IN ('admin', 'parent', 'child')
+- [x] Index on household_id: idx_household_members_household
+- [x] Index on user_id: idx_household_members_user
+- [x] Migration tested with INSERT attempts (valid and invalid)
+- [x] init.sql updated
+
+## Dependencies
+- task-011: Households table must exist
+- feature-001: Users table must exist (already complete)
+
+## Technical Notes
+
+### Table Schema
+```sql
+CREATE TABLE IF NOT EXISTS household_members (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  household_id UUID NOT NULL REFERENCES households(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  role VARCHAR(50) NOT NULL CHECK (role IN ('admin', 'parent', 'child')),
+  joined_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE(household_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_household_members_household ON household_members(household_id);
+CREATE INDEX IF NOT EXISTS idx_household_members_user ON household_members(user_id);
+```
+
+### Role Definitions
+- **admin**: Can manage household settings, invite users, delete household
+- **parent**: Can create tasks, assign tasks, view reports
+- **child**: Can view own tasks, mark tasks complete (future: linked to child profile)
+
+### Performance Considerations
+- Index on household_id for "get all members of household" queries
+- Index on user_id for "get all households for user" queries
+- Both columns frequently used in WHERE clauses
+
+### Testing Commands
+```bash
+# Apply migration
+docker exec -i st44-db psql -U postgres -d st44 < docker/postgres/migrations/012_create_household_members_table.sql
+
+# Test constraints
+docker exec -it st44-db psql -U postgres -d st44 <<EOF
+-- Should succeed
+INSERT INTO households (name) VALUES ('Test Family') RETURNING id;
+INSERT INTO household_members (household_id, user_id, role) 
+VALUES ('<household-id>', '<user-id>', 'admin');
+
+-- Should fail (duplicate)
+INSERT INTO household_members (household_id, user_id, role) 
+VALUES ('<same-household-id>', '<same-user-id>', 'parent');
+
+-- Should fail (invalid role)
+INSERT INTO household_members (household_id, user_id, role) 
+VALUES ('<household-id>', '<user-id>', 'superuser');
+EOF
+```
+
+## Affected Areas
+- [x] Database (PostgreSQL)
+- [ ] Backend (Fastify/Node.js)
+- [ ] Frontend (Angular)
+- [ ] Infrastructure (Docker/Nginx)
+- [ ] CI/CD
+- [x] Documentation
+
+## Implementation Plan
+
+### Implementation Steps
+1. Create migration file `012_create_household_members_table.sql`
+2. Add CREATE TABLE with all columns
+3. Add foreign key constraints with CASCADE
+4. Add UNIQUE constraint on (household_id, user_id)
+5. Add CHECK constraint for role validation
+6. Create indexes on household_id and user_id
+7. Add migration tracking
+8. Test all constraints
+9. Update init.sql
+
+### Testing Strategy
+- Test foreign key constraints (valid and invalid references)
+- Test UNIQUE constraint (duplicate prevention)
+- Test CHECK constraint (invalid roles rejected)
+- Test CASCADE delete behavior
+- Test index performance with EXPLAIN ANALYZE
+
+## Progress Log
+- [2025-12-14 00:20] Task created from feature-002 breakdown
+- [2025-12-14 01:10] Status changed to in-progress
+- [2025-12-14 01:15] Migration file 012_create_household_members_table.sql created
+- [2025-12-14 01:20] Updated init.sql with household_members table and indexes
+- [2025-12-14 01:25] Migration applied successfully
+- [2025-12-14 01:30] Table structure verified - all columns and types correct
+- [2025-12-14 01:35] UNIQUE constraint tested - duplicate prevented successfully
+- [2025-12-14 01:40] CHECK constraint tested - invalid role 'guest' rejected
+- [2025-12-14 01:45] CASCADE delete tested - member deleted when household deleted
+- [2025-12-14 01:50] Migration recorded in schema_migrations (version 012)
+- [2025-12-14 01:55] Idempotency confirmed - safe to run multiple times
+- [2025-12-14 02:00] All acceptance criteria met, status changed to completed
+
+## Related Files
+- `docker/postgres/migrations/012_create_household_members_table.sql`
+- `docker/postgres/init.sql`
+
+## Lessons Learned
+- Foreign key constraints with CASCADE delete work seamlessly
+- UNIQUE constraint on composite key (household_id, user_id) prevents duplicates
+- CHECK constraint validates role values at database level
+- Comprehensive constraint testing caught edge cases early
+- Actual time (0.5h) much faster than estimated (3-4h) - clear specs help
+- Two indexes created for bidirectional queries (household→members, user→households)

--- a/tasks/items/task-013-create-children-table.md
+++ b/tasks/items/task-013-create-children-table.md
@@ -4,11 +4,13 @@
 - **ID**: task-013
 - **Feature**: feature-002 - Multi-Tenant Database Schema
 - **Epic**: epic-001 - Multi-Tenant Foundation
-- **Status**: pending
+- **Status**: completed
 - **Priority**: critical
 - **Created**: 2025-12-14
+- **Completed**: 2025-12-14
 - **Assigned Agent**: database
 - **Estimated Duration**: 2-3 hours
+- **Actual Duration**: 0.5 hours
 
 ## Description
 Create the children table to store child profiles within households. These profiles represent the children who will be assigned tasks (separate from user accounts). A child profile includes name and birth year for age-appropriate task assignment. This enables the core functionality of the chore app: assigning tasks to specific children.
@@ -23,13 +25,13 @@ Create the children table to store child profiles within households. These profi
 - Test data isolation (children only visible to their household)
 
 ## Acceptance Criteria
-- [ ] Migration file created (013_create_children_table.sql)
-- [ ] Table has id (UUID PK), household_id (FK), name (VARCHAR 255 NOT NULL), birth_year (INTEGER), created_at, updated_at
-- [ ] Foreign key to households with ON DELETE CASCADE
-- [ ] Index on household_id: idx_children_household
-- [ ] Migration tested with sample data
-- [ ] init.sql updated
-- [ ] Data isolation verified (cannot see other household's children)
+- [x] Migration file created (013_create_children_table.sql)
+- [x] Table has id (UUID PK), household_id (FK), name (VARCHAR 255 NOT NULL), birth_year (INTEGER), created_at, updated_at
+- [x] Foreign key to households with ON DELETE CASCADE
+- [x] Index on household_id: idx_children_household
+- [x] Migration tested with sample data
+- [x] init.sql updated
+- [x] Data isolation verified (cannot see other household's children)
 
 ## Dependencies
 - task-011: Households table must exist
@@ -113,10 +115,22 @@ EOF
 
 ## Progress Log
 - [2025-12-14 00:20] Task created from feature-002 breakdown
+- [2025-12-14 02:10] Status changed to in-progress
+- [2025-12-14 02:15] Migration file 013_create_children_table.sql created
+- [2025-12-14 02:20] Updated init.sql with children table, index, and trigger
+- [2025-12-14 02:25] Migration applied successfully and columns verified
+- [2025-12-14 02:30] Sample data inserted and scoped queries verified
+- [2025-12-14 02:35] CASCADE delete verified (children removed with household)
+- [2025-12-14 02:40] Migration recorded in schema_migrations (version 013)
+- [2025-12-14 02:45] Idempotency confirmed (safe to run multiple times)
+- [2025-12-14 02:50] All acceptance criteria met, status changed to completed
 
 ## Related Files
 - `docker/postgres/migrations/013_create_children_table.sql`
 - `docker/postgres/init.sql`
 
 ## Lessons Learned
-[To be filled after completion]
+- Index on household_id ensures efficient scoped queries
+- Using birth_year (nullable) balances utility and privacy
+- Clear migration conventions speed up implementation
+- Testing CASCADE deletes prevents orphaned records


### PR DESCRIPTION
## Overview\nImplements task-013: Create children table scoped to households for child profiles used in task assignments.\n\n## Changes\n- Created migration file 013_create_children_table.sql\n- Added children table with foreign key to households (CASCADE delete)\n- Created household_id index for efficient queries\n- Updated init.sql with table, index, and updated_at trigger\n\n## Testing\n- Applied migration and verified columns\n- Inserted sample data and verified household scoping\n- Verified CASCADE delete behavior\n- Migration recorded in schema_migrations (version 013)\n- Idempotency confirmed\n\n## Acceptance Criteria\nAll 7 acceptance criteria met\n\n## Next Steps\nAfter merge:\n- Move task-013 to done/ folder\n- Start task-014: Create tasks table\n\n## Related\n- Task: task-013-create-children-table.md\n- Feature: feature-002-multi-tenant-schema.md\n- Epic: epic-001-multi-tenant-foundation.md