### PR TITLE
hotfix: exclude test files from Docker build

### DIFF
--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -14,5 +14,5 @@
     "allowSyntheticDefaultImports": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
 }


### PR DESCRIPTION
## Problem

Deployment has been failing since PR #28 with this error:
```
src/server.test.ts(3,23): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
```

## Root Cause

- PR #28 added comprehensive tests including `server.test.ts`
- The test file imports with `.ts` extension: `import { build } from './server.ts';`
- This works fine for running tests with Node.js
- But Docker build runs `tsc` which compiles ALL `.ts` files in `src/`
- TypeScript compiler doesn't like `.ts` extensions in imports by default
- Test files shouldn't be compiled for production anyway

## Solution

Updated `apps/backend/tsconfig.json` to exclude test files:
```json
"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
```

## Testing

✅ Tested locally:
- `npm run build` succeeds
- Docker build succeeds: `docker build -f apps/backend/Dockerfile apps/backend`
- Verified `dist/server.js` is generated correctly

## Impact

- **Critical**: Fixes all deployment failures since PR #28
- **Low Risk**: Only changes what files get compiled (excludes tests)
- **No Behavior Change**: Tests still run normally with Node.js test runner

## Files Changed

- `apps/backend/tsconfig.json`: Added test file exclusions

Fixes: All Deploy workflow failures since 2025-12-11
