### PR TITLE
fix: Include migrations in database Docker image and run from container

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,21 +114,10 @@ jobs:
 
       - name: Run Database Migrations
         run: |
-          echo "Copying migration runner to server..."
-          scp -i ~/.ssh/id_deploy docker/postgres/run-migrations.sh \
-            ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }}:/srv/st44-home/docker/postgres/
-          
           echo "Running database migrations..."
           ssh -i ~/.ssh/id_deploy -o StrictHostKeyChecking=yes \
             ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }} \
-            "cd /srv/st44-home && \
-             export DB_HOST=localhost && \
-             export DB_PORT=5432 && \
-             export DB_NAME=st44 && \
-             export DB_USER=postgres && \
-             export DB_PASSWORD='${{ secrets.DB_PASSWORD }}' && \
-             chmod +x docker/postgres/run-migrations.sh && \
-             docker/postgres/run-migrations.sh"
+            "docker exec st44-db /usr/local/bin/run-migrations.sh"
 
       - name: Start Application Services
         run: |

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -3,5 +3,12 @@ FROM postgres:17-alpine
 # Copy initialization script
 COPY init.sql /docker-entrypoint-initdb.d/
 
+# Copy migration runner script and migrations
+COPY run-migrations.sh /usr/local/bin/
+COPY migrations /migrations/
+
+# Make migration script executable
+RUN chmod +x /usr/local/bin/run-migrations.sh
+
 # The postgres image will automatically run any .sql files
 # in /docker-entrypoint-initdb.d/ on first startup

--- a/docker/postgres/run-migrations.sh
+++ b/docker/postgres/run-migrations.sh
@@ -20,8 +20,15 @@ PGPASSWORD="${DB_PASSWORD}"
 
 export PGHOST PGPORT PGDATABASE PGUSER PGPASSWORD
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATIONS_DIR="${SCRIPT_DIR}/migrations"
+# Determine migrations directory
+# When run inside container: /migrations
+# When run on host: ./docker/postgres/migrations
+if [ -d "/migrations" ]; then
+    MIGRATIONS_DIR="/migrations"
+else
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    MIGRATIONS_DIR="${SCRIPT_DIR}/migrations"
+fi
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "  Database Migration Runner"


### PR DESCRIPTION
## Problem

Production database is empty (no tables exist) because migrations were never applied. Root cause investigation revealed:

1. **Production server structure**: /srv/st44-home/ only contains infra/ directory and docker-compose.yml - no repository files
2. **Deployment workflow assumption**: Assumed migration files existed on server at /srv/st44-home/docker/postgres/migrations/
3. **Reality**: Server only pulls pre-built Docker images from GHCR, never clones repository
4. **Result**: Migration files never available on server, migrations never ran

## Solution

This PR fixes the root cause by:

1. **Embed migrations in database Docker image**: Modified docker/postgres/Dockerfile to COPY:
   - un-migrations.sh  /usr/local/bin/ in container
   - migrations/  /migrations/ in container
   
2. **Run migrations from inside container**: Modified deployment workflow to use:
   \\\ash
   docker exec st44-db /usr/local/bin/run-migrations.sh
   \\\
   Instead of trying to scp files to non-existent server directories.

3. **Make migration script portable**: Updated \un-migrations.sh\ to detect container vs host:
   - If \/migrations\ exists  running in container
   - If \./docker/postgres/migrations\ exists  running on host (dev)

## Impact

After this PR merges and CI builds new database image:
-  All migration files embedded in database image (self-contained)
-  Deployment workflow can run migrations via docker exec (no server files needed)
-  Future deployments will auto-apply migrations correctly
-  Aligns with container best practices (image should be self-contained)

## Temporary Fix Needed

Production still needs manual migration application to restore service NOW:
\\\ash
# Temporary fix while waiting for new image
docker exec st44-db /usr/local/bin/psql -U postgres -d st44 << 'EOF'
-- Apply migration 000 manually
-- Apply migration 011 manually
-- etc...
EOF
\\\

## Testing

- [ ] CI builds new database image with migrations embedded
- [ ] Verify migrations/ directory exists in built image
- [ ] Verify run-migrations.sh exists at /usr/local/bin/ in image
- [ ] Deploy and verify migration step succeeds

## Related

- Closes task-023 (database initialization issues)
- Related to PR #38 (migration automation system)