### PR TITLE
feat(task-028): test database setup for E2E

### DIFF
--- a/infra/docker-compose.test.yml
+++ b/infra/docker-compose.test.yml
@@ -1,0 +1,25 @@
+version: '3.9'
+
+services:
+  db-test:
+    image: postgres:17-alpine
+    container_name: st44-db-test
+    environment:
+      POSTGRES_DB: st44_test
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "55432:5432"
+    volumes:
+      - st44-db-test-data:/var/lib/postgresql/data
+      - ../docker/postgres/init.sql:/docker-entrypoint-initdb.d/00_init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d st44_test"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    restart: unless-stopped
+
+volumes:
+  st44-db-test-data:
+    name: st44-db-test-data

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "docker:up": "cd infra && docker compose up -d",
     "docker:down": "cd infra && docker compose down",
     "docker:logs": "cd infra && docker compose logs -f",
-    "docker:restart": "cd infra && docker compose restart"
+    "docker:restart": "cd infra && docker compose restart",
+    "db:test:up": "cd infra && docker compose -f docker-compose.test.yml up -d",
+    "db:test:down": "cd infra && docker compose -f docker-compose.test.yml down -v",
+    "db:test:migrate": "pwsh -Command \"docker exec -i st44-db-test psql -U postgres -d st44_test < docker/postgres/init.sql\""
   },
   "packageManager": "npm@11.6.2"
 }

--- a/tasks/items/task-028-test-database-setup.md
+++ b/tasks/items/task-028-test-database-setup.md
@@ -1,0 +1,56 @@
+# Task: Set up Test Database (task-028)
+
+## Status
+in-progress
+
+## Priority
+high
+
+## Feature
+feature-006-e2e-testing-infrastructure.md - Link to parent feature
+
+## Epic
+epic-006-testing-quality-assurance.md - Link to parent epic
+
+## Description
+Create a dedicated test database setup that can be started and stopped independently of the dev database. Provide commands and configuration to run migrations against the test database and reset it between test runs. This supports Playwright E2E tests and future integration tests.
+
+## Requirements
+- Provide a Docker Compose config for a `st44-db-test` PostgreSQL container
+- Use the existing `docker/postgres/init.sql` for initial schema
+- Add npm scripts to start/stop the test DB and run migrations
+- Keep the solution isolated (does not interfere with dev DB)
+- Document quick usage in this task file
+
+## Acceptance Criteria
+- [ ] `npm run db:test:up` starts a test Postgres on a different port
+- [ ] `npm run db:test:down` stops and removes the test container/volume
+- [ ] `npm run db:test:migrate` applies all migrations to the test DB
+- [ ] E2E tests can target the test DB without affecting dev DB
+- [ ] Instructions added in this file under Technical Notes
+
+## Dependencies
+- task-027 (Playwright setup)
+
+## Technical Notes
+- Compose file: `infra/docker-compose.test.yml`
+- Service name: `db-test` with container name `st44-db-test`
+- Port: 55432 on host → 5432 in container to avoid collision
+- Database: `st44_test` with user/password `postgres`
+- Migrations: reuse `docker/postgres/migrations/*.sql` when available; fallback to `init.sql`
+
+## Implementation Plan
+1. Add `infra/docker-compose.test.yml` defining `db-test` service (Postgres 17)
+2. Mount `docker/postgres/init.sql` to initialize fresh DBs
+3. Add root npm scripts:
+   - `db:test:up` (compose up -d)
+   - `db:test:down` (compose down -v)
+   - `db:test:migrate` (run `psql` from container to apply migrations or `init.sql`)
+4. Document quickstart in this task file
+5. Verify commands locally
+
+## Agent Assignment
+DevOps | Database | Testing Agent
+
+## Progress Log
+- [2025-12-14 12:10] Task created and marked in-progress; branch `feature/task-028-test-database-setup` opened


### PR DESCRIPTION
## Problem
E2E tests need an isolated database that can be started/stopped independently and reset safely, without affecting developer local DB.

## Solution
- Added infra/docker-compose.test.yml with db-test (Postgres 17) on host port 55432
- Mounted docker/postgres/init.sql for initial schema
- Added root npm scripts: db:test:up, db:test:down, db:test:migrate
- Created 	asks/items/task-028-test-database-setup.md with plan and acceptance criteria

## Changes
- Added: infra/docker-compose.test.yml
- Updated: package.json (scripts)
- Added: tasks/items/task-028-test-database-setup.md

## Testing
- Run 
pm run db:test:up to start the test DB
- Run 
pm run db:test:migrate to apply init.sql to st44_test
- Run 
pm run db:test:down to clean up

## Notes
- Uses distinct host port (55432) and DB name (st44_test) to avoid collisions
- Ready for integration with Playwright flows in subsequent tasks (029-030)