### PR TITLE
feat: household membership validation middleware

### DIFF
--- a/apps/backend/src/middleware/household-membership.ts
+++ b/apps/backend/src/middleware/household-membership.ts
@@ -1,0 +1,150 @@
+import { FastifyRequest, FastifyReply } from 'fastify';
+import { pool } from '../database.js';
+
+// UUID validation regex
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isValidUuid(value: string): boolean {
+  return UUID_REGEX.test(value);
+}
+
+// Extend FastifyRequest to include household context
+declare module 'fastify' {
+  interface FastifyRequest {
+    household?: {
+      role: 'admin' | 'parent';
+      householdId: string;
+    };
+  }
+}
+
+interface HouseholdRouteParams {
+  Params: {
+    id?: string;
+    householdId?: string;
+  };
+}
+
+/**
+ * Validates that authenticated user is a member of the household
+ * specified in route params (:id or :householdId).
+ * Attaches household role to request context for downstream use.
+ */
+export async function validateHouseholdMembership(
+  request: FastifyRequest<HouseholdRouteParams>,
+  reply: FastifyReply,
+) {
+  const householdId = request.params.id || request.params.householdId;
+  const userId = request.user?.userId;
+
+  if (!userId) {
+    return reply.status(401).send({
+      error: 'Unauthorized',
+      message: 'Authentication required',
+    });
+  }
+
+  if (!householdId) {
+    return reply.status(400).send({
+      error: 'Bad Request',
+      message: 'Household ID required in route',
+    });
+  }
+
+  if (!isValidUuid(householdId)) {
+    return reply.status(400).send({
+      error: 'Bad Request',
+      message: 'Invalid household ID format',
+    });
+  }
+
+  try {
+    const result = await pool.query(
+      'SELECT role FROM household_members WHERE household_id = $1 AND user_id = $2',
+      [householdId, userId],
+    );
+
+    if (result.rows.length === 0) {
+      request.log.warn(
+        { userId, householdId },
+        'User attempted to access household they are not a member of',
+      );
+      return reply.status(403).send({
+        error: 'Forbidden',
+        message: 'You are not a member of this household',
+      });
+    }
+
+    // Attach household context to request
+    request.household = {
+      role: result.rows[0].role,
+      householdId,
+    };
+
+    // Middleware successful - continue to route handler
+  } catch (error) {
+    request.log.error(error, 'Failed to validate household membership');
+    return reply.status(500).send({
+      error: 'Internal Server Error',
+      message: 'Membership validation failed',
+    });
+  }
+}
+
+/**
+ * Requires user to have admin role in the household.
+ * Must be used AFTER validateHouseholdMembership middleware.
+ */
+export async function requireHouseholdAdmin(request: FastifyRequest, reply: FastifyReply) {
+  const role = request.household?.role;
+
+  if (!role) {
+    request.log.error('requireHouseholdAdmin called without household context');
+    return reply.status(500).send({
+      error: 'Internal Server Error',
+      message: 'Household context missing',
+    });
+  }
+
+  if (role !== 'admin') {
+    request.log.warn(
+      { userId: request.user?.userId, role },
+      'User attempted admin-only action without admin role',
+    );
+    return reply.status(403).send({
+      error: 'Forbidden',
+      message: 'Admin role required for this action',
+    });
+  }
+
+  // Middleware successful - continue to route handler
+}
+
+/**
+ * Requires user to have parent or admin role in the household.
+ * Must be used AFTER validateHouseholdMembership middleware.
+ */
+export async function requireHouseholdParent(request: FastifyRequest, reply: FastifyReply) {
+  const role = request.household?.role;
+
+  if (!role) {
+    request.log.error('requireHouseholdParent called without household context');
+    return reply.status(500).send({
+      error: 'Internal Server Error',
+      message: 'Household context missing',
+    });
+  }
+
+  if (role !== 'admin' && role !== 'parent') {
+    request.log.warn(
+      { userId: request.user?.userId, role },
+      'User attempted parent-level action without sufficient role',
+    );
+    return reply.status(403).send({
+      error: 'Forbidden',
+      message: 'Parent or admin role required for this action',
+    });
+  }
+
+  // Middleware successful - continue to route handler
+}

--- a/tasks/items/task-022-household-membership-middleware.md
+++ b/tasks/items/task-022-household-membership-middleware.md
@@ -4,7 +4,7 @@
 - **ID**: task-022
 - **Feature**: feature-003 - Household Management
 - **Epic**: epic-001 - Multi-Tenant Foundation
-- **Status**: pending
+- **Status**: in-progress
 - **Priority**: high
 - **Created**: 2025-12-14
 - **Assigned Agent**: backend

--- a/test-household-membership.ps1
+++ b/test-household-membership.ps1
@@ -1,0 +1,201 @@
+# Test household membership middleware
+# Tests: authentication, membership validation, role-based authorization
+
+Write-Host "=== Testing Household Membership Middleware ===" -ForegroundColor Cyan
+
+# Test data
+$email1 = "member-test-$([guid]::NewGuid().ToString().Substring(0,8))@example.com"
+$email2 = "nonmember-test-$([guid]::NewGuid().ToString().Substring(0,8))@example.com"
+$password = "SecurePass123!"
+$baseUrl = "http://localhost:3000"
+
+# Register user 1 (will be household admin)
+Write-Host "`nRegistering user 1 (admin)..." -ForegroundColor Yellow
+$registerResponse1 = Invoke-RestMethod -Uri "$baseUrl/api/auth/register" -Method POST `
+    -ContentType "application/json" `
+    -Body (@{ email = $email1; password = $password } | ConvertTo-Json) `
+    -StatusCodeVariable "registerStatus1"
+
+if ($registerStatus1 -eq 201) {
+    Write-Host "✓ User 1 registered: $($registerResponse1.userId)" -ForegroundColor Green
+} else {
+    Write-Host "✗ User 1 registration failed" -ForegroundColor Red
+    exit 1
+}
+
+# Login user 1
+Write-Host "`nLogging in user 1..." -ForegroundColor Yellow
+$loginResponse1 = Invoke-RestMethod -Uri "$baseUrl/api/auth/login" -Method POST `
+    -ContentType "application/json" `
+    -Body (@{ email = $email1; password = $password } | ConvertTo-Json) `
+    -StatusCodeVariable "loginStatus1"
+
+if ($loginStatus1 -eq 200) {
+    $token1 = $loginResponse1.accessToken
+    Write-Host "✓ User 1 logged in" -ForegroundColor Green
+} else {
+    Write-Host "✗ User 1 login failed" -ForegroundColor Red
+    exit 1
+}
+
+# Register user 2 (will not be household member)
+Write-Host "`nRegistering user 2 (non-member)..." -ForegroundColor Yellow
+$registerResponse2 = Invoke-RestMethod -Uri "$baseUrl/api/auth/register" -Method POST `
+    -ContentType "application/json" `
+    -Body (@{ email = $email2; password = $password } | ConvertTo-Json) `
+    -StatusCodeVariable "registerStatus2"
+
+if ($registerStatus2 -eq 201) {
+    Write-Host "✓ User 2 registered: $($registerResponse2.userId)" -ForegroundColor Green
+} else {
+    Write-Host "✗ User 2 registration failed" -ForegroundColor Red
+    exit 1
+}
+
+# Login user 2
+Write-Host "`nLogging in user 2..." -ForegroundColor Yellow
+$loginResponse2 = Invoke-RestMethod -Uri "$baseUrl/api/auth/login" -Method POST `
+    -ContentType "application/json" `
+    -Body (@{ email = $email2; password = $password } | ConvertTo-Json) `
+    -StatusCodeVariable "loginStatus2"
+
+if ($loginStatus2 -eq 200) {
+    $token2 = $loginResponse2.accessToken
+    Write-Host "✓ User 2 logged in" -ForegroundColor Green
+} else {
+    Write-Host "✗ User 2 login failed" -ForegroundColor Red
+    exit 1
+}
+
+# User 1 creates household
+Write-Host "`nUser 1 creating household..." -ForegroundColor Yellow
+$headers1 = @{ Authorization = "Bearer $token1" }
+$createResponse = Invoke-RestMethod -Uri "$baseUrl/api/households" -Method POST `
+    -ContentType "application/json" `
+    -Headers $headers1 `
+    -Body (@{ name = "Test Family" } | ConvertTo-Json) `
+    -StatusCodeVariable "createStatus"
+
+if ($createStatus -eq 201) {
+    $householdId = $createResponse.id
+    Write-Host "✓ Household created: $householdId" -ForegroundColor Green
+    Write-Host "  Role: $($createResponse.role)" -ForegroundColor Gray
+} else {
+    Write-Host "✗ Household creation failed" -ForegroundColor Red
+    exit 1
+}
+
+# Test 1: User 1 (admin) can GET household details
+Write-Host "`nTest 1: User 1 (admin) GET household details..." -ForegroundColor Yellow
+try {
+    $getResponse = Invoke-RestMethod -Uri "$baseUrl/api/households/$householdId" -Method GET `
+        -Headers $headers1 `
+        -StatusCodeVariable "getStatus"
+    
+    if ($getStatus -eq 200 -and $getResponse.role -eq "admin") {
+        Write-Host "✓ Admin can access household details" -ForegroundColor Green
+        Write-Host "  Name: $($getResponse.name)" -ForegroundColor Gray
+        Write-Host "  Role: $($getResponse.role)" -ForegroundColor Gray
+    } else {
+        Write-Host "✗ Unexpected response" -ForegroundColor Red
+    }
+} catch {
+    Write-Host "✗ Request failed: $($_.Exception.Message)" -ForegroundColor Red
+}
+
+# Test 2: User 2 (non-member) CANNOT GET household details
+Write-Host "`nTest 2: User 2 (non-member) GET household details (should fail)..." -ForegroundColor Yellow
+$headers2 = @{ Authorization = "Bearer $token2" }
+try {
+    $response = Invoke-RestMethod -Uri "$baseUrl/api/households/$householdId" -Method GET `
+        -Headers $headers2 `
+        -StatusCodeVariable "status" `
+        -SkipHttpErrorCheck
+    
+    if ($status -eq 403) {
+        Write-Host "✓ Non-member correctly denied access (403)" -ForegroundColor Green
+        Write-Host "  Error: $($response.message)" -ForegroundColor Gray
+    } else {
+        Write-Host "✗ Expected 403, got $status" -ForegroundColor Red
+    }
+} catch {
+    Write-Host "✗ Request failed unexpectedly: $($_.Exception.Message)" -ForegroundColor Red
+}
+
+# Test 3: User 1 (admin) can UPDATE household
+Write-Host "`nTest 3: User 1 (admin) UPDATE household name..." -ForegroundColor Yellow
+try {
+    $updateResponse = Invoke-RestMethod -Uri "$baseUrl/api/households/$householdId" -Method PUT `
+        -ContentType "application/json" `
+        -Headers $headers1 `
+        -Body (@{ name = "Updated Family Name" } | ConvertTo-Json) `
+        -StatusCodeVariable "updateStatus"
+    
+    if ($updateStatus -eq 200 -and $updateResponse.name -eq "Updated Family Name") {
+        Write-Host "✓ Admin can update household" -ForegroundColor Green
+        Write-Host "  New name: $($updateResponse.name)" -ForegroundColor Gray
+    } else {
+        Write-Host "✗ Unexpected response" -ForegroundColor Red
+    }
+} catch {
+    Write-Host "✗ Request failed: $($_.Exception.Message)" -ForegroundColor Red
+}
+
+# Test 4: User 2 (non-member) CANNOT UPDATE household
+Write-Host "`nTest 4: User 2 (non-member) UPDATE household (should fail)..." -ForegroundColor Yellow
+try {
+    $response = Invoke-RestMethod -Uri "$baseUrl/api/households/$householdId" -Method PUT `
+        -ContentType "application/json" `
+        -Headers $headers2 `
+        -Body (@{ name = "Hacker Family" } | ConvertTo-Json) `
+        -StatusCodeVariable "status" `
+        -SkipHttpErrorCheck
+    
+    if ($status -eq 403) {
+        Write-Host "✓ Non-member correctly denied update (403)" -ForegroundColor Green
+        Write-Host "  Error: $($response.message)" -ForegroundColor Gray
+    } else {
+        Write-Host "✗ Expected 403, got $status" -ForegroundColor Red
+    }
+} catch {
+    Write-Host "✗ Request failed unexpectedly: $($_.Exception.Message)" -ForegroundColor Red
+}
+
+# Test 5: Invalid household ID format
+Write-Host "`nTest 5: Invalid household ID format (should fail)..." -ForegroundColor Yellow
+try {
+    $response = Invoke-RestMethod -Uri "$baseUrl/api/households/invalid-id" -Method GET `
+        -Headers $headers1 `
+        -StatusCodeVariable "status" `
+        -SkipHttpErrorCheck
+    
+    if ($status -eq 400) {
+        Write-Host "✓ Invalid UUID correctly rejected (400)" -ForegroundColor Green
+        Write-Host "  Error: $($response.message)" -ForegroundColor Gray
+    } else {
+        Write-Host "✗ Expected 400, got $status" -ForegroundColor Red
+    }
+} catch {
+    Write-Host "✗ Request failed unexpectedly: $($_.Exception.Message)" -ForegroundColor Red
+}
+
+# Test 6: Non-existent household ID
+Write-Host "`nTest 6: Non-existent household ID (should fail)..." -ForegroundColor Yellow
+$fakeId = "00000000-0000-0000-0000-000000000000"
+try {
+    $response = Invoke-RestMethod -Uri "$baseUrl/api/households/$fakeId" -Method GET `
+        -Headers $headers1 `
+        -StatusCodeVariable "status" `
+        -SkipHttpErrorCheck
+    
+    if ($status -eq 403) {
+        Write-Host "✓ Non-existent household correctly rejected (403)" -ForegroundColor Green
+        Write-Host "  Error: $($response.message)" -ForegroundColor Gray
+    } else {
+        Write-Host "✗ Expected 403, got $status" -ForegroundColor Red
+    }
+} catch {
+    Write-Host "✗ Request failed unexpectedly: $($_.Exception.Message)" -ForegroundColor Red
+}
+
+Write-Host "`n=== All Tests Complete ===" -ForegroundColor Cyan


### PR DESCRIPTION
## Problem
Need middleware to validate household membership and enforce role-based access control for household-scoped resources.

## Solution
Created composable middleware functions that validate membership and roles before allowing access to household endpoints.

## Changes
- **New File**: pps/backend/src/middleware/household-membership.ts
  - alidateHouseholdMembership(): Validates user is member, attaches role to request
  - equireHouseholdAdmin(): Enforces admin-only access  
  - equireHouseholdParent(): Enforces parent/admin access
  - UUID validation and comprehensive error handling
- **Updated**: pps/backend/src/routes/households.ts
  - Applied middleware to GET and PUT household endpoints
  - Simplified handlers (removed duplicate auth/membership checks)
  - Middleware chain: authenticateUser  validateHouseholdMembership  requireHouseholdAdmin
- **New File**: 	est-household-membership.ps1
  - 6 test scenarios covering membership validation and role enforcement
  - All tests passing 

## Testing
-  Admin can access household details (200)
-  Non-member denied access (403)  
-  Admin can update household (200)
-  Non-member denied update (403)
-  Invalid UUID format rejected (400)
-  Non-existent household rejected (403)

## Dependencies
- Depends on: task-021 (household CRUD endpoints)
- Part of: feature-003 (Household Management)

## Breaking Changes
None

## Checklist
- [x] Middleware implemented and tested
- [x] TypeScript compilation successful
- [x] Code formatted with Prettier
- [x] All test scenarios passing
- [x] Error handling comprehensive
- [x] Security validated (multi-tenant isolation)