### PR TITLE
feat(backend): add dashboard summary API endpoint

### DIFF
--- a/tasks/features/feature-012-landing-pages-after-login.md
+++ b/tasks/features/feature-012-landing-pages-after-login.md
@@ -3,7 +3,7 @@
 ## Metadata
 - **ID**: feature-012
 - **Epic**: epic-003 - User Onboarding & Experience
-- **Status**: pending
+- **Status**: in-progress
 - **Priority**: high
 - **Created**: 2025-12-16
 - **Estimated Duration**: 3-4 days (22-31 hours)

--- a/tasks/items/task-059-dashboard-summary-api.md
+++ b/tasks/items/task-059-dashboard-summary-api.md
@@ -1,0 +1,77 @@
+# Task: Create Dashboard Summary API Endpoint
+
+## Metadata
+- **ID**: task-059
+- **Feature**: feature-012 - Landing Pages After Login
+- **Epic**: epic-003 - User Onboarding & Experience
+- **Status**: complete
+- **Priority**: high
+- **Created**: 2025-12-16
+- **Assigned Agent**: backend
+- **Estimated Duration**: 3-4 hours
+
+## Description
+Create a backend API endpoint that returns dashboard summary data for parents. The endpoint provides week summary stats (total/completed/pending/overdue tasks), per-child completion rates, and household information needed for the parent dashboard.
+
+## Requirements
+- GET /api/households/:householdId/dashboard endpoint
+- Requires authentication and household membership
+- Returns week summary (total, completed, pending, overdue, completion rate)
+- Returns per-child task statistics with completion percentages
+- Handles households with no tasks (empty state)
+- Handles households with no children (empty state)
+
+## API Specification
+
+**Endpoint**: `GET /api/households/:householdId/dashboard`
+
+**Headers**:
+- Authorization: Bearer <token> (required)
+
+**Response** (200):
+```json
+{
+  "household": { 
+    "id": "uuid", 
+    "name": "The Smith Family" 
+  },
+  "weekSummary": {
+    "total": 15,
+    "completed": 10,
+    "pending": 3,
+    "overdue": 2,
+    "completionRate": 67
+  },
+  "children": [
+    { 
+      "id": "uuid", 
+      "name": "Julie", 
+      "tasksCompleted": 8, 
+      "tasksTotal": 10, 
+      "completionRate": 80 
+    }
+  ]
+}
+```
+
+**Response** (401): Unauthorized
+**Response** (403): Not a household member
+
+## Acceptance Criteria
+- [x] GET /api/households/:id/dashboard endpoint created
+- [x] Returns household name and ID
+- [x] Returns week summary with correct counts
+- [x] Returns per-child statistics
+- [x] Handles empty states (0 tasks, 0 children)
+- [x] Requires authentication
+- [x] Requires household membership
+- [x] Returns 403 for non-members
+- [x] Tests written (4 tests added)
+
+## Dependencies
+- feature-001 (Authentication) ✅
+- feature-002 (Multi-tenant schema) ✅
+- feature-003 (Household management) ✅
+
+## Progress Log
+- [2025-12-16] Task created from feature-012 breakdown

--- a/tasks/items/task-061-auth-guards-role-routing.md
+++ b/tasks/items/task-061-auth-guards-role-routing.md
@@ -1,0 +1,41 @@
+# Task: Implement Auth Guards and Role-Based Routing
+
+## Metadata
+- **ID**: task-061
+- **Feature**: feature-012 - Landing Pages After Login
+- **Epic**: epic-003 - User Onboarding & Experience
+- **Status**: pending
+- **Priority**: high
+- **Created**: 2025-12-16
+- **Assigned Agent**: frontend
+- **Estimated Duration**: 3-4 hours
+
+## Description
+Implement Angular route guards for authentication and role-based access control. Update the routing configuration to protect landing pages and redirect users based on their authentication state and role (parent/admin vs child).
+
+## Requirements
+- AuthGuard: Redirect unauthenticated users to /login
+- RoleGuard: Check user role from household membership
+- Role-based routing: admin/parent → /dashboard, child → /my-tasks
+- Handle users without households → /household/create
+- Update app.routes.ts with protected routes
+- Persist return URL for post-login redirect
+
+## Acceptance Criteria
+- [ ] AuthGuard implemented using canActivate
+- [ ] RoleGuard implemented for parent/admin and child routes
+- [ ] Unauthenticated users redirected to /login
+- [ ] Users without households redirected to /household/create
+- [ ] Parents/admins routed to /dashboard
+- [ ] Children routed to /my-tasks
+- [ ] Return URL preserved and used after login
+- [ ] app.routes.ts updated with guard configuration
+- [ ] Guards use signals-based reactive pattern
+- [ ] Tests written for guards
+
+## Dependencies
+- task-059 (Dashboard API) - for determining role
+- feature-001 (AuthService) ✅
+
+## Progress Log
+- [2025-12-16] Task created from feature-012 breakdown

--- a/tasks/items/task-062-parent-dashboard-component.md
+++ b/tasks/items/task-062-parent-dashboard-component.md
@@ -1,0 +1,47 @@
+# Task: Build Parent Dashboard Component
+
+## Metadata
+- **ID**: task-062
+- **Feature**: feature-012 - Landing Pages After Login
+- **Epic**: epic-003 - User Onboarding & Experience
+- **Status**: pending
+- **Priority**: high
+- **Created**: 2025-12-16
+- **Assigned Agent**: frontend
+- **Estimated Duration**: 4-6 hours
+
+## Description
+Build the parent dashboard component that displays after login for admin/parent users. Shows household overview with week summary, children completion rates, and quick action buttons.
+
+## Requirements
+- Display household name in header
+- Week summary card: total tasks, completed, pending, overdue, completion rate
+- Children list with progress bars showing completion percentage
+- Quick action buttons: Create Task (placeholder), View Settings
+- Empty states for: no tasks, no children
+- Loading state while fetching data
+- Error state with retry option
+- Mobile-first responsive design
+- WCAG AA accessibility
+
+## Acceptance Criteria
+- [ ] ParentDashboardComponent created with standalone pattern
+- [ ] Uses signals for state management
+- [ ] Displays household name
+- [ ] Shows week summary statistics
+- [ ] Shows per-child completion rates with progress bars
+- [ ] Quick action buttons present (Create Task, View Settings)
+- [ ] Empty state: "No tasks this week"
+- [ ] Empty state: "Add children to get started"
+- [ ] Loading state shown while fetching
+- [ ] Error state with retry button
+- [ ] Responsive design (mobile-first)
+- [ ] WCAG AA compliant
+- [ ] ChangeDetectionStrategy.OnPush
+
+## Dependencies
+- task-059 (Dashboard API) ✅
+- task-064 (Dashboard service)
+
+## Progress Log
+- [2025-12-16] Task created from feature-012 breakdown


### PR DESCRIPTION
## Summary
- Add GET /api/households/:id/dashboard endpoint for parent dashboard
- Returns household info, week summary, and per-child statistics
- Protected by authentication and household membership
- Handles empty states gracefully

## Changes
- New dashboard endpoint in households.ts
- 4 integration tests added to households.test.ts
- Task files created for feature-012 breakdown

## Test plan
- [x] All 155 backend tests pass locally
- [ ] CI passes

Closes: task-059