### PR TITLE
fix: E2E workflow cache-dependency-path for monorepo

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: |
+            apps/frontend/package-lock.json
+            apps/backend/package-lock.json
 
       - name: Install Playwright Browsers
         working-directory: apps/frontend

--- a/tasks/items/task-081-fix-e2e-ci-lock-file-error.md
+++ b/tasks/items/task-081-fix-e2e-ci-lock-file-error.md
@@ -4,7 +4,7 @@
 - **ID**: task-081
 - **Feature**: CI/CD E2E Testing
 - **Epic**: epic-006 - Testing & Quality Assurance Infrastructure
-- **Status**: pending
+- **Status**: in-progress
 - **Priority**: high
 - **Created**: 2025-12-19
 - **Assigned Agent**: orchestrator (DevOps/CI)
@@ -144,3 +144,8 @@ Likely files to check:
 
 ## Progress Log
 - [2025-12-19 11:45] Task created based on scheduled E2E test CI failure
+- [2025-12-19] Status changed to in-progress, investigating workflow files
+- [2025-12-19] Found issue: e2e.yml uses `cache: 'npm'` without `cache-dependency-path`
+- [2025-12-19] Applied fix: Added cache-dependency-path with both frontend and backend lock files
+- [2025-12-19] Verified both package-lock.json files exist at expected paths
+- [2025-12-19] Ready to test in CI


### PR DESCRIPTION
## Problem
Scheduled E2E tests were failing with error:
`
Error: Dependencies lock file is not found in /home/runner/work/st44-home/st44-home.
Supported file patterns: package-lock.json,npm-shrinkwrap.json,yarn.lock
`

The ctions/setup-node@v4 action with cache: 'npm' was looking for package-lock.json at the repository root, but our monorepo structure has lock files in pps/frontend/ and pps/backend/ subdirectories.

## Solution
Added cache-dependency-path configuration to specify both lock file locations:
`yaml
cache-dependency-path: |
  apps/frontend/package-lock.json
  apps/backend/package-lock.json
`

This enables npm dependency caching while correctly locating the lock files in our monorepo structure.

## Changes
- Updated .github/workflows/e2e.yml with cache-dependency-path configuration
- Both frontend and backend lock files are now used for caching
- E2E tests should now run without the lock file error
- Dependency caching will improve E2E test run times

## Testing
- PR CI will validate the workflow doesn't error
- Scheduled E2E tests will use the fixed configuration
- Both frontend and backend dependencies will be cached

## Related
- Resolves task-081
- Part of Epic-006 (Testing & Quality Assurance Infrastructure)
- Unblocks scheduled E2E test runs