### PR TITLE
fix: Remove duplicate /api prefix in ChildrenService

### DIFF
--- a/apps/frontend/src/app/services/children.service.ts
+++ b/apps/frontend/src/app/services/children.service.ts
@@ -42,7 +42,7 @@ export class ChildrenService {
    */
   async listChildren(householdId: string): Promise<Child[]> {
     const response = await this.api.get<ListChildrenResponse>(
-      `/api/households/${householdId}/children`,
+      `/households/${householdId}/children`,
     );
     return response.children;
   }
@@ -51,7 +51,7 @@ export class ChildrenService {
    * Add a new child to a household
    */
   async createChild(householdId: string, data: CreateChildRequest): Promise<Child> {
-    return this.api.post<Child>(`/api/households/${householdId}/children`, data);
+    return this.api.post<Child>(`/households/${householdId}/children`, data);
   }
 
   /**
@@ -62,15 +62,13 @@ export class ChildrenService {
     childId: string,
     data: UpdateChildRequest,
   ): Promise<Child> {
-    return this.api.put<Child>(`/api/households/${householdId}/children/${childId}`, data);
+    return this.api.put<Child>(`/households/${householdId}/children/${childId}`, data);
   }
 
   /**
    * Delete a child from a household
    */
   async deleteChild(householdId: string, childId: string): Promise<DeleteChildResponse> {
-    return this.api.delete<DeleteChildResponse>(
-      `/api/households/${householdId}/children/${childId}`,
-    );
+    return this.api.delete<DeleteChildResponse>(`/households/${householdId}/children/${childId}`);
   }
 }

--- a/tasks/items/task-078-fix-children-crud-api-routing.md
+++ b/tasks/items/task-078-fix-children-crud-api-routing.md
@@ -4,7 +4,7 @@
 - **ID**: task-078
 - **Feature**: Bug Fix (feature-003 - Household Management)
 - **Epic**: epic-001 - Multi-Tenant Foundation
-- **Status**: pending
+- **Status**: in-progress
 - **Priority**: high
 - **Created**: 2025-12-19
 - **Assigned Agent**: backend
@@ -109,3 +109,7 @@ export const environment = {
 
 ## Progress Log
 - [2025-12-19 11:15] Task created based on user-reported bug
+- [2025-12-19] Status changed to in-progress, investigating root cause
+- [2025-12-19] Root cause found: ApiService has baseUrl = `${environment.apiUrl}/api`
+- [2025-12-19] ChildrenService adds `/api/` prefix, causing double `/api/api/`
+- [2025-12-19] Fix: Remove `/api/` prefix from ChildrenService endpoint calls


### PR DESCRIPTION
## Problem
Children CRUD operations were failing with 404 errors showing double /api/api/ prefix in the URL path:
`
GET:/api/api/households/71816d58-f8cd-4708-9342-f6d1a049ad28/children not found
`

## Root Cause
- ApiService has aseUrl = \\/api\` (line 12)
- environment.apiUrl is empty string in development
- ApiService.baseUrl becomes /api
- ChildrenService was adding /api/ prefix to all endpoints
- Result: /api + /api/households/... = /api/api/households/... 

## Solution
Removed /api/ prefix from all ChildrenService endpoint calls since ApiService already provides it.

## Changes
- Updated all four methods in ChildrenService:
  - listChildren: /api/households/...  /households/...
  - createChild: /api/households/...  /households/...
  - updateChild: /api/households/...  /households/...
  - deleteChild: /api/households/...  /households/...

## Testing
- [ ] Children list endpoint works (GET /api/households/:id/children)
- [ ] Create child works (POST /api/households/:id/children)
- [ ] Update child works (PUT /api/households/:id/children/:childId)
- [ ] Delete child works (DELETE /api/households/:id/children/:childId)
- [ ] No other services affected

## Related
- Resolves task-078
- Fixes core functionality regression in feature-003 (Household Management)