### PR TITLE
feat: Skip deployment for documentation-only changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,30 @@ permissions:
   packages: write
 
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_deploy: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check for code changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'apps/**'
+              - 'infra/**'
+              - 'docker/**'
+              - '.github/workflows/**'
+              - 'package.json'
+              - 'package-lock.json'
+
   build-and-push-frontend:
+    needs: check-changes
+    if: needs.check-changes.outputs.should_deploy == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -40,6 +63,8 @@ jobs:
           tags: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}-frontend:latest
 
   build-and-push-backend:
+    needs: check-changes
+    if: needs.check-changes.outputs.should_deploy == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -65,6 +90,8 @@ jobs:
           tags: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}-backend:latest
 
   build-and-push-database:
+    needs: check-changes
+    if: needs.check-changes.outputs.should_deploy == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/tasks/items/done/task-078-fix-children-crud-api-routing.md
+++ b/tasks/items/done/task-078-fix-children-crud-api-routing.md
@@ -4,7 +4,7 @@
 - **ID**: task-078
 - **Feature**: Bug Fix (feature-003 - Household Management)
 - **Epic**: epic-001 - Multi-Tenant Foundation
-- **Status**: in-progress
+- **Status**: completed
 - **Priority**: high
 - **Created**: 2025-12-19
 - **Assigned Agent**: backend
@@ -53,14 +53,14 @@ Potential causes:
 - Confirm no other routes have similar issues
 
 ## Acceptance Criteria
-- [ ] Children CRUD endpoints return 200/201 (not 404)
-- [ ] API path shows single `/api/` prefix (not double)
-- [ ] Can successfully add a child to household
-- [ ] Can list children for household
-- [ ] Can update child details
-- [ ] Can delete child
-- [ ] Works in both dev and Docker environments
-- [ ] No other routes affected by the fix
+- [x] Children CRUD endpoints return 200/201 (not 404)
+- [x] API path shows single `/api/` prefix (not double)
+- [x] Can successfully add a child to household
+- [x] Can list children for household
+- [x] Can update child details
+- [x] Can delete child
+- [x] Works in both dev and Docker environments
+- [x] No other routes affected by the fix
 
 ## Technical Notes
 
@@ -113,3 +113,6 @@ export const environment = {
 - [2025-12-19] Root cause found: ApiService has baseUrl = `${environment.apiUrl}/api`
 - [2025-12-19] ChildrenService adds `/api/` prefix, causing double `/api/api/`
 - [2025-12-19] Fix: Remove `/api/` prefix from ChildrenService endpoint calls
+- [2025-12-19] PR #100 created and merged successfully
+- [2025-12-19] CI checks passed (frontend + backend)
+- [2025-12-19] Task completed - Children CRUD routing fixed

--- a/tasks/items/task-079-skip-deployment-for-docs-only-changes.md
+++ b/tasks/items/task-079-skip-deployment-for-docs-only-changes.md
@@ -4,7 +4,7 @@
 - **ID**: task-079
 - **Feature**: DevOps Optimization
 - **Epic**: N/A (Infrastructure improvement)
-- **Status**: pending
+- **Status**: in-progress
 - **Priority**: medium
 - **Created**: 2025-12-19
 - **Assigned Agent**: orchestrator (DevOps)
@@ -137,3 +137,6 @@ fi
 
 ## Progress Log
 - [2025-12-19 11:25] Task created based on user feedback about unnecessary deployments
+- [2025-12-19] Status changed to in-progress
+- [2025-12-19] Implementing Option B: dorny/paths-filter action for clean path detection
+- [2025-12-19] Will add path filter to deploy.yml to check for code changes


### PR DESCRIPTION
## Problem
Every push to main triggers full deployment workflow, even when only documentation files change (tasks/, ROADMAP.md, agent specs, etc.). This wastes CI/CD resources and time.

## Solution
Added dorny/paths-filter action to detect code vs documentation changes:
- **Code changes** (pps/, infra/, docker/, workflows, package files): Full deployment
- **Documentation-only changes** (	asks/, docs/, *.md): Skip deployment
- **Mixed changes**: Full deployment (safety first)

## Implementation
- Added check-changes job using paths-filter action
- All build/deploy jobs now depend on check-changes
- Jobs only run if should_deploy == 'true'
- Clear conditional logic: if: needs.check-changes.outputs.should_deploy == 'true'

## Benefits
- Saves CI/CD minutes on documentation commits
- Faster feedback for planning work
- Reduces unnecessary deployments
- Clearer separation between code and docs changes

## Testing
This PR itself changes .github/workflows/deploy.yml (code path), so it WILL deploy.
After merge, pushing task files to main will skip deployment.

## Related
- Implements task-079
- DevOps optimization (medium priority)