### PR TITLE
fix: Correct database name in E2E test helpers

### DIFF
--- a/apps/frontend/e2e/helpers/test-helpers.ts
+++ b/apps/frontend/e2e/helpers/test-helpers.ts
@@ -7,8 +7,8 @@ import { Pool } from 'pg';
 export async function resetTestDatabase(): Promise<void> {
   const pool = new Pool({
     host: 'localhost',
-    port: 55432, // Test DB port from task-028
-    database: 'st44_test',
+    port: 55432, // Test DB port from E2E workflow
+    database: 'st44', // Must match E2E workflow postgres service POSTGRES_DB
     user: 'postgres',
     password: 'postgres',
   });


### PR DESCRIPTION
## Problem

E2E tests were failing with database st44_test does not exist error because:
- E2E workflow creates PostgreSQL service with POSTGRES_DB: st44
- test-helpers.ts was hardcoded to connect to st44_test

## Solution

Changed 	est-helpers.ts to use st44 database name to match the E2E workflow configuration.

## Testing

This fix will be validated by the E2E workflow run triggered by this PR.