### PR TITLE
fix: correct E2E test import path

### DIFF
--- a/apps/frontend/e2e/features/task-viewing-completion.spec.ts
+++ b/apps/frontend/e2e/features/task-viewing-completion.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, Page } from '@playwright/test';
 import { loginAsParent, loginAsChild } from '../helpers/auth-helpers';
-import { resetDatabase, seedTestData } from '../helpers/database';
+import { resetDatabase, seedTestData } from '../helpers/seed-database';
 
 // Test data
 const TEST_PARENT = {


### PR DESCRIPTION
## Problem
The task-viewing-completion.spec.ts E2E test file has an incorrect import path that causes module resolution errors.

## Solution
Corrected import from '../helpers/database' to '../helpers/seed-database' to match the actual filename.

## Status
**Note**: This test file is still work-in-progress (Task-099). It imports a seedTestData() function that doesn't exist yet in seed-database.ts, so the 16 tests in this file will still fail until that function is implemented. This PR only fixes the import path issue.

## Changes
- Fixed import path in task-viewing-completion.spec.ts

## Related
- Task-099: Task viewing and completion E2E tests (WIP)