### PR TITLE
fix: household list schema mismatch - transform to camelCase

### DIFF
--- a/apps/backend/src/routes/households.ts
+++ b/apps/backend/src/routes/households.ts
@@ -137,6 +137,7 @@ async function listHouseholds(request: FastifyRequest, reply: FastifyReply) {
       [userId],
     );
 
+    // Transform to camelCase for API response
     const households = result.rows.map((row) => ({
       id: row.id,
       name: row.name,
@@ -144,8 +145,8 @@ async function listHouseholds(request: FastifyRequest, reply: FastifyReply) {
       memberCount: parseInt(row.member_count, 10),
       childrenCount: parseInt(row.children_count, 10),
       joinedAt: row.joined_at,
-      created_at: row.created_at,
-      updated_at: row.updated_at,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
     }));
 
     return reply.send(households);

--- a/apps/backend/src/schemas/households.ts
+++ b/apps/backend/src/schemas/households.ts
@@ -48,9 +48,16 @@ const listHouseholdsSchemaBase = {
       items: {
         type: 'object',
         properties: {
-          ...householdSchema.properties,
+          id: uuidSchema,
+          name: { type: 'string', minLength: 1, maxLength: 255 },
           role: { type: 'string', enum: ['admin', 'parent', 'child'] },
+          memberCount: { type: 'number', minimum: 1 },
+          childrenCount: { type: 'number', minimum: 0 },
+          joinedAt: timestampSchema,
+          createdAt: timestampSchema,
+          updatedAt: timestampSchema,
         },
+        required: ['id', 'name', 'role', 'createdAt', 'updatedAt'],
       },
     },
     401: errorResponseSchema,

--- a/tasks/items/task-102-fix-household-list-schema-mismatch.md
+++ b/tasks/items/task-102-fix-household-list-schema-mismatch.md
@@ -1,10 +1,11 @@
 # Task-102: Fix Household List Endpoint Schema Mismatch
 
-**Status**: `pending`  
+**Status**: `in-progress`  
 **Priority**: `🔴 CRITICAL - PRODUCTION BLOCKER`  
 **Assignee**: Backend Agent  
 **Epic**: None (Urgent Bug Fix)  
-**Created**: 2025-12-22  
+**Created**: 2025-12-22
+**Started**: 2025-12-22  
 **Related**: Task-100, Task-101 (OpenAPI Schema Alignment)
 
 ---


### PR DESCRIPTION
## Problem

After login, users with existing households see household selector stuck on 'Loading...' indefinitely. Browser console shows error: updatedAt is required! createdAt is required!

**Root Cause**: GET /api/households was returning snake_case properties (created_at, updated_at) but schema expected camelCase (createdAt, updatedAt). Fast-json-stringify validation rejected the response.

**Severity**: CRITICAL - Blocks ALL existing users from accessing the application.

## Solution

Applied dual fix:
1. **Transform response** in listHouseholds: Changed mapping to use createdAt/updatedAt instead of created_at/updated_at
2. **Update schema** in listHouseholdsSchemaBase: Define explicit camelCase properties instead of spreading householdSchema

This follows the pattern from Task-101 (PR #129) which fixed the same issue for household creation.

## Changes

- Modified pps/backend/src/routes/households.ts (~lines 106-145): Changed listHouseholds response mapping to camelCase
- Modified pps/backend/src/schemas/households.ts: Updated listHouseholdsSchemaBase to use explicit camelCase properties (createdAt, updatedAt, memberCount, childrenCount, joinedAt)

## Testing

-  All 272 backend tests passing
-  Local verification: Response now matches schema expectations
-  No test regressions introduced

## Related

- Fixes task-102
- Follows same pattern as PR #129 (task-101)