### PR TITLE
fix: household members 500 error - return array directly

### DIFF
--- a/apps/backend/src/middleware/household-membership.test.ts
+++ b/apps/backend/src/middleware/household-membership.test.ts
@@ -160,7 +160,7 @@ describe('Household Membership Middleware', () => {
       });
       assert.strictEqual(response.statusCode, 200);
       const body = JSON.parse(response.body);
-      assert.ok(Array.isArray(body.members));
+      assert.ok(Array.isArray(body)); // Now returns array directly
     });
 
     test('should fail at auth middleware first', async () => {

--- a/apps/backend/src/routes/households.test.ts
+++ b/apps/backend/src/routes/households.test.ts
@@ -261,8 +261,8 @@ describe('Household API', () => {
 
       assert.strictEqual(response.statusCode, 200);
       const body = JSON.parse(response.body);
-      assert.ok(Array.isArray(body.members));
-      assert.strictEqual(body.members.length, 2);
+      assert.ok(Array.isArray(body)); // Now returns array directly
+      assert.strictEqual(body.length, 2);
     });
 
     test('should reject without authentication', async () => {

--- a/apps/backend/src/routes/households.ts
+++ b/apps/backend/src/routes/households.ts
@@ -393,15 +393,15 @@ async function getHouseholdMembers(
       [id],
     );
 
-    return reply.send({
-      members: result.rows.map((row: unknown) => ({
+    return reply.send(
+      result.rows.map((row: unknown) => ({
         user_id: (row as { user_id: number }).user_id,
         email: (row as { email: string }).email,
         display_name: null, // TODO: Add display_name column to users table
         role: (row as { role: string }).role,
         joined_at: (row as { joined_at: Date }).joined_at,
       })),
-    });
+    );
   } catch (error) {
     request.log.error(error, 'Failed to get household members');
     return reply.status(500).send({


### PR DESCRIPTION
Problem: GET /api/households/:householdId/members returned 500 error. Root Cause: Implementation returned object with members property but schema expected array directly. Solution: Modified getHouseholdMembers to return array directly. Updated tests. All 272 backend tests passing. Fixes task-103.