### PR TITLE
fix: correct admin role check and child birthYear response format

### DIFF
--- a/apps/backend/src/routes/children.ts
+++ b/apps/backend/src/routes/children.ts
@@ -151,7 +151,8 @@ async function updateChild(request: FastifyRequest<UpdateChildRequest>, reply: F
       id: child.id,
       household_id: child.household_id,
       name: child.name,
-      birth_year: child.birth_year,
+      birthYear: child.birth_year,
+      avatar_url: null,
       created_at: child.created_at,
       updated_at: child.updated_at,
     });

--- a/apps/frontend/src/app/components/household-settings/household-settings.ts
+++ b/apps/frontend/src/app/components/household-settings/household-settings.ts
@@ -38,14 +38,14 @@ export class HouseholdSettingsComponent implements OnInit {
 
   household = signal<HouseholdListItem | null>(null);
   members = signal<HouseholdMember[]>([]);
-  currentUserRole = signal<'parent' | 'child' | null>(null);
+  currentUserRole = signal<'admin' | 'parent' | 'child' | null>(null);
   isLoading = signal(false);
   isSaving = signal(false);
   errorMessage = signal('');
   successMessage = signal('');
 
-  // Parents have admin privileges in the household
-  isAdmin = computed(() => this.currentUserRole() === 'parent');
+  // Admin role has household admin privileges
+  isAdmin = computed(() => this.currentUserRole() === 'admin');
 
   householdForm: FormGroup = this.fb.group({
     name: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(100)]],


### PR DESCRIPTION
## Bug Fixes

### Bug #1: Admin cannot edit household name
**Problem**: Users with 'admin' role were incorrectly blocked from editing household settings.
**Root Cause**: Frontend checked for 'parent' role while backend middleware requires 'admin' role.
**Fix**: Changed household settings component to check for 'admin' role instead of 'parent'.

### Bug #2: Child update fails with 'birthYear is required' error
**Problem**: Updating a child with payload {"name":"Name","birthYear":2020} returned 500 error.
**Root Cause**: Backend returned birth_year (snake_case) but schema validates birthYear (camelCase).
**Fix**: Changed child update endpoint response to use camelCase birthYear matching the schema.

## Files Changed
- apps/frontend/src/app/components/household-settings/household-settings.ts
- apps/backend/src/routes/children.ts

## Testing
- Verified admin users can now edit household names
- Verified child updates correctly handle birthYear field