### PR TITLE
fix: household members response camelCase

### DIFF
--- a/apps/backend/src/routes/households.ts
+++ b/apps/backend/src/routes/households.ts
@@ -399,11 +399,11 @@ async function getHouseholdMembers(
 
     return reply.send(
       result.rows.map((row: unknown) => ({
-        user_id: (row as { user_id: string }).user_id,
+        userId: (row as { user_id: string }).user_id,
         email: (row as { email: string }).email,
-        display_name: null, // TODO: Add display_name column to users table
+        displayName: null, // TODO: Add display_name column to users table
         role: (row as { role: string }).role,
-        joined_at: (row as { joined_at: Date }).joined_at,
+        joinedAt: toDateTimeString((row as { joined_at: Date }).joined_at),
       })),
     );
   } catch (error) {
@@ -519,10 +519,11 @@ export default async function householdRoutes(server: FastifyInstance) {
           items: {
             type: 'object',
             properties: {
-              user_id: { type: 'string', format: 'uuid' },
+              userId: { type: 'string', format: 'uuid' },
               email: { type: 'string', format: 'email' },
+              displayName: { type: ['string', 'null'] },
               role: { type: 'string', enum: ['admin', 'parent', 'child'] },
-              joined_at: { type: 'string', format: 'date-time' },
+              joinedAt: { type: 'string', format: 'date-time' },
             },
           },
         },

--- a/apps/frontend/src/app/services/household.service.ts
+++ b/apps/frontend/src/app/services/household.service.ts
@@ -24,7 +24,7 @@ export interface HouseholdMember {
   userId: string;
   email: string;
   displayName: string | null;
-  role: 'parent' | 'child';
+  role: 'admin' | 'parent' | 'child';
   joinedAt: string;
 }
 


### PR DESCRIPTION
## Problem
Household Settings determines admin privileges by matching the logged-in user against the household members list (expects `userId` + `role`). The members endpoint was returning snake_case keys (e.g. `user_id`), so the frontend couldn't find the current user and incorrectly showed: "Only household admins can edit household details."

## Solution
- Return camelCase member fields from `GET /api/households/:householdId/members` (`userId`, `displayName`, `joinedAt`).
- Align the Fastify response schema to the camelCase payload.
- Allow `admin` in the frontend `HouseholdMember.role` union.

## Testing
- Backend: `npm run test:backend`
- Backend: `npm run type-check` + `npm run build`
- Frontend: `npm run type-check` (production build)
