### PR TITLE
chore: check in Claude config and types integration test

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,102 @@
+# Claude Code Configuration
+
+This directory contains Claude Code-specific configuration for autonomous development.
+
+## Directory Structure
+
+```
+.claude/
+├── settings.json          # Permissions and configuration
+├── commands/              # Custom command prompts
+│   ├── continue-work.md   # Main autonomous loop
+│   ├── frontend.md        # Frontend agent context
+│   ├── backend.md         # Backend agent context
+│   ├── database.md        # Database agent context
+│   └── ship.md            # PR and merge workflow
+└── README.md              # This file
+```
+
+## Quick Start
+
+### Start Autonomous Development
+Tell Claude Code:
+```
+Read tasks/ROADMAP.md and execute the top priority from the "Now" section
+```
+
+### Manual Agent Invocation
+```
+Read .claude/commands/frontend.md and implement [task]
+Read .claude/commands/backend.md and implement [task]
+Read .claude/commands/database.md and implement [task]
+```
+
+## How It Works
+
+### Orchestrator Pattern
+Claude Code acts as an orchestrator that:
+1. Reads ROADMAP.md for priorities
+2. Breaks down features into tasks
+3. Spawns specialized subagents using the Task tool
+4. Coordinates work across frontend, backend, database
+5. Validates and ships changes
+6. Loops continuously
+
+### Subagent Delegation
+The orchestrator spawns Task agents with specific prompts:
+```
+// Spawn frontend agent
+Task tool with subagent_type="general-purpose" and prompt:
+"Read .github/agents/frontend-agent.md for context. Implement: [task]"
+
+// Spawn backend agent
+Task tool with subagent_type="general-purpose" and prompt:
+"Read .github/agents/backend-agent.md for context. Implement: [task]"
+```
+
+### Parallel Execution
+Independent tasks run in parallel using `run_in_background: true`:
+```
+1. Spawn backend agent (background)
+2. Spawn database agent (background)
+3. Wait for both (TaskOutput)
+4. Spawn frontend agent (sequential - depends on API)
+```
+
+## Settings
+
+### Permissions (settings.json)
+Pre-approved commands that won't require confirmation:
+- npm/npx commands
+- git/gh commands
+- Docker commands
+- File read/write in project directories
+
+### Denied Actions
+- Force push to main
+- Destructive operations
+
+## Integration with Existing System
+
+This setup works with the existing agent system:
+- `.github/agents/` - Detailed agent specifications
+- `.github/prompts/` - Workflow prompts (Copilot-compatible)
+- `tasks/` - Work item hierarchy
+- `AGENTS.md` files - Living documentation
+
+## Commands Reference
+
+| Command | Purpose |
+|---------|---------|
+| `continue-work.md` | Start/continue autonomous loop |
+| `frontend.md` | Frontend implementation context |
+| `backend.md` | Backend implementation context |
+| `database.md` | Database/migration context |
+| `ship.md` | PR creation and merge workflow |
+
+## Tips
+
+1. **Let it run** - The orchestrator is designed to work autonomously
+2. **Check ROADMAP.md** - This is the source of truth for priorities
+3. **Trust the process** - Tests, CI, and PR reviews catch issues
+4. **Intervene when stuck** - If CI fails repeatedly, provide guidance

--- a/.claude/commands/backend.md
+++ b/.claude/commands/backend.md
@@ -1,0 +1,22 @@
+# Backend Agent Task
+
+You are the Backend Agent. Read `.github/agents/backend-agent.md` and `apps/backend/AGENTS.md` for full context.
+
+## Your Role
+Implement Fastify backend features following project conventions:
+- Async/await for all async operations
+- Type-safe route handlers with generics
+- Parameterized queries (never concatenate SQL)
+- Proper error handling with status codes
+- Use `@st44/types` schemas for validation
+
+## Before Starting
+1. Read the task file for requirements and acceptance criteria
+2. Read `apps/backend/AGENTS.md` for patterns
+3. Check `docker/postgres/init.sql` for schema
+
+## After Completing
+1. Run `npm run format` in apps/backend
+2. Run `npm run type-check` in apps/backend
+3. Run `npm run test` in apps/backend
+4. Report results back to orchestrator

--- a/.claude/commands/continue-work.md
+++ b/.claude/commands/continue-work.md
@@ -1,0 +1,23 @@
+# Continue Work - Autonomous Development Loop
+
+Execute the autonomous development workflow by reading and following `.github/prompts/continue-work.prompt.md`.
+
+## Quick Start
+1. Read `tasks/ROADMAP.md` for current priorities
+2. Pick the top item from "Now" section
+3. If it's a feature without tasks, break it down first
+4. Implement the work using specialized subagents
+5. Run tests, create PR, merge
+6. Loop back to step 1
+
+## Subagent Delegation
+Use the Task tool to spawn specialized agents:
+- **Frontend work**: Spawn agent with context from `.github/agents/frontend-agent.md`
+- **Backend work**: Spawn agent with context from `.github/agents/backend-agent.md`
+- **Database work**: Spawn agent with context from `.github/agents/database-agent.md`
+
+## Critical Rules
+- NEVER push to main directly
+- ALWAYS run local tests before PR
+- ALWAYS update ROADMAP.md after completing work
+- Move completed tasks to `done/` folders

--- a/.claude/commands/database.md
+++ b/.claude/commands/database.md
@@ -1,0 +1,46 @@
+# Database Agent Task
+
+You are the Database Agent. Read `.github/agents/database-agent.md` and `docker/postgres/migrations/README.md` for full context.
+
+## Your Role
+Implement database changes following project conventions:
+- ALWAYS create migration files in `docker/postgres/migrations/`
+- Use naming convention: `NNN_descriptive_name.sql`
+- Make migrations idempotent (IF NOT EXISTS, ON CONFLICT DO NOTHING)
+- Wrap in BEGIN/COMMIT transactions
+- Update schema_migrations table
+- Also update init.sql for fresh installs
+
+## Migration Template
+```sql
+-- Migration: NNN_description
+-- Description: What this changes
+-- Date: YYYY-MM-DD
+-- Related Task: task-XXX
+
+BEGIN;
+
+-- Your changes here
+CREATE TABLE IF NOT EXISTS ...
+
+-- Record migration
+INSERT INTO schema_migrations (version, name, applied_at)
+VALUES ('NNN', 'description', NOW())
+ON CONFLICT (version) DO NOTHING;
+
+COMMIT;
+```
+
+## Before Starting
+1. Check existing migrations: `ls docker/postgres/migrations/*.sql`
+2. Find next version number
+3. Read task requirements
+
+## After Completing
+1. Test migration locally:
+   ```bash
+   docker exec -i st44-db psql -U postgres -d st44 < docker/postgres/migrations/NNN_name.sql
+   ```
+2. Verify in schema_migrations table
+3. Update init.sql if needed
+4. Report results back to orchestrator

--- a/.claude/commands/frontend.md
+++ b/.claude/commands/frontend.md
@@ -1,0 +1,23 @@
+# Frontend Agent Task
+
+You are the Frontend Agent. Read `.github/agents/frontend-agent.md` and `apps/frontend/AGENTS.md` for full context.
+
+## Your Role
+Implement Angular frontend features following project conventions:
+- Standalone components with signals
+- `ChangeDetectionStrategy.OnPush`
+- `inject()` for dependency injection
+- Native control flow (`@if`, `@for`, `@switch`)
+- Reactive forms with validation
+- WCAG AA accessibility compliance
+
+## Before Starting
+1. Read the task file for requirements and acceptance criteria
+2. Read `apps/frontend/AGENTS.md` for patterns
+3. Identify affected components and services
+
+## After Completing
+1. Run `npm run format` in apps/frontend
+2. Run `npm run lint` in apps/frontend
+3. Run `npm run test:ci` in apps/frontend
+4. Report results back to orchestrator

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,51 @@
+# Ship - Create PR and Merge
+
+Run local checks, create PR, wait for CI, and merge.
+
+## Pre-flight Checks (MANDATORY)
+```bash
+# Format
+cd apps/frontend && npm run format
+cd ../backend && npm run format
+
+# Lint
+cd apps/frontend && npm run lint
+
+# Type check
+cd apps/backend && npm run type-check
+
+# Build
+npm run build
+
+# Tests
+npm run test
+```
+
+**STOP if any check fails. Fix issues first.**
+
+## Create PR
+```bash
+git add .
+git commit -m "type: description"
+git push -u origin $(git branch --show-current)
+
+# Check for existing PR
+gh pr view --json number,state 2>/dev/null || gh pr create --base main
+```
+
+## Wait for CI and Merge
+```bash
+# Poll until checks complete
+gh pr view --json statusCheckRollup,mergeable,state
+
+# When checks pass
+gh pr merge --squash --delete-branch
+```
+
+## Post-Merge (CRITICAL)
+```bash
+git checkout main
+git pull origin main
+```
+
+Then update ROADMAP.md and move completed task to done/ folder.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://claude.ai/code/settings-schema.json",
+  "permissions": {
+    "allow": [
+      "Bash(npm run *)",
+      "Bash(npx *)",
+      "Bash(git *)",
+      "Bash(gh *)",
+      "Bash(cd *)",
+      "Bash(ls *)",
+      "Bash(mkdir *)",
+      "Bash(docker *)",
+      "Bash(docker-compose *)",
+      "Bash(curl *)",
+      "Bash(pwsh *)",
+      "Bash(Start-Sleep *)",
+      "Bash(Test-Path *)",
+      "Bash(Get-Content *)",
+      "Bash(Remove-Item *)",
+      "Bash(Move-Item *)",
+      "Read(*)",
+      "Write(apps/**)",
+      "Write(packages/**)",
+      "Write(docker/**)",
+      "Write(infra/**)",
+      "Write(tasks/**)",
+      "Write(docs/**)",
+      "Write(.claude/**)",
+      "Edit(*)"
+    ],
+    "deny": [
+      "Bash(rm -rf /)",
+      "Bash(*--force*push*main*)",
+      "Bash(*push*--force*origin main*)",
+      "Bash(*push origin main*)"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,216 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Full-stack TypeScript monorepo: Angular 21+ frontend, Fastify backend, PostgreSQL database.
+
+## Commands
+
+### Build
+```bash
+npm run build                    # Build all (types → backend → frontend)
+npm run build:types              # Build shared types package
+npm run build:backend            # Build backend only
+npm run build:frontend           # Build frontend only
+```
+
+### Development
+```bash
+# Start database
+cd infra && docker compose up -d db
+
+# Start dev servers (opens separate windows)
+npm run dev:backend              # Backend at localhost:3000
+npm run dev:frontend             # Frontend at localhost:4200
+npm run dev:all                  # Both servers
+npm run dev:stop                 # Stop all dev servers
+```
+
+### Testing
+```bash
+npm test                         # All tests
+npm run test:types               # packages/types tests (vitest)
+npm run test:backend             # Backend tests (tsx --test)
+npm run test:frontend            # Frontend tests (karma)
+
+# Single test file (backend)
+cd apps/backend && npx tsx --test src/routes/tasks.test.ts
+
+# Single test file (types package)
+cd packages/types && npx vitest run src/schemas/task.schema.test.ts
+
+# E2E tests
+cd apps/frontend
+npm run test:e2e:full            # Start services, run tests, stop services
+npm run test:e2e:local           # Run tests against running services
+npm run test:e2e:ui              # Interactive UI mode
+```
+
+### Type Checking & Formatting
+```bash
+npm run type-check               # Check types (backend + types package)
+cd apps/frontend && npm run format && cd ../backend && npm run format  # Format before commit
+```
+
+### Docker
+```bash
+npm run docker:up                # Start full stack
+npm run docker:down              # Stop stack
+npm run db:test:up               # Start test database
+npm run db:test:down             # Stop test database
+```
+
+## Architecture
+
+```
+apps/
+├── frontend/                    # Angular 21+ (standalone components, signals)
+│   └── src/app/
+│       ├── components/          # UI components
+│       └── services/            # API services
+├── backend/                     # Fastify API
+│   └── src/
+│       ├── routes/              # Route handlers
+│       ├── middleware/          # Auth, etc.
+│       └── test-helpers/        # Test utilities
+packages/
+├── types/                       # @st44/types - shared Zod schemas and types
+docker/
+└── postgres/
+    ├── init.sql                 # Database schema
+    └── migrations/              # Versioned migrations (NNN_name.sql)
+infra/                           # Docker Compose configuration
+```
+
+## Key Conventions
+
+### TypeScript
+- **camelCase everywhere** - variables, properties, database columns (no snake_case)
+- Strict mode, ESM modules
+- Use `unknown` over `any`
+
+### Angular (Frontend)
+- Standalone components only (no NgModules, `standalone: true` is implicit)
+- Use `signal()`, `computed()` for state (not RxJS for component state)
+- Use `inject()` for DI (not constructor injection)
+- Use `input()`, `output()` functions (not decorators)
+- Use `@if`, `@for`, `@switch` (not `*ngIf`, `*ngFor`)
+- Use `[class.x]="..."` (not `ngClass`)
+- `ChangeDetectionStrategy.OnPush` required
+
+### Fastify (Backend)
+- Async/await, type-safe route handlers
+- Parameterized queries only (SQL injection prevention)
+- Use `@st44/types` schemas for validation
+- Connection pooling via `pg.Pool`
+
+### Database
+- Migrations in `docker/postgres/migrations/NNN_name.sql`
+- Make migrations idempotent (`IF NOT EXISTS`, `ON CONFLICT DO NOTHING`)
+- Wrap in `BEGIN`/`COMMIT` transactions
+- Update `schema_migrations` table in each migration
+- Also update `init.sql` for new tables
+
+## Git Workflow
+
+1. Create feature branch: `git checkout -b feature/name`
+2. Make changes, format code
+3. Push and create PR: `gh pr create --base main`
+4. Squash merge after CI passes
+
+Never push directly to main.
+
+## Shared Types (@st44/types)
+
+Zod schemas in `packages/types/src/schemas/` define validation for both frontend and backend:
+```typescript
+import { TaskSchema, type Task } from '@st44/types/schemas';
+```
+
+When modifying schemas, rebuild: `npm run build:types`
+
+## Autonomous Development Mode
+
+This repo supports fully autonomous development. To take over development:
+
+### Start the Loop
+```
+Read tasks/ROADMAP.md and execute the top priority from the "Now" section
+```
+
+### Orchestrator Workflow
+
+The orchestrator runs an autonomous loop:
+
+1. **Read ROADMAP.md** → Get next priority (task, feature, or epic)
+2. **Break down if needed** → Features must be decomposed into tasks first
+3. **Delegate to subagents** → Spawn specialized agents for implementation
+4. **Validate** → Run tests locally, ensure all pass
+5. **Ship** → Create PR, wait for CI, merge
+6. **Loop** → Pull main, go back to step 1
+
+### Subagent Delegation
+
+Use the **Task tool** to spawn specialized agents. Each agent should be given:
+- The task description and acceptance criteria
+- Path to its agent spec file for context
+- Relevant files to read/modify
+
+**Frontend Agent** - Angular components, services, UI
+```
+Spawn Task agent with prompt:
+"Read .github/agents/frontend-agent.md for context. Then implement: [task description]"
+```
+
+**Backend Agent** - Fastify routes, business logic, middleware
+```
+Spawn Task agent with prompt:
+"Read .github/agents/backend-agent.md for context. Then implement: [task description]"
+```
+
+**Database Agent** - Migrations, schema changes, queries
+```
+Spawn Task agent with prompt:
+"Read .github/agents/database-agent.md for context. Then implement: [task description]"
+```
+
+### Parallel Execution
+
+When tasks are independent, spawn multiple agents in parallel:
+```
+// Example: Feature requires both frontend and backend work
+1. Spawn backend agent for API endpoint (run_in_background: true)
+2. Spawn database agent for migration (run_in_background: true)
+3. Wait for both to complete
+4. Spawn frontend agent for UI (depends on API)
+```
+
+### Critical Rules
+
+1. **Never push to main** - Always use feature branches
+2. **Test before PR** - Run `npm test` and `npm run type-check` locally
+3. **Update ROADMAP.md** - After completing work, update status
+4. **Move to done/** - Completed tasks go to `tasks/items/done/`
+5. **Pull after merge** - Always `git checkout main && git pull` after merge
+
+### Task System
+
+```
+tasks/
+├── ROADMAP.md           # Prioritized backlog (start here)
+├── epics/               # Large initiatives (weeks)
+├── features/            # User-facing functionality (days)
+├── items/               # Atomic tasks (hours)
+│   └── done/            # Completed tasks
+└── templates/           # Templates for new items
+```
+
+### Agent Specs
+
+Detailed agent specifications in `.github/agents/`:
+- `orchestrator-agent.md` - Full workflow documentation
+- `frontend-agent.md` - Angular patterns and conventions
+- `backend-agent.md` - Fastify patterns and conventions
+- `database-agent.md` - Migration and query patterns

--- a/packages/types/tests/integration.test.ts
+++ b/packages/types/tests/integration.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from 'vitest';
+import { TaskSchema, CreateTaskRequestSchema } from '../src/schemas/task.schema';
+import { HouseholdSchema, CreateHouseholdRequestSchema } from '../src/schemas/household.schema';
+import { ChildSchema, CreateChildRequestSchema } from '../src/schemas/child.schema';
+import { UserSchema } from '../src/schemas/user.schema';
+import { AssignmentSchema } from '../src/schemas/assignment.schema';
+import { zodToOpenAPI } from '../src/generators/openapi.generator';
+
+describe('Type System Integration', () => {
+  describe('Task Schema Integration', () => {
+    it('TaskSchema parses valid task data', () => {
+      const validTask = {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        householdId: '123e4567-e89b-12d3-a456-426614174001',
+        name: 'Clean Room',
+        description: null,
+        points: 10,
+        ruleType: 'daily',
+        ruleConfig: null,
+        active: true,
+        createdAt: '2025-12-22T10:00:00Z',
+        updatedAt: '2025-12-22T10:00:00Z',
+      };
+      
+      const result = TaskSchema.safeParse(validTask);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.id).toBe(validTask.id);
+        expect(result.data.name).toBe(validTask.name);
+        expect(result.data.points).toBe(validTask.points);
+      }
+    });
+    
+    it('CreateTaskRequestSchema validates valid request', () => {
+      const validRequest = {
+        name: 'New Task',
+        ruleType: 'daily',
+        points: 5,
+      };
+      
+      const result = CreateTaskRequestSchema.safeParse(validRequest);
+      expect(result.success).toBe(true);
+    });
+    
+    it('CreateTaskRequestSchema rejects invalid request', () => {
+      const invalidRequest = {
+        name: '', // Too short
+        ruleType: 'invalid', // Invalid enum
+      };
+      
+      const result = CreateTaskRequestSchema.safeParse(invalidRequest);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues.length).toBeGreaterThan(0);
+      }
+    });
+    
+    it('TaskSchema OpenAPI matches Zod schema', () => {
+      const openApiSchema = zodToOpenAPI(TaskSchema);
+      
+      expect(openApiSchema.type).toBe('object');
+      expect(openApiSchema.properties).toHaveProperty('id');
+      expect(openApiSchema.properties).toHaveProperty('name');
+      expect(openApiSchema.properties).toHaveProperty('householdId');
+      expect(openApiSchema.required).toContain('name');
+      expect(openApiSchema.required).toContain('householdId');
+    });
+  });
+  
+  describe('Household Schema Integration', () => {
+    it('HouseholdSchema parses valid household data', () => {
+      const validHousehold = {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        name: 'Smith Family',
+        createdAt: '2025-12-22T10:00:00Z',
+        updatedAt: '2025-12-22T10:00:00Z',
+      };
+      
+      const result = HouseholdSchema.safeParse(validHousehold);
+      expect(result.success).toBe(true);
+    });
+    
+    it('CreateHouseholdRequestSchema validates valid request', () => {
+      const validRequest = {
+        name: 'New Household',
+      };
+      
+      const result = CreateHouseholdRequestSchema.safeParse(validRequest);
+      expect(result.success).toBe(true);
+    });
+    
+    it('CreateHouseholdRequestSchema rejects invalid request', () => {
+      const invalidRequest = {
+        name: '', // Too short
+      };
+      
+      const result = CreateHouseholdRequestSchema.safeParse(invalidRequest);
+      expect(result.success).toBe(false);
+    });
+  });
+  
+  describe('Child Schema Integration', () => {
+    it('ChildSchema parses valid child data', () => {
+      const validChild = {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        householdId: '123e4567-e89b-12d3-a456-426614174001',
+        name: 'Emma',
+        birthYear: 2015,
+        avatarUrl: null,
+        createdAt: '2025-12-22T10:00:00Z',
+        updatedAt: '2025-12-22T10:00:00Z',
+      };
+      
+      const result = ChildSchema.safeParse(validChild);
+      expect(result.success).toBe(true);
+    });
+    
+    it('CreateChildRequestSchema validates valid request', () => {
+      const validRequest = {
+        name: 'New Child',
+        birthYear: 2020,
+      };
+      
+      const result = CreateChildRequestSchema.safeParse(validRequest);
+      expect(result.success).toBe(true);
+    });
+    
+    it('CreateChildRequestSchema rejects invalid birth year', () => {
+      const invalidRequest = {
+        name: 'Child',
+        birthYear: 1899, // Too old
+      };
+      
+      const result = CreateChildRequestSchema.safeParse(invalidRequest);
+      expect(result.success).toBe(false);
+    });
+  });
+  
+  describe('User Schema Integration', () => {
+    it('UserSchema parses valid user data', () => {
+      const validUser = {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        email: 'user@example.com',
+        passwordHash: 'hashed_password',
+        googleId: null,
+        createdAt: '2025-12-22T10:00:00Z',
+        updatedAt: '2025-12-22T10:00:00Z',
+      };
+      
+      const result = UserSchema.safeParse(validUser);
+      expect(result.success).toBe(true);
+    });
+  });
+  
+  describe('Assignment Schema Integration', () => {
+    it('AssignmentSchema parses valid assignment data', () => {
+      const validAssignment = {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        taskId: '123e4567-e89b-12d3-a456-426614174001',
+        title: 'Clean Room',
+        description: 'Clean your bedroom',
+        ruleType: 'daily' as const,
+        childId: '123e4567-e89b-12d3-a456-426614174002',
+        childName: 'Alice',
+        date: '2025-12-22',
+        status: 'pending' as const,
+        completedAt: null,
+        createdAt: '2025-12-22T10:00:00Z',
+        updatedAt: '2025-12-22T10:00:00Z',
+      };
+      
+      const result = AssignmentSchema.safeParse(validAssignment);
+      expect(result.success).toBe(true);
+    });
+    
+    it('AssignmentSchema validates status enum', () => {
+      const invalidAssignment = {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        taskId: '123e4567-e89b-12d3-a456-426614174001',
+        childId: '123e4567-e89b-12d3-a456-426614174002',
+        date: '2025-12-22',
+        status: 'invalid_status', // Invalid enum value
+        completedAt: null,
+        createdAt: '2025-12-22T10:00:00Z',
+        updatedAt: '2025-12-22T10:00:00Z',
+      };
+      
+      const result = AssignmentSchema.safeParse(invalidAssignment);
+      expect(result.success).toBe(false);
+    });
+  });
+  
+  describe('OpenAPI Generator Integration', () => {
+    it('generates OpenAPI schema for all entities', () => {
+      const schemas = [
+        { name: 'Task', schema: TaskSchema },
+        { name: 'Household', schema: HouseholdSchema },
+        { name: 'Child', schema: ChildSchema },
+        { name: 'User', schema: UserSchema },
+        { name: 'Assignment', schema: AssignmentSchema },
+      ];
+      
+      schemas.forEach(({ name, schema }) => {
+        const openApiSchema = zodToOpenAPI(schema);
+        expect(openApiSchema.type).toBe('object');
+        expect(openApiSchema.properties).toBeDefined();
+        expect(Object.keys(openApiSchema.properties).length).toBeGreaterThan(0);
+      });
+    });
+    
+    it('OpenAPI required fields match Zod schema', () => {
+      const openApiSchema = zodToOpenAPI(TaskSchema);
+      
+      // Required fields based on Zod schema
+      expect(openApiSchema.required).toContain('id');
+      expect(openApiSchema.required).toContain('householdId');
+      expect(openApiSchema.required).toContain('name');
+      expect(openApiSchema.required).toContain('ruleType');
+    });
+  });
+  
+  describe('Type Consistency Across Packages', () => {
+    it('ensures frontend types match backend schemas', () => {
+      // This test verifies that the type system can be used
+      // consistently across frontend and backend without type errors
+      
+      // Simulate backend data
+      const backendTask = {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        householdId: '123e4567-e89b-12d3-a456-426614174001',
+        name: 'Clean Room',
+        description: 'Clean your bedroom thoroughly',
+        points: 10,
+        ruleType: 'daily' as const,
+        ruleConfig: null,
+        active: true,
+        createdAt: '2025-12-22T10:00:00Z',
+        updatedAt: '2025-12-22T10:00:00Z',
+      };
+      
+      // Validate with backend schema
+      const backendResult = TaskSchema.safeParse(backendTask);
+      expect(backendResult.success).toBe(true);
+      
+      // Frontend would receive this and use the same type
+      // This test confirms no type mismatches exist
+      if (backendResult.success) {
+        const frontendTask = backendResult.data;
+        expect(frontendTask.id).toBe(backendTask.id);
+        expect(frontendTask.name).toBe(backendTask.name);
+        expect(frontendTask.householdId).toBe(backendTask.householdId);
+      }
+    });
+    
+    it('ensures request types work for API calls', () => {
+      // Simulate frontend creating request
+      const frontendRequest = {
+        name: 'New Task',
+        description: 'Task description',
+        ruleType: 'weekly_rotation' as const,
+        ruleConfig: { children: ['child1', 'child2'], startDate: '2025-12-22' },
+        points: 15,
+      };
+      
+      // Validate with request schema (backend would do this)
+      const result = CreateTaskRequestSchema.safeParse(frontendRequest);
+      expect(result.success).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## What
Checks in Claude Code configuration plus an integration test for the shared `@st44/types` package.

## Why
- Makes the repo Claude Code-ready (commands + permissions are documented and reproducible).
- Adds a lightweight integration test that validates Zod schemas and OpenAPI generation work together.

## Changes
- Adds `.claude/` (settings + command prompts)
- Adds `CLAUDE.md` (repo usage + workflow)
- Adds `packages/types/tests/integration.test.ts`

## Testing
- `npm run test:types`
