### PR TITLE
Fix: Enable task creation buttons on parent dashboard

### DIFF
--- a/apps/frontend/src/app/pages/parent-dashboard/parent-dashboard.html
+++ b/apps/frontend/src/app/pages/parent-dashboard/parent-dashboard.html
@@ -68,9 +68,9 @@
       } @else {
         <div class="empty-state">
           <p>No tasks this week. Create your first task!</p>
-          <button type="button" class="btn btn-primary" disabled title="Coming soon">
+          <a [routerLink]="['/households', household()!.id, 'tasks']" class="btn btn-primary">
             <span aria-hidden="true">+</span> Create Task
-          </button>
+          </a>
         </div>
       }
     </section>
@@ -119,9 +119,9 @@
 
     <!-- Quick Actions -->
     <footer class="quick-actions">
-      <button type="button" class="btn btn-primary" disabled title="Coming soon">
+      <a [routerLink]="['/households', household()!.id, 'tasks']" class="btn btn-primary">
         <span aria-hidden="true">+</span> Add Task
-      </button>
+      </a>
       <a routerLink="/household/settings" class="btn btn-secondary">
         <span aria-hidden="true">📋</span> Manage Household
       </a>


### PR DESCRIPTION
## Summary
Fixes the disabled task creation buttons on the parent dashboard by linking them to the existing task list page which has full task creation functionality.

## Changes
- Changed `<button disabled>` elements to `<a [routerLink]>` elements
- Both "Add Task" and "Create Task" buttons now navigate to `/households/:householdId/tasks`
- Removed `disabled` attribute and `title="Coming soon"`
- Links to existing `TaskListComponent` which has `openCreateForm()` method and TaskFormComponent

## Testing
- ✅ Frontend build successful
- ✅ All 222 frontend tests passing
- ✅ Verified RouterLink import already exists in component

## Impact
**Unblocks core product** - Parents can now create task templates, making the task management system fully functional.

## Issue
Closes #145

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)