### PR TITLE
feat: add StatCard component for dashboard stats (#187)

### DIFF
--- a/apps/frontend/src/app/components/stat-card/stat-card.css
+++ b/apps/frontend/src/app/components/stat-card/stat-card.css
@@ -1,0 +1,54 @@
+.stat-card {
+  background: var(--color-surface, #ffffff);
+  border-radius: var(--radius-md, 24px);
+  padding: var(--space-lg, 1.5rem);
+  text-align: center;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+  transition: transform 0.3s ease;
+  cursor: default;
+}
+
+.stat-card:hover {
+  transform: translateY(-4px);
+}
+
+.stat-icon {
+  font-size: 36px;
+  margin-bottom: var(--space-sm, 0.75rem);
+  line-height: 1;
+}
+
+.stat-value {
+  font-family: var(--font-heading, 'Fredoka', sans-serif);
+  font-size: 32px;
+  font-weight: 700;
+  background: linear-gradient(
+    135deg,
+    var(--color-primary, #6366f1) 0%,
+    var(--color-secondary, #ec4899) 100%
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: var(--space-xs, 0.5rem);
+  line-height: 1.2;
+}
+
+.stat-label {
+  font-size: 12px;
+  color: var(--color-text-secondary, #64748b);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+  .stat-card {
+    transition: none;
+  }
+
+  .stat-card:hover {
+    transform: none;
+  }
+}

--- a/apps/frontend/src/app/components/stat-card/stat-card.html
+++ b/apps/frontend/src/app/components/stat-card/stat-card.html
@@ -1,0 +1,5 @@
+<div class="stat-card" [class]="gradient()">
+  <div class="stat-icon">{{ icon() }}</div>
+  <div class="stat-value">{{ value() }}</div>
+  <div class="stat-label">{{ label() }}</div>
+</div>

--- a/apps/frontend/src/app/components/stat-card/stat-card.spec.ts
+++ b/apps/frontend/src/app/components/stat-card/stat-card.spec.ts
@@ -1,0 +1,115 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { StatCard } from './stat-card';
+import { ComponentRef } from '@angular/core';
+
+describe('StatCard', () => {
+  let component: StatCard;
+  let componentRef: ComponentRef<StatCard>;
+  let fixture: ComponentFixture<StatCard>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [StatCard],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(StatCard);
+    component = fixture.componentInstance;
+    componentRef = fixture.componentRef;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display icon', () => {
+    componentRef.setInput('icon', '✓');
+    componentRef.setInput('value', '3/8');
+    componentRef.setInput('label', 'Today');
+    fixture.detectChanges();
+
+    const iconElement = fixture.nativeElement.querySelector('.stat-icon');
+    expect(iconElement?.textContent).toContain('✓');
+  });
+
+  it('should display value', () => {
+    componentRef.setInput('icon', '✓');
+    componentRef.setInput('value', '3/8');
+    componentRef.setInput('label', 'Today');
+    fixture.detectChanges();
+
+    const valueElement = fixture.nativeElement.querySelector('.stat-value');
+    expect(valueElement?.textContent).toContain('3/8');
+  });
+
+  it('should display numeric value', () => {
+    componentRef.setInput('icon', '⭐');
+    componentRef.setInput('value', 450);
+    componentRef.setInput('label', 'Points');
+    fixture.detectChanges();
+
+    const valueElement = fixture.nativeElement.querySelector('.stat-value');
+    expect(valueElement?.textContent).toContain('450');
+  });
+
+  it('should display label', () => {
+    componentRef.setInput('icon', '✓');
+    componentRef.setInput('value', '3/8');
+    componentRef.setInput('label', 'Today');
+    fixture.detectChanges();
+
+    const labelElement = fixture.nativeElement.querySelector('.stat-label');
+    expect(labelElement?.textContent).toContain('Today');
+  });
+
+  it('should apply custom gradient class when provided', () => {
+    componentRef.setInput('icon', '✓');
+    componentRef.setInput('value', '3/8');
+    componentRef.setInput('label', 'Today');
+    componentRef.setInput('gradient', 'custom-gradient');
+    fixture.detectChanges();
+
+    const cardElement = fixture.nativeElement.querySelector('.stat-card');
+    expect(cardElement?.classList.contains('custom-gradient')).toBe(true);
+  });
+
+  it('should have correct CSS classes', () => {
+    componentRef.setInput('icon', '✓');
+    componentRef.setInput('value', '3/8');
+    componentRef.setInput('label', 'Today');
+    fixture.detectChanges();
+
+    const cardElement = fixture.nativeElement.querySelector('.stat-card');
+    const iconElement = fixture.nativeElement.querySelector('.stat-icon');
+    const valueElement = fixture.nativeElement.querySelector('.stat-value');
+    const labelElement = fixture.nativeElement.querySelector('.stat-label');
+
+    expect(cardElement).toBeTruthy();
+    expect(iconElement).toBeTruthy();
+    expect(valueElement).toBeTruthy();
+    expect(labelElement).toBeTruthy();
+  });
+
+  it('should display percentage value correctly', () => {
+    componentRef.setInput('icon', '📊');
+    componentRef.setInput('value', '87%');
+    componentRef.setInput('label', 'Completion Rate');
+    fixture.detectChanges();
+
+    const valueElement = fixture.nativeElement.querySelector('.stat-value');
+    expect(valueElement?.textContent).toContain('87%');
+  });
+
+  it('should handle different emoji icons', () => {
+    const icons = ['✓', '📅', '⭐', '🔥', '🏆', '📊'];
+
+    icons.forEach((icon) => {
+      componentRef.setInput('icon', icon);
+      componentRef.setInput('value', '1');
+      componentRef.setInput('label', 'Test');
+      fixture.detectChanges();
+
+      const iconElement = fixture.nativeElement.querySelector('.stat-icon');
+      expect(iconElement?.textContent).toContain(icon);
+    });
+  });
+});

--- a/apps/frontend/src/app/components/stat-card/stat-card.stories.ts
+++ b/apps/frontend/src/app/components/stat-card/stat-card.stories.ts
@@ -1,0 +1,119 @@
+import { Meta, StoryObj } from '@storybook/angular';
+import { StatCard } from './stat-card';
+
+/**
+ * StatCard displays statistics with an icon, value, and label.
+ * Used on dashboards to show metrics like tasks completed, points earned, etc.
+ *
+ * Part of the Diddit! Design System.
+ */
+const meta: Meta<StatCard> = {
+  title: 'Components/StatCard',
+  component: StatCard,
+  tags: ['autodocs'],
+  argTypes: {
+    icon: {
+      control: 'text',
+      description: 'Emoji or icon character to display',
+    },
+    value: {
+      control: 'text',
+      description: 'Stat value (number or string like "3/8")',
+    },
+    label: {
+      control: 'text',
+      description: 'Label describing the stat',
+    },
+    gradient: {
+      control: 'text',
+      description: 'Optional custom CSS class for gradient',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<StatCard>;
+
+/**
+ * Default stat card showing today's task completion
+ */
+export const Today: Story = {
+  args: {
+    icon: '✓',
+    value: '3/8',
+    label: 'Today',
+  },
+};
+
+/**
+ * Stat card showing weekly progress
+ */
+export const Week: Story = {
+  args: {
+    icon: '📅',
+    value: '18/32',
+    label: 'Week',
+  },
+};
+
+/**
+ * Stat card showing total points earned
+ */
+export const Points: Story = {
+  args: {
+    icon: '⭐',
+    value: '450',
+    label: 'Points',
+  },
+};
+
+/**
+ * Stat card showing current streak
+ */
+export const Streak: Story = {
+  args: {
+    icon: '🔥',
+    value: '7',
+    label: 'Day Streak',
+  },
+};
+
+/**
+ * Stat card with trophy icon for achievements
+ */
+export const Achievements: Story = {
+  args: {
+    icon: '🏆',
+    value: '12',
+    label: 'Achievements',
+  },
+};
+
+/**
+ * Stat card showing percentage
+ */
+export const Percentage: Story = {
+  args: {
+    icon: '📊',
+    value: '87%',
+    label: 'Completion Rate',
+  },
+};
+
+/**
+ * Multiple stat cards in a grid layout
+ */
+export const MultipleCards: Story = {
+  render: () => ({
+    template: `
+      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; max-width: 800px;">
+        <app-stat-card [icon]="'✓'" [value]="'3/8'" [label]="'Today'" />
+        <app-stat-card [icon]="'📅'" [value]="'18/32'" [label]="'Week'" />
+        <app-stat-card [icon]="'⭐'" [value]="'450'" [label]="'Points'" />
+        <app-stat-card [icon]="'🔥'" [value]="'7'" [label]="'Day Streak'" />
+        <app-stat-card [icon]="'🏆'" [value]="'12'" [label]="'Achievements'" />
+        <app-stat-card [icon]="'📊'" [value]="'87%'" [label]="'Completion'" />
+      </div>
+    `,
+  }),
+};

--- a/apps/frontend/src/app/components/stat-card/stat-card.ts
+++ b/apps/frontend/src/app/components/stat-card/stat-card.ts
@@ -1,0 +1,31 @@
+import { Component, ChangeDetectionStrategy, input } from '@angular/core';
+
+@Component({
+  selector: 'app-stat-card',
+  imports: [],
+  templateUrl: './stat-card.html',
+  styleUrl: './stat-card.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class StatCard {
+  /**
+   * Icon or emoji to display (e.g., '✓', '🏆', '📊')
+   */
+  icon = input.required<string>();
+
+  /**
+   * Stat value to display (e.g., '3/8', '450', '100%')
+   */
+  value = input.required<number | string>();
+
+  /**
+   * Label describing the stat (e.g., 'Today', 'Points', 'Week')
+   */
+  label = input.required<string>();
+
+  /**
+   * Optional custom gradient class name
+   * If not provided, uses default primary gradient
+   */
+  gradient = input<string>();
+}


### PR DESCRIPTION
## Summary

Implements `StatCard` component for displaying statistics on the dashboard as part of the UI/UX redesign.

Part of #184 (UI/UX Redesign)
Closes #187

## Features

- **Reusable component** for displaying stats with icon, value, and label
- **Gradient text effect** for values using primary → secondary gradient
- **Hover animation** with translateY effect
- **Responsive design** using design tokens
- **Accessibility**:
  - Semantic HTML structure
  - Reduced motion support
  - No WCAG violations

## Component Details

**Location:** `apps/frontend/src/app/components/stat-card/`

**Inputs:**
- `icon` (required): Emoji or icon character (e.g., '✓', '⭐', '🔥')
- `value` (required): Number or string (e.g., '3/8', 450, '87%')
- `label` (required): Description of the stat (e.g., 'Today', 'Points')
- `gradient` (optional): Custom CSS class for gradient

**Usage:**
```html
<app-stat-card 
  [icon]="'✓'" 
  [value]="'3/8'" 
  [label]="'Today'" />
```

## Testing

- ✅ **9 unit tests** - All passing
- ✅ **Storybook stories** - 6+ examples including multi-card grid
- ✅ **Build passes** - No TypeScript errors
- ✅ **Angular 21+ compliant** - Standalone, signals, OnPush

## Test Plan

- [x] Component renders correctly
- [x] All inputs work as expected
- [x] Hover effects smooth
- [x] Gradient applies correctly
- [x] Custom gradient class works
- [x] Reduced motion supported
- [x] Unit tests pass
- [x] Build successful

## Screenshots

See Storybook for visual examples:
- Today stats (3/8)
- Weekly stats (18/32)
- Points display (450)
- Streak counter (7 days)
- Achievements (12)
- Percentage (87%)

## Next Steps

After merge, this component will be used in:
- Home dashboard (issue #191)
- Tasks screen (issue #192)
- Stats/Progress page (issue #194)

🤖 Generated with [Claude Code](https://claude.com/claude-code)