### PR TITLE
feat: add MemberCard component for family member display (#188)

### DIFF
--- a/apps/frontend/src/app/components/member-card/member-card.css
+++ b/apps/frontend/src/app/components/member-card/member-card.css
@@ -1,0 +1,100 @@
+.member-card {
+  background: var(--color-surface, #ffffff);
+  border-radius: var(--radius-md, 24px);
+  padding: var(--space-lg, 1.5rem);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06);
+  display: flex;
+  align-items: center;
+  gap: var(--space-md, 1rem);
+  transition: all 0.3s ease;
+}
+
+.member-card.clickable {
+  cursor: pointer;
+}
+
+.member-card.clickable:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+.member-card.clickable:focus {
+  outline: 2px solid var(--color-primary, #6366f1);
+  outline-offset: 2px;
+}
+
+.member-avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: linear-gradient(
+    135deg,
+    var(--color-primary, #6366f1) 0%,
+    var(--color-secondary, #ec4899) 100%
+  );
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-weight: 700;
+  font-size: 20px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  flex-shrink: 0;
+  font-family: var(--font-heading, 'Fredoka', sans-serif);
+}
+
+.member-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.member-name {
+  font-family: var(--font-heading, 'Fredoka', sans-serif);
+  font-size: 18px;
+  font-weight: 700;
+  margin-bottom: var(--space-xs, 0.5rem);
+  color: var(--color-text-primary, #1e293b);
+}
+
+.member-role {
+  font-size: 14px;
+  color: var(--color-text-secondary, #64748b);
+  font-weight: 600;
+}
+
+.member-role.role-parent {
+  color: var(--color-purple, #a855f7);
+}
+
+.member-role.role-child {
+  color: var(--color-success, #10b981);
+}
+
+.member-stats {
+  text-align: right;
+}
+
+.member-points {
+  font-family: var(--font-heading, 'Fredoka', sans-serif);
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--color-accent, #fbbf24);
+  margin-bottom: var(--space-xs, 0.5rem);
+}
+
+.member-tasks {
+  font-size: 12px;
+  color: var(--color-text-secondary, #64748b);
+  font-weight: 600;
+}
+
+/* Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+  .member-card {
+    transition: none;
+  }
+
+  .member-card.clickable:hover {
+    transform: none;
+  }
+}

--- a/apps/frontend/src/app/components/member-card/member-card.html
+++ b/apps/frontend/src/app/components/member-card/member-card.html
@@ -1,0 +1,27 @@
+<div
+  class="member-card"
+  [class.clickable]="clickable()"
+  (click)="handleClick()"
+  [attr.role]="clickable() ? 'button' : null"
+  [attr.tabindex]="clickable() ? 0 : null"
+  (keydown.enter)="handleClick()"
+  (keydown.space)="handleClick()"
+>
+  <div class="member-avatar">{{ initials() }}</div>
+
+  <div class="member-info">
+    <div class="member-name">{{ member().name }}</div>
+    <div class="member-role" [class]="roleClass()">
+      {{ member().role === 'parent' ? 'Parent' : 'Child' }}
+    </div>
+  </div>
+
+  @if (showStats()) {
+    <div class="member-stats">
+      <div class="member-points">{{ member().points || 0 }} pts</div>
+      <div class="member-tasks">
+        {{ member().tasksCompleted || 0 }}/{{ member().totalTasks || 0 }} tasks
+      </div>
+    </div>
+  }
+</div>

--- a/apps/frontend/src/app/components/member-card/member-card.spec.ts
+++ b/apps/frontend/src/app/components/member-card/member-card.spec.ts
@@ -1,0 +1,239 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MemberCard, type MemberCardData } from './member-card';
+import { ComponentRef } from '@angular/core';
+
+describe('MemberCard', () => {
+  let component: MemberCard;
+  let componentRef: ComponentRef<MemberCard>;
+  let fixture: ComponentFixture<MemberCard>;
+
+  const mockParentMember: MemberCardData = {
+    id: '1',
+    name: 'Sarah Johnson',
+    email: 'sarah@example.com',
+    role: 'parent',
+    tasksCompleted: 12,
+    totalTasks: 15,
+    points: 450,
+  };
+
+  const mockChildMember: MemberCardData = {
+    id: '2',
+    name: 'Alex Johnson',
+    role: 'child',
+    tasksCompleted: 8,
+    totalTasks: 10,
+    points: 280,
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MemberCard],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MemberCard);
+    component = fixture.componentInstance;
+    componentRef = fixture.componentRef;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display member name', () => {
+    componentRef.setInput('member', mockParentMember);
+    fixture.detectChanges();
+
+    const nameElement = fixture.nativeElement.querySelector('.member-name');
+    expect(nameElement?.textContent).toContain('Sarah Johnson');
+  });
+
+  it('should display correct initials for full name', () => {
+    componentRef.setInput('member', mockParentMember);
+    fixture.detectChanges();
+
+    const avatarElement = fixture.nativeElement.querySelector('.member-avatar');
+    expect(avatarElement?.textContent?.trim()).toBe('SJ');
+  });
+
+  it('should display initials for single name', () => {
+    componentRef.setInput('member', { ...mockParentMember, name: 'Mike' });
+    fixture.detectChanges();
+
+    const avatarElement = fixture.nativeElement.querySelector('.member-avatar');
+    expect(avatarElement?.textContent?.trim()).toBe('MI');
+  });
+
+  it('should display parent role', () => {
+    componentRef.setInput('member', mockParentMember);
+    fixture.detectChanges();
+
+    const roleElement = fixture.nativeElement.querySelector('.member-role');
+    expect(roleElement?.textContent).toContain('Parent');
+    expect(roleElement?.classList.contains('role-parent')).toBe(true);
+  });
+
+  it('should display child role', () => {
+    componentRef.setInput('member', mockChildMember);
+    fixture.detectChanges();
+
+    const roleElement = fixture.nativeElement.querySelector('.member-role');
+    expect(roleElement?.textContent).toContain('Child');
+    expect(roleElement?.classList.contains('role-child')).toBe(true);
+  });
+
+  it('should display stats when showStats is true', () => {
+    componentRef.setInput('member', mockParentMember);
+    componentRef.setInput('showStats', true);
+    fixture.detectChanges();
+
+    const statsElement = fixture.nativeElement.querySelector('.member-stats');
+    expect(statsElement).toBeTruthy();
+
+    const pointsElement = fixture.nativeElement.querySelector('.member-points');
+    expect(pointsElement?.textContent).toContain('450 pts');
+
+    const tasksElement = fixture.nativeElement.querySelector('.member-tasks');
+    expect(tasksElement?.textContent).toContain('12/15 tasks');
+  });
+
+  it('should hide stats when showStats is false', () => {
+    componentRef.setInput('member', mockParentMember);
+    componentRef.setInput('showStats', false);
+    fixture.detectChanges();
+
+    const statsElement = fixture.nativeElement.querySelector('.member-stats');
+    expect(statsElement).toBeFalsy();
+  });
+
+  it('should display zero stats correctly', () => {
+    componentRef.setInput('member', {
+      ...mockParentMember,
+      tasksCompleted: 0,
+      totalTasks: 0,
+      points: 0,
+    });
+    componentRef.setInput('showStats', true);
+    fixture.detectChanges();
+
+    const pointsElement = fixture.nativeElement.querySelector('.member-points');
+    expect(pointsElement?.textContent).toContain('0 pts');
+
+    const tasksElement = fixture.nativeElement.querySelector('.member-tasks');
+    expect(tasksElement?.textContent).toContain('0/0 tasks');
+  });
+
+  it('should display default values for missing stats', () => {
+    const memberWithoutStats: MemberCardData = {
+      id: '3',
+      name: 'Test User',
+      role: 'child',
+    };
+
+    componentRef.setInput('member', memberWithoutStats);
+    componentRef.setInput('showStats', true);
+    fixture.detectChanges();
+
+    const pointsElement = fixture.nativeElement.querySelector('.member-points');
+    expect(pointsElement?.textContent).toContain('0 pts');
+
+    const tasksElement = fixture.nativeElement.querySelector('.member-tasks');
+    expect(tasksElement?.textContent).toContain('0/0 tasks');
+  });
+
+  it('should apply clickable class when clickable is true', () => {
+    componentRef.setInput('member', mockParentMember);
+    componentRef.setInput('clickable', true);
+    fixture.detectChanges();
+
+    const cardElement = fixture.nativeElement.querySelector('.member-card');
+    expect(cardElement?.classList.contains('clickable')).toBe(true);
+  });
+
+  it('should not apply clickable class when clickable is false', () => {
+    componentRef.setInput('member', mockParentMember);
+    componentRef.setInput('clickable', false);
+    fixture.detectChanges();
+
+    const cardElement = fixture.nativeElement.querySelector('.member-card');
+    expect(cardElement?.classList.contains('clickable')).toBe(false);
+  });
+
+  it('should emit click event when clickable and clicked', () => {
+    const clickSpy = vi.fn();
+    component.cardClick.subscribe(clickSpy);
+
+    componentRef.setInput('member', mockParentMember);
+    componentRef.setInput('clickable', true);
+    fixture.detectChanges();
+
+    const cardElement = fixture.nativeElement.querySelector('.member-card');
+    cardElement?.click();
+
+    expect(clickSpy).toHaveBeenCalledWith('1');
+  });
+
+  it('should not emit click event when not clickable', () => {
+    const clickSpy = vi.fn();
+    component.cardClick.subscribe(clickSpy);
+
+    componentRef.setInput('member', mockParentMember);
+    componentRef.setInput('clickable', false);
+    fixture.detectChanges();
+
+    const cardElement = fixture.nativeElement.querySelector('.member-card');
+    cardElement?.click();
+
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
+  it('should have correct accessibility attributes when clickable', () => {
+    componentRef.setInput('member', mockParentMember);
+    componentRef.setInput('clickable', true);
+    fixture.detectChanges();
+
+    const cardElement = fixture.nativeElement.querySelector('.member-card');
+    expect(cardElement?.getAttribute('role')).toBe('button');
+    expect(cardElement?.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('should not have button role when not clickable', () => {
+    componentRef.setInput('member', mockParentMember);
+    componentRef.setInput('clickable', false);
+    fixture.detectChanges();
+
+    const cardElement = fixture.nativeElement.querySelector('.member-card');
+    expect(cardElement?.getAttribute('role')).toBeNull();
+    expect(cardElement?.getAttribute('tabindex')).toBeNull();
+  });
+
+  it('should handle keyboard enter key when clickable', () => {
+    const clickSpy = vi.fn();
+    component.cardClick.subscribe(clickSpy);
+
+    componentRef.setInput('member', mockParentMember);
+    componentRef.setInput('clickable', true);
+    fixture.detectChanges();
+
+    const cardElement = fixture.nativeElement.querySelector('.member-card');
+    const event = new KeyboardEvent('keydown', { key: 'Enter' });
+    cardElement?.dispatchEvent(event);
+
+    expect(clickSpy).toHaveBeenCalledWith('1');
+  });
+
+  it('should handle keyboard space key when clickable', () => {
+    const clickSpy = vi.fn();
+    component.cardClick.subscribe(clickSpy);
+
+    componentRef.setInput('member', mockParentMember);
+    componentRef.setInput('clickable', true);
+    fixture.detectChanges();
+
+    const cardElement = fixture.nativeElement.querySelector('.member-card');
+    const event = new KeyboardEvent('keydown', { key: ' ' });
+    cardElement?.dispatchEvent(event);
+
+    expect(clickSpy).toHaveBeenCalledWith('1');
+  });
+});

--- a/apps/frontend/src/app/components/member-card/member-card.stories.ts
+++ b/apps/frontend/src/app/components/member-card/member-card.stories.ts
@@ -1,0 +1,186 @@
+import { Meta, StoryObj } from '@storybook/angular';
+import { MemberCard, type MemberCardData } from './member-card';
+
+/**
+ * MemberCard displays family member information with avatar, role, and optional stats.
+ * Used on the Family screen to show household members.
+ *
+ * Part of the Diddit! Design System.
+ */
+const meta: Meta<MemberCard> = {
+  title: 'Components/MemberCard',
+  component: MemberCard,
+  tags: ['autodocs'],
+  argTypes: {
+    member: {
+      description: 'Member data to display',
+    },
+    showStats: {
+      control: 'boolean',
+      description: 'Whether to show task and points statistics',
+    },
+    clickable: {
+      control: 'boolean',
+      description: 'Whether the card is clickable',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<MemberCard>;
+
+const parentMember: MemberCardData = {
+  id: '1',
+  name: 'Sarah Johnson',
+  email: 'sarah@example.com',
+  role: 'parent',
+  tasksCompleted: 12,
+  totalTasks: 15,
+  points: 450,
+};
+
+const childMember: MemberCardData = {
+  id: '2',
+  name: 'Alex Johnson',
+  email: 'alex@example.com',
+  role: 'child',
+  tasksCompleted: 8,
+  totalTasks: 10,
+  points: 280,
+};
+
+/**
+ * Parent member card with stats
+ */
+export const Parent: Story = {
+  args: {
+    member: parentMember,
+    showStats: true,
+    clickable: false,
+  },
+};
+
+/**
+ * Child member card with stats
+ */
+export const Child: Story = {
+  args: {
+    member: childMember,
+    showStats: true,
+    clickable: false,
+  },
+};
+
+/**
+ * Clickable card (for interactive use)
+ */
+export const Clickable: Story = {
+  args: {
+    member: parentMember,
+    showStats: true,
+    clickable: true,
+  },
+};
+
+/**
+ * Card without stats
+ */
+export const WithoutStats: Story = {
+  args: {
+    member: parentMember,
+    showStats: false,
+    clickable: false,
+  },
+};
+
+/**
+ * Member with zero stats
+ */
+export const ZeroStats: Story = {
+  args: {
+    member: {
+      id: '3',
+      name: 'New Member',
+      role: 'child',
+      tasksCompleted: 0,
+      totalTasks: 0,
+      points: 0,
+    },
+    showStats: true,
+    clickable: false,
+  },
+};
+
+/**
+ * Member with single name
+ */
+export const SingleName: Story = {
+  args: {
+    member: {
+      id: '4',
+      name: 'Mike',
+      role: 'parent',
+      tasksCompleted: 5,
+      totalTasks: 8,
+      points: 150,
+    },
+    showStats: true,
+    clickable: false,
+  },
+};
+
+/**
+ * Multiple member cards in a grid
+ */
+export const MultipleCards: Story = {
+  render: () => ({
+    template: `
+      <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(350px, 1fr)); gap: 1rem; max-width: 1200px;">
+        <app-member-card
+          [member]="{
+            id: '1',
+            name: 'Sarah Johnson',
+            role: 'parent',
+            tasksCompleted: 12,
+            totalTasks: 15,
+            points: 450
+          }"
+          [showStats]="true"
+          [clickable]="true" />
+        <app-member-card
+          [member]="{
+            id: '2',
+            name: 'Alex Johnson',
+            role: 'child',
+            tasksCompleted: 8,
+            totalTasks: 10,
+            points: 280
+          }"
+          [showStats]="true"
+          [clickable]="true" />
+        <app-member-card
+          [member]="{
+            id: '3',
+            name: 'Mike Johnson',
+            role: 'parent',
+            tasksCompleted: 5,
+            totalTasks: 8,
+            points: 150
+          }"
+          [showStats]="true"
+          [clickable]="true" />
+        <app-member-card
+          [member]="{
+            id: '4',
+            name: 'Emma Johnson',
+            role: 'child',
+            tasksCompleted: 3,
+            totalTasks: 5,
+            points: 90
+          }"
+          [showStats]="true"
+          [clickable]="true" />
+      </div>
+    `,
+  }),
+};

--- a/apps/frontend/src/app/components/member-card/member-card.ts
+++ b/apps/frontend/src/app/components/member-card/member-card.ts
@@ -1,0 +1,73 @@
+import { Component, ChangeDetectionStrategy, input, output, computed } from '@angular/core';
+
+/**
+ * Extended member data for display purposes
+ * Combines HouseholdMember with user details and stats
+ */
+export interface MemberCardData {
+  id: string;
+  name: string;
+  email?: string;
+  role: 'parent' | 'child';
+  tasksCompleted?: number;
+  totalTasks?: number;
+  points?: number;
+}
+
+@Component({
+  selector: 'app-member-card',
+  imports: [],
+  templateUrl: './member-card.html',
+  styleUrl: './member-card.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MemberCard {
+  /**
+   * Member data to display
+   */
+  member = input.required<MemberCardData>();
+
+  /**
+   * Whether to show task/points statistics
+   */
+  showStats = input(true);
+
+  /**
+   * Whether the card is clickable
+   */
+  clickable = input(false);
+
+  /**
+   * Emitted when card is clicked (if clickable)
+   */
+  cardClick = output<string>();
+
+  /**
+   * Get initials from member name
+   */
+  initials = computed(() => {
+    const name = this.member().name;
+    const parts = name.split(' ');
+    if (parts.length >= 2) {
+      return `${parts[0][0]}${parts[1][0]}`.toUpperCase();
+    }
+    return name.substring(0, 2).toUpperCase();
+  });
+
+  /**
+   * Get role badge color class
+   */
+  roleClass = computed(() => {
+    const role = this.member().role;
+    return role === 'parent' ? 'role-parent' : 'role-child';
+  });
+
+  /**
+   * Handle card click
+   */
+  handleClick() {
+    if (this.clickable()) {
+      this.cardClick.emit(this.member().id);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements `MemberCard` component for displaying family members on the Family screen as part of the UI/UX redesign.

Part of #184 (UI/UX Redesign)
Closes #188

## Features

- **Reusable component** for displaying family members
- **Gradient avatar** with auto-generated initials
- **Role badge** with color-coding (Parent: purple, Child: green)
- **Optional stats** display (tasks completed, points earned)
- **Clickable mode** with full keyboard support (Enter/Space keys)
- **Hover animation** with translateY effect
- **Accessibility**:
  - ARIA button role when clickable
  - Keyboard navigation support
  - Reduced motion support
  - Proper focus indicators

## Component Details

**Location:** `apps/frontend/src/app/components/member-card/`

**Inputs:**
- `member` (required): MemberCardData with id, name, role, optional stats
- `showStats` (default: true): Toggle stats display
- `clickable` (default: false): Enable click/keyboard interaction

**Outputs:**
- `cardClick`: Emits member ID when clicked (if clickable)

**Usage:**
```html
<app-member-card 
  [member]="memberData" 
  [showStats]="true"
  [clickable]="true"
  (cardClick)="handleMemberClick($event)" />
```

## Testing

- ✅ **18 unit tests** - All passing
- ✅ **Storybook stories** - 7+ examples (parent, child, clickable, no stats, etc.)
- ✅ **Build passes** - No TypeScript errors
- ✅ **Angular 21+ compliant** - Standalone, signals, OnPush

## Test Plan

- [x] Component renders member data
- [x] Initials generated correctly
- [x] Role badges display with correct colors
- [x] Stats show/hide based on input
- [x] Click events emit properly
- [x] Keyboard support (Enter/Space)
- [x] Accessibility attributes correct
- [x] Reduced motion supported
- [x] All tests pass
- [x] Build successful

## Screenshots

See Storybook for visual examples:
- Parent member with stats
- Child member with stats
- Clickable cards
- Cards without stats
- Multiple card grid layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)