### PR TITLE
feat(a11y): Add WCAG 2.1 AA accessibility improvements

### DIFF
--- a/apps/frontend/src/app/components/member-card/member-card.html
+++ b/apps/frontend/src/app/components/member-card/member-card.html
@@ -4,10 +4,11 @@
   (click)="handleClick()"
   [attr.role]="clickable() ? 'button' : null"
   [attr.tabindex]="clickable() ? 0 : null"
+  [attr.aria-label]="clickable() ? 'View ' + member().name + ' details' : null"
   (keydown.enter)="handleClick()"
   (keydown.space)="handleClick()"
 >
-  <div class="member-avatar">{{ initials() }}</div>
+  <div class="member-avatar" aria-hidden="true">{{ initials() }}</div>
 
   <div class="member-info">
     <div class="member-name">{{ member().name }}</div>

--- a/apps/frontend/src/app/components/modals/add-child-modal/add-child-modal.html
+++ b/apps/frontend/src/app/components/modals/add-child-modal/add-child-modal.html
@@ -9,9 +9,13 @@
         formControlName="name"
         placeholder="e.g., Emma"
         [class.error]="form.controls.name.invalid && form.controls.name.touched"
+        [attr.aria-invalid]="form.controls.name.invalid && form.controls.name.touched"
+        [attr.aria-describedby]="
+          form.controls.name.invalid && form.controls.name.touched ? 'child-name-error' : null
+        "
       />
       @if (form.controls.name.invalid && form.controls.name.touched) {
-        <div class="form-error">
+        <div id="child-name-error" class="form-error" role="alert">
           @if (form.controls.name.errors?.['required']) {
             Child's name is required
           }
@@ -33,9 +37,13 @@
         min="1"
         max="18"
         [class.error]="form.controls.age.invalid && form.controls.age.touched"
+        [attr.aria-invalid]="form.controls.age.invalid && form.controls.age.touched"
+        [attr.aria-describedby]="
+          form.controls.age.invalid && form.controls.age.touched ? 'child-age-error' : null
+        "
       />
       @if (form.controls.age.invalid && form.controls.age.touched) {
-        <div class="form-error">
+        <div id="child-age-error" class="form-error" role="alert">
           @if (form.controls.age.errors?.['required']) {
             Age is required
           }

--- a/apps/frontend/src/app/components/modals/edit-task-modal/edit-task-modal.html
+++ b/apps/frontend/src/app/components/modals/edit-task-modal/edit-task-modal.html
@@ -10,9 +10,13 @@
           formControlName="name"
           placeholder="e.g., Take out trash"
           [class.error]="form.controls.name.invalid && form.controls.name.touched"
+          [attr.aria-invalid]="form.controls.name.invalid && form.controls.name.touched"
+          [attr.aria-describedby]="
+            form.controls.name.invalid && form.controls.name.touched ? 'edit-task-name-error' : null
+          "
         />
         @if (form.controls.name.invalid && form.controls.name.touched) {
-          <div class="form-error">
+          <div id="edit-task-name-error" class="form-error" role="alert">
             @if (form.controls.name.errors?.['required']) {
               Task name is required
             }
@@ -33,9 +37,15 @@
           min="1"
           max="1000"
           [class.error]="form.controls.points.invalid && form.controls.points.touched"
+          [attr.aria-invalid]="form.controls.points.invalid && form.controls.points.touched"
+          [attr.aria-describedby]="
+            form.controls.points.invalid && form.controls.points.touched
+              ? 'edit-points-error'
+              : null
+          "
         />
         @if (form.controls.points.invalid && form.controls.points.touched) {
-          <div class="form-error">
+          <div id="edit-points-error" class="form-error" role="alert">
             @if (form.controls.points.errors?.['min']) {
               Points must be at least 1
             }

--- a/apps/frontend/src/app/components/modals/invite-modal/invite-modal.html
+++ b/apps/frontend/src/app/components/modals/invite-modal/invite-modal.html
@@ -9,9 +9,13 @@
         formControlName="email"
         placeholder="family@example.com"
         [class.error]="form.controls.email.invalid && form.controls.email.touched"
+        [attr.aria-invalid]="form.controls.email.invalid && form.controls.email.touched"
+        [attr.aria-describedby]="
+          form.controls.email.invalid && form.controls.email.touched ? 'invite-email-error' : null
+        "
       />
       @if (form.controls.email.invalid && form.controls.email.touched) {
-        <div class="form-error">
+        <div id="invite-email-error" class="form-error" role="alert">
           @if (form.controls.email.errors?.['required']) {
             Email address is required
           }

--- a/apps/frontend/src/app/components/modals/quick-add-modal/quick-add-modal.html
+++ b/apps/frontend/src/app/components/modals/quick-add-modal/quick-add-modal.html
@@ -9,9 +9,13 @@
         formControlName="name"
         placeholder="e.g., Take out trash"
         [class.error]="form.controls.name.invalid && form.controls.name.touched"
+        [attr.aria-invalid]="form.controls.name.invalid && form.controls.name.touched"
+        [attr.aria-describedby]="
+          form.controls.name.invalid && form.controls.name.touched ? 'task-name-error' : null
+        "
       />
       @if (form.controls.name.invalid && form.controls.name.touched) {
-        <div class="form-error">
+        <div id="task-name-error" class="form-error" role="alert">
           @if (form.controls.name.errors?.['required']) {
             Task name is required
           }
@@ -31,6 +35,14 @@
         [class.error]="
           form.controls.assignedChildId.invalid && form.controls.assignedChildId.touched
         "
+        [attr.aria-invalid]="
+          form.controls.assignedChildId.invalid && form.controls.assignedChildId.touched
+        "
+        [attr.aria-describedby]="
+          form.controls.assignedChildId.invalid && form.controls.assignedChildId.touched
+            ? 'assign-to-error'
+            : null
+        "
       >
         <option value="">Choose person...</option>
         @for (child of children(); track child.id) {
@@ -38,7 +50,9 @@
         }
       </select>
       @if (form.controls.assignedChildId.invalid && form.controls.assignedChildId.touched) {
-        <div class="form-error">Please select who to assign this task to</div>
+        <div id="assign-to-error" class="form-error" role="alert">
+          Please select who to assign this task to
+        </div>
       }
     </div>
 
@@ -52,9 +66,13 @@
         min="1"
         max="1000"
         [class.error]="form.controls.points.invalid && form.controls.points.touched"
+        [attr.aria-invalid]="form.controls.points.invalid && form.controls.points.touched"
+        [attr.aria-describedby]="
+          form.controls.points.invalid && form.controls.points.touched ? 'points-error' : null
+        "
       />
       @if (form.controls.points.invalid && form.controls.points.touched) {
-        <div class="form-error">
+        <div id="points-error" class="form-error" role="alert">
           @if (form.controls.points.errors?.['min']) {
             Points must be at least 1
           }

--- a/apps/frontend/src/app/components/stat-card/stat-card.html
+++ b/apps/frontend/src/app/components/stat-card/stat-card.html
@@ -1,5 +1,10 @@
-<div class="stat-card" [class]="gradient()">
-  <div class="stat-icon">{{ icon() }}</div>
+<div
+  class="stat-card"
+  [class]="gradient()"
+  role="group"
+  [attr.aria-label]="label() + ': ' + value()"
+>
+  <div class="stat-icon" aria-hidden="true">{{ icon() }}</div>
   <div class="stat-value">{{ value() }}</div>
   <div class="stat-label">{{ label() }}</div>
 </div>

--- a/apps/frontend/src/app/pages/family/family.html
+++ b/apps/frontend/src/app/pages/family/family.html
@@ -1,15 +1,15 @@
 <!-- Loading State -->
 @if (loading()) {
-  <div class="loading-container">
-    <div class="spinner"></div>
+  <div class="loading-container" role="status" aria-live="polite">
+    <div class="spinner" aria-hidden="true"></div>
     <p>Loading family members...</p>
   </div>
 }
 
 <!-- Error State -->
 @if (error() && !loading()) {
-  <div class="error-container">
-    <div class="error-icon">⚠️</div>
+  <div class="error-container" role="alert" aria-live="assertive">
+    <div class="error-icon" aria-hidden="true">⚠️</div>
     <h2>Oops!</h2>
     <p>{{ error() }}</p>
     <button class="btn-retry" (click)="loadData()">Try Again</button>
@@ -66,8 +66,8 @@
               }
             </div>
           } @else {
-            <div class="empty-state">
-              <div class="empty-icon">👥</div>
+            <div class="empty-state" role="status">
+              <div class="empty-icon" aria-hidden="true">👥</div>
               <h3>No members yet</h3>
               <p>Start inviting family members to your household.</p>
             </div>

--- a/apps/frontend/src/app/pages/home/home.html
+++ b/apps/frontend/src/app/pages/home/home.html
@@ -1,15 +1,15 @@
 <!-- Loading State -->
 @if (loading()) {
-  <div class="loading-container">
-    <div class="spinner"></div>
+  <div class="loading-container" role="status" aria-live="polite">
+    <div class="spinner" aria-hidden="true"></div>
     <p>Loading your dashboard...</p>
   </div>
 }
 
 <!-- Error State -->
 @if (error() && !loading()) {
-  <div class="error-container">
-    <div class="error-icon">⚠️</div>
+  <div class="error-container" role="alert" aria-live="assertive">
+    <div class="error-icon" aria-hidden="true">⚠️</div>
     <h2>Oops!</h2>
     <p>{{ error() }}</p>
     <button class="btn-retry" (click)="loadData()">Try Again</button>
@@ -70,8 +70,8 @@
               }
             </div>
           } @else {
-            <div class="empty-state">
-              <div class="empty-icon">✨</div>
+            <div class="empty-state" role="status">
+              <div class="empty-icon" aria-hidden="true">✨</div>
               <h3>All done!</h3>
               <p>You've completed all your tasks for today.</p>
             </div>

--- a/apps/frontend/src/app/pages/progress/progress.html
+++ b/apps/frontend/src/app/pages/progress/progress.html
@@ -10,15 +10,15 @@
 <div class="main-content">
   <!-- Loading State -->
   @if (loading()) {
-    <div class="loading-container">
-      <div class="loading-spinner"></div>
+    <div class="loading-container" role="status" aria-live="polite">
+      <div class="loading-spinner" aria-hidden="true"></div>
       <p>Loading progress...</p>
     </div>
   }
 
   <!-- Error State -->
   @if (error()) {
-    <div class="error-container">
+    <div class="error-container" role="alert" aria-live="assertive">
       <p class="error-message">{{ error() }}</p>
       <button class="retry-button" (click)="loadData()">Try Again</button>
     </div>
@@ -27,90 +27,122 @@
   <!-- Main Content -->
   @if (!loading() && !error()) {
     <!-- Household Stats Section -->
-    <div class="stats-section">
-      <div class="stats-grid">
-        <div class="stat-box">
+    <section class="stats-section" aria-labelledby="stats-heading">
+      <h2 id="stats-heading" class="visually-hidden">Household Statistics</h2>
+      <div class="stats-grid" role="list">
+        <div
+          class="stat-box"
+          role="listitem"
+          aria-label="Total Points: {{ householdStats().totalPoints }}"
+        >
           <div class="stat-value">{{ householdStats().totalPoints }}</div>
           <div class="stat-label">Total Points</div>
         </div>
-        <div class="stat-box">
+        <div
+          class="stat-box"
+          role="listitem"
+          aria-label="Completion Rate: {{ householdStats().completionRate }} percent"
+        >
           <div class="stat-value">{{ householdStats().completionRate }}%</div>
           <div class="stat-label">Completion Rate</div>
         </div>
-        <div class="stat-box">
+        <div
+          class="stat-box"
+          role="listitem"
+          aria-label="Tasks This Week: {{ householdStats().tasksCompletedThisWeek }}"
+        >
           <div class="stat-value">{{ householdStats().tasksCompletedThisWeek }}</div>
           <div class="stat-label">Tasks This Week</div>
         </div>
       </div>
-    </div>
+    </section>
 
     <!-- Leaderboard Section -->
-    <div class="section">
+    <section class="section" aria-labelledby="leaderboard-heading">
       <div class="section-header">
-        <h2>This Week's Leaders</h2>
+        <h2 id="leaderboard-heading">This Week's Leaders</h2>
         <p class="section-subtitle">Great work, everyone!</p>
       </div>
 
       @if (hasLeaderboard()) {
-        <div class="leaderboard">
+        <ol class="leaderboard" aria-label="Weekly leaderboard rankings">
           @for (entry of leaderboard(); track entry.userId) {
-            <div class="leaderboard-item" [class.current-user]="entry.isCurrentUser">
-              <div class="leaderboard-rank">{{ getMedalForRank(entry.rank) }}</div>
+            <li
+              class="leaderboard-item"
+              [class.current-user]="entry.isCurrentUser"
+              [attr.aria-current]="entry.isCurrentUser ? 'true' : null"
+            >
+              <div class="leaderboard-rank" aria-hidden="true">
+                {{ getMedalForRank(entry.rank) }}
+              </div>
               <div class="leaderboard-info">
                 <div class="leaderboard-name">{{ entry.name }}</div>
                 <div class="leaderboard-tasks">{{ entry.tasksCompleted }} tasks completed</div>
               </div>
-              <div class="leaderboard-points">{{ entry.points }}</div>
-            </div>
+              <div class="leaderboard-points" aria-label="{{ entry.points }} points">
+                {{ entry.points }}
+              </div>
+            </li>
           }
-        </div>
+        </ol>
       } @else {
-        <div class="empty-state">
+        <div class="empty-state" role="status">
           <p>No leaderboard data yet. Complete some tasks to get started!</p>
         </div>
       }
-    </div>
+    </section>
 
     <!-- Achievements Section -->
-    <div class="section">
+    <section class="section" aria-labelledby="achievements-heading">
       <div class="section-header">
-        <h2>Achievements</h2>
+        <h2 id="achievements-heading">Achievements</h2>
         <p class="section-subtitle">Keep up the amazing progress!</p>
       </div>
 
       @if (hasAchievements()) {
-        <div class="achievements-grid">
+        <div class="achievements-grid" role="list" aria-label="Achievement badges">
           @for (achievement of achievements(); track achievement.id) {
-            <div
+            <article
               class="achievement-card"
               [class.unlocked]="achievement.unlocked"
               [class.locked]="!achievement.unlocked"
+              role="listitem"
+              [attr.aria-label]="
+                achievement.name + (achievement.unlocked ? ' - Unlocked' : ' - Locked')
+              "
             >
-              <div class="achievement-icon">{{ achievement.icon }}</div>
+              <div class="achievement-icon" aria-hidden="true">{{ achievement.icon }}</div>
               <div class="achievement-info">
                 <h3>{{ achievement.name }}</h3>
                 <div class="achievement-desc">{{ achievement.description }}</div>
                 @if (!achievement.unlocked && achievement.progress !== undefined) {
                   <div class="achievement-progress">
-                    <div class="progress-bar">
+                    <div
+                      class="progress-bar"
+                      role="progressbar"
+                      [attr.aria-valuenow]="achievement.progress"
+                      aria-valuemin="0"
+                      aria-valuemax="100"
+                      [attr.aria-label]="'Progress: ' + achievement.progress + ' percent'"
+                    >
                       <div class="progress-fill" [style.width.%]="achievement.progress"></div>
                     </div>
-                    <div class="progress-text">{{ achievement.progress }}%</div>
+                    <div class="progress-text" aria-hidden="true">{{ achievement.progress }}%</div>
                   </div>
                 }
                 @if (achievement.unlocked) {
                   <div class="achievement-unlocked">Unlocked!</div>
                 }
               </div>
-            </div>
+            </article>
           }
         </div>
       } @else {
-        <div class="empty-state">
+        <div class="empty-state" role="status">
           <p>No achievements yet. Start completing tasks to unlock badges!</p>
         </div>
       }
-    </div>
+    </section>
   }
 </div>
 

--- a/apps/frontend/src/app/pages/tasks/tasks.html
+++ b/apps/frontend/src/app/pages/tasks/tasks.html
@@ -40,16 +40,16 @@
 
   <!-- Loading State -->
   @if (loading()) {
-    <div class="loading-state">
-      <div class="loading-spinner"></div>
+    <div class="loading-state" role="status" aria-live="polite">
+      <div class="loading-spinner" aria-hidden="true"></div>
       <p class="loading-text">Loading tasks...</p>
     </div>
   }
 
   <!-- Error State -->
   @if (error() && !loading()) {
-    <div class="error-state">
-      <div class="error-icon">⚠️</div>
+    <div class="error-state" role="alert" aria-live="assertive">
+      <div class="error-icon" aria-hidden="true">⚠️</div>
       <p class="error-text">{{ error() }}</p>
       <button type="button" class="retry-button" (click)="loadTasks()">Retry</button>
     </div>
@@ -60,8 +60,8 @@
     <div class="task-list">
       @if (filteredTasks().length === 0) {
         <!-- Empty State -->
-        <div class="empty-state">
-          <div class="empty-icon">📋</div>
+        <div class="empty-state" role="status">
+          <div class="empty-icon" aria-hidden="true">📋</div>
           <p class="empty-text">{{ emptyMessage() }}</p>
         </div>
       } @else {

--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -254,3 +254,90 @@ h6 {
 .animate-scale-in {
   animation: scaleIn var(--transition-slow) ease-out;
 }
+
+/* ===== ACCESSIBILITY UTILITIES ===== */
+
+/**
+ * Visually hidden content for screen readers only
+ * Use for content that should be read by screen readers but not visible
+ */
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+/**
+ * Skip to main content link
+ * Becomes visible on focus for keyboard navigation
+ */
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: var(--color-primary);
+  color: white;
+  padding: var(--space-sm) var(--space-md);
+  z-index: var(--z-index-toast);
+  text-decoration: none;
+  font-weight: var(--font-weight-semibold);
+  border-radius: 0 0 var(--radius-sm) 0;
+  transition: top var(--transition-fast);
+}
+
+.skip-link:focus {
+  top: 0;
+  outline: 3px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+/**
+ * Focus visible styles for better keyboard navigation visibility
+ */
+:focus-visible {
+  outline: 3px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+/**
+ * Reduced motion preference
+ * Respects user's system preference for reduced motion
+ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/**
+ * High contrast mode adjustments
+ */
+@media (prefers-contrast: high) {
+  :root {
+    --color-text-primary: #000000;
+    --color-text-secondary: #1a1a1a;
+    --color-text-tertiary: #333333;
+    --shadow-sm: none;
+    --shadow-md: none;
+    --shadow-lg: none;
+    --shadow-xl: none;
+  }
+
+  button,
+  input,
+  select,
+  textarea {
+    border-width: 2px !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Add ARIA live regions for loading/error states across pages
- Add aria-invalid and aria-describedby to form inputs in modals
- Convert leaderboard to semantic ol/li structure
- Add proper section/heading structure to Progress page
- Add accessibility utility classes (.visually-hidden, .skip-link)
- Add prefers-reduced-motion and prefers-contrast media query support

## Changes Made
- **Loading/Error states**: Added `role="status"` and `aria-live="polite"` to loading containers, `role="alert"` and `aria-live="assertive"` to error containers
- **Empty states**: Added `role="status"` for screen reader announcements
- **Decorative icons**: Added `aria-hidden="true"` to emoji icons
- **Form validation**: Added `aria-invalid`, `aria-describedby`, and `role="alert"` to form error messages in Quick Add, Edit Task, Invite, and Add Child modals
- **Progress page**: Converted to semantic sections with headings, added proper ARIA labels to stats, leaderboard rankings, and achievement cards
- **Stat cards**: Added `role="group"` with descriptive aria-label
- **Member cards**: Added aria-label for clickable cards
- **Global styles**: Added `.visually-hidden`, `.skip-link`, `:focus-visible`, `@media (prefers-reduced-motion)`, and `@media (prefers-contrast: high)` support

## Test plan
- [x] Build passes
- [x] All 426 unit tests pass
- [ ] Screen reader testing (requires browser)
- [ ] Keyboard navigation testing (requires browser)
- [ ] Lighthouse accessibility audit (requires browser)

Part of #184 (UI/UX Redesign)
Partial completion of #199 (Accessibility Audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)