### PR TITLE
feat(backend): add stats API endpoints for UX redesign

### DIFF
--- a/apps/backend/src/routes/stats.test.ts
+++ b/apps/backend/src/routes/stats.test.ts
@@ -1,0 +1,372 @@
+import { test, describe, before, after } from 'node:test';
+import assert from 'node:assert';
+import { build } from '../server.ts';
+import type { FastifyInstance } from 'fastify';
+import pg from 'pg';
+import { registerAndLogin } from '../test-helpers/auth.ts';
+
+/**
+ * Stats API Tests
+ */
+
+describe('Stats API', () => {
+  let app: FastifyInstance;
+  let pool: pg.Pool;
+  let parentToken: string;
+  let childToken: string;
+  let parentUserId: string;
+  let childUserId: string;
+  let householdId: string;
+  let childId: string;
+  let taskId: string;
+
+  before(async () => {
+    app = await build();
+    await app.ready();
+
+    pool = new pg.Pool({
+      host: process.env.TEST_DB_HOST || process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.TEST_DB_PORT || '55432'),
+      database: process.env.TEST_DB_NAME || 'st44_test',
+      user: process.env.TEST_DB_USER || process.env.DB_USER || 'postgres',
+      password: process.env.TEST_DB_PASSWORD || process.env.DB_PASSWORD || 'postgres',
+    });
+
+    // Create test users
+    const parentEmail = `test-stats-parent-${Date.now()}@example.com`;
+    const childEmail = `test-stats-child-${Date.now()}@example.com`;
+    const testPassword = 'TestPass123!';
+
+    const parentData = await registerAndLogin(app, parentEmail, testPassword);
+    const childData = await registerAndLogin(app, childEmail, testPassword);
+
+    parentToken = parentData.accessToken;
+    childToken = childData.accessToken;
+
+    // Get user IDs
+    const parentResult = await pool.query('SELECT id FROM users WHERE email = $1', [parentEmail]);
+    const childResult = await pool.query('SELECT id FROM users WHERE email = $1', [childEmail]);
+
+    parentUserId = parentResult.rows[0].id;
+    childUserId = childResult.rows[0].id;
+
+    // Create household
+    const householdResult = await pool.query(
+      'INSERT INTO households (name) VALUES ($1) RETURNING id',
+      [`Test Stats Household ${Date.now()}`],
+    );
+    householdId = householdResult.rows[0].id;
+
+    // Add parent as admin
+    await pool.query(
+      'INSERT INTO household_members (household_id, user_id, role) VALUES ($1, $2, $3)',
+      [householdId, parentUserId, 'admin'],
+    );
+
+    // Add child user as household member with 'child' role
+    await pool.query(
+      'INSERT INTO household_members (household_id, user_id, role) VALUES ($1, $2, $3)',
+      [householdId, childUserId, 'child'],
+    );
+
+    // Create child profile and link to user
+    const childProfileResult = await pool.query(
+      'INSERT INTO children (household_id, user_id, name, birth_year) VALUES ($1, $2, $3, $4) RETURNING id',
+      [householdId, childUserId, 'Test Stats Child', 2015],
+    );
+    childId = childProfileResult.rows[0].id;
+
+    // Create a task for testing
+    const taskResult = await pool.query(
+      'INSERT INTO tasks (household_id, name, description, points, rule_type, active) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id',
+      [householdId, 'Test Stats Task', 'A test task for stats', 15, 'daily', true],
+    );
+    taskId = taskResult.rows[0].id;
+
+    // Create task assignments and completions for testing
+    const today = new Date().toISOString().split('T')[0];
+    const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
+
+    // Create completed assignment for yesterday
+    const assignmentResult = await pool.query(
+      'INSERT INTO task_assignments (household_id, task_id, child_id, date, status) VALUES ($1, $2, $3, $4, $5) RETURNING id',
+      [householdId, taskId, childId, yesterday, 'completed'],
+    );
+
+    // Record completion with points
+    await pool.query(
+      "INSERT INTO task_completions (household_id, task_assignment_id, child_id, points_earned, completed_at) VALUES ($1, $2, $3, $4, NOW() - INTERVAL '1 day')",
+      [householdId, assignmentResult.rows[0].id, childId, 15],
+    );
+
+    // Create pending assignment for today
+    await pool.query(
+      'INSERT INTO task_assignments (household_id, task_id, child_id, date, status) VALUES ($1, $2, $3, $4, $5)',
+      [householdId, taskId, childId, today, 'pending'],
+    );
+  });
+
+  after(async () => {
+    // Cleanup
+    await pool.query('DELETE FROM task_completions WHERE household_id = $1', [householdId]);
+    await pool.query('DELETE FROM task_assignments WHERE household_id = $1', [householdId]);
+    await pool.query('DELETE FROM tasks WHERE household_id = $1', [householdId]);
+    await pool.query('DELETE FROM children WHERE household_id = $1', [householdId]);
+    await pool.query('DELETE FROM household_members WHERE household_id = $1', [householdId]);
+    await pool.query('DELETE FROM households WHERE id = $1', [householdId]);
+    await pool.query('DELETE FROM users WHERE id IN ($1, $2)', [parentUserId, childUserId]);
+    await pool.end();
+    await app.close();
+  });
+
+  describe('GET /api/stats/dashboard', () => {
+    test('should return dashboard stats for parent', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/stats/dashboard',
+        headers: { Authorization: `Bearer ${parentToken}` },
+      });
+
+      assert.strictEqual(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+
+      // Verify response structure
+      assert.ok(typeof body.activeTasks === 'number');
+      assert.ok(typeof body.weeklyCompleted === 'number');
+      assert.ok(typeof body.totalPoints === 'number');
+      assert.ok(Array.isArray(body.todaysTasks));
+      assert.ok(Array.isArray(body.upcomingTasks));
+    });
+
+    test('should return dashboard stats with householdId parameter', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/stats/dashboard?householdId=${householdId}`,
+        headers: { Authorization: `Bearer ${parentToken}` },
+      });
+
+      assert.strictEqual(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+
+      // Should have at least 1 active task (today's pending task)
+      assert.ok(body.activeTasks >= 1);
+    });
+
+    test("should include today's tasks in response", async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/stats/dashboard?householdId=${householdId}`,
+        headers: { Authorization: `Bearer ${parentToken}` },
+      });
+
+      assert.strictEqual(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+
+      // Should have today's task in todaysTasks
+      assert.ok(body.todaysTasks.length >= 1);
+
+      // Verify task structure
+      const task = body.todaysTasks[0];
+      assert.ok(task.id);
+      assert.ok(task.title);
+      assert.ok(task.status);
+      assert.ok(typeof task.points === 'number');
+    });
+
+    test('should reject without authentication', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/stats/dashboard',
+      });
+
+      assert.strictEqual(response.statusCode, 401);
+    });
+
+    test('should return 404 for invalid household', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/stats/dashboard?householdId=00000000-0000-0000-0000-000000000000',
+        headers: { Authorization: `Bearer ${parentToken}` },
+      });
+
+      assert.strictEqual(response.statusCode, 404);
+    });
+  });
+
+  describe('GET /api/stats/leaderboard', () => {
+    test('should return leaderboard for week period', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/stats/leaderboard?period=week',
+        headers: { Authorization: `Bearer ${parentToken}` },
+      });
+
+      assert.strictEqual(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+
+      // Verify response structure
+      assert.ok(Array.isArray(body.rankings));
+
+      // Should have our test child in rankings
+      assert.ok(body.rankings.length >= 1);
+
+      const ranking = body.rankings[0];
+      assert.ok(ranking.userId);
+      assert.ok(ranking.name);
+      assert.ok(typeof ranking.points === 'number');
+      assert.ok(typeof ranking.tasksCompleted === 'number');
+    });
+
+    test('should return leaderboard for month period', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/stats/leaderboard?period=month',
+        headers: { Authorization: `Bearer ${parentToken}` },
+      });
+
+      assert.strictEqual(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+      assert.ok(Array.isArray(body.rankings));
+    });
+
+    test('should return leaderboard for alltime period', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/stats/leaderboard?period=alltime',
+        headers: { Authorization: `Bearer ${parentToken}` },
+      });
+
+      assert.strictEqual(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+      assert.ok(Array.isArray(body.rankings));
+
+      // With alltime, should include all completions
+      const testChild = body.rankings.find((r: { userId: string }) => r.userId === childId);
+      if (testChild) {
+        // Should have at least 1 completion (from yesterday)
+        assert.ok(testChild.tasksCompleted >= 1);
+        assert.ok(testChild.points >= 15);
+      }
+    });
+
+    test('should default to week period', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/stats/leaderboard',
+        headers: { Authorization: `Bearer ${parentToken}` },
+      });
+
+      assert.strictEqual(response.statusCode, 200);
+    });
+
+    test('should reject without authentication', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/stats/leaderboard',
+      });
+
+      assert.strictEqual(response.statusCode, 401);
+    });
+  });
+
+  describe('GET /api/stats/achievements', () => {
+    test('should return achievements for child user', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/stats/achievements',
+        headers: { Authorization: `Bearer ${childToken}` },
+      });
+
+      assert.strictEqual(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+
+      // Verify response structure
+      assert.ok(Array.isArray(body.unlocked));
+      assert.ok(Array.isArray(body.locked));
+      assert.ok(Array.isArray(body.progress));
+
+      // Verify achievement structure
+      if (body.unlocked.length > 0) {
+        const achievement = body.unlocked[0];
+        assert.ok(achievement.id);
+        assert.ok(achievement.name);
+        assert.ok(achievement.description);
+        assert.ok(achievement.icon);
+      }
+
+      // Verify progress structure
+      if (body.progress.length > 0) {
+        const progressItem = body.progress[0];
+        assert.ok(progressItem.achievementId);
+        assert.ok(typeof progressItem.current === 'number');
+        assert.ok(typeof progressItem.required === 'number');
+      }
+    });
+
+    test('should return achievements with specific userId', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/stats/achievements?userId=${childId}`,
+        headers: { Authorization: `Bearer ${parentToken}` },
+      });
+
+      assert.strictEqual(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+
+      assert.ok(Array.isArray(body.unlocked));
+      assert.ok(Array.isArray(body.locked));
+    });
+
+    test('should return empty achievements for parent without child profile', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/stats/achievements',
+        headers: { Authorization: `Bearer ${parentToken}` },
+      });
+
+      assert.strictEqual(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+
+      // Parent has no child profile, so should have empty unlocked
+      assert.ok(Array.isArray(body.unlocked));
+      assert.strictEqual(body.unlocked.length, 0);
+
+      // Should have all achievements as locked
+      assert.ok(body.locked.length > 0);
+    });
+
+    test('should unlock first_task achievement after completing a task', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/stats/achievements',
+        headers: { Authorization: `Bearer ${childToken}` },
+      });
+
+      assert.strictEqual(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+
+      // Should have first_task unlocked (we completed 1 task in setup)
+      const firstTask = body.unlocked.find((a: { id: string }) => a.id === 'first_task');
+      assert.ok(firstTask, 'first_task achievement should be unlocked');
+    });
+
+    test('should reject without authentication', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/stats/achievements',
+      });
+
+      assert.strictEqual(response.statusCode, 401);
+    });
+
+    test('should return 404 for invalid userId', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/stats/achievements?userId=00000000-0000-0000-0000-000000000000',
+        headers: { Authorization: `Bearer ${parentToken}` },
+      });
+
+      assert.strictEqual(response.statusCode, 404);
+    });
+  });
+});

--- a/apps/backend/src/routes/stats.ts
+++ b/apps/backend/src/routes/stats.ts
@@ -1,0 +1,667 @@
+import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { z, zodToOpenAPI, CommonErrors } from '@st44/types/generators';
+import { db } from '../database.js';
+import { authenticateUser } from '../middleware/auth.js';
+import { stripResponseValidation } from '../schemas/common.js';
+
+/**
+ * Stats API endpoints for UX redesign dashboard
+ * Provides dashboard statistics, leaderboard, and achievements data
+ */
+
+interface DashboardQuerystring {
+  householdId?: string;
+}
+
+interface LeaderboardQuerystring {
+  householdId?: string;
+  period?: 'week' | 'month' | 'alltime';
+}
+
+interface AchievementsQuerystring {
+  userId?: string;
+  householdId?: string;
+}
+
+// Achievement definitions
+const ACHIEVEMENTS = [
+  {
+    id: 'first_task',
+    name: 'First Steps',
+    description: 'Complete your first task',
+    icon: '🌟',
+    requirement: 1,
+    type: 'tasks_completed' as const,
+  },
+  {
+    id: 'task_master_10',
+    name: 'Task Master',
+    description: 'Complete 10 tasks',
+    icon: '⭐',
+    requirement: 10,
+    type: 'tasks_completed' as const,
+  },
+  {
+    id: 'task_champion_50',
+    name: 'Task Champion',
+    description: 'Complete 50 tasks',
+    icon: '🏆',
+    requirement: 50,
+    type: 'tasks_completed' as const,
+  },
+  {
+    id: 'task_legend_100',
+    name: 'Task Legend',
+    description: 'Complete 100 tasks',
+    icon: '👑',
+    requirement: 100,
+    type: 'tasks_completed' as const,
+  },
+  {
+    id: 'point_collector_100',
+    name: 'Point Collector',
+    description: 'Earn 100 points',
+    icon: '💎',
+    requirement: 100,
+    type: 'points_earned' as const,
+  },
+  {
+    id: 'point_hoarder_500',
+    name: 'Point Hoarder',
+    description: 'Earn 500 points',
+    icon: '💰',
+    requirement: 500,
+    type: 'points_earned' as const,
+  },
+  {
+    id: 'streak_3',
+    name: 'On a Roll',
+    description: 'Complete all tasks for 3 days in a row',
+    icon: '🔥',
+    requirement: 3,
+    type: 'streak' as const,
+  },
+  {
+    id: 'streak_7',
+    name: 'Week Warrior',
+    description: 'Complete all tasks for 7 days in a row',
+    icon: '💪',
+    requirement: 7,
+    type: 'streak' as const,
+  },
+  {
+    id: 'streak_30',
+    name: 'Monthly Master',
+    description: 'Complete all tasks for 30 days in a row',
+    icon: '🎯',
+    requirement: 30,
+    type: 'streak' as const,
+  },
+];
+
+/**
+ * Helper to get user's household ID
+ */
+async function getUserHouseholdId(
+  userId: string,
+  requestedHouseholdId?: string,
+): Promise<string | null> {
+  if (requestedHouseholdId) {
+    // Verify user is member of requested household
+    const result = await db.query(
+      'SELECT household_id FROM household_members WHERE user_id = $1 AND household_id = $2',
+      [userId, requestedHouseholdId],
+    );
+    return result.rows.length > 0 ? requestedHouseholdId : null;
+  }
+
+  // Get first household user belongs to
+  const result = await db.query(
+    'SELECT household_id FROM household_members WHERE user_id = $1 LIMIT 1',
+    [userId],
+  );
+  return result.rows.length > 0 ? result.rows[0].household_id : null;
+}
+
+/**
+ * Calculate streak for a child
+ */
+async function calculateStreak(childId: string, householdId: string): Promise<number> {
+  const result = await db.query(
+    `WITH daily_completion AS (
+      SELECT
+        date,
+        COUNT(*) as total_tasks,
+        SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed_tasks
+      FROM task_assignments
+      WHERE child_id = $1 AND household_id = $2
+      GROUP BY date
+      ORDER BY date DESC
+    ),
+    completion_status AS (
+      SELECT
+        date,
+        CASE WHEN total_tasks = completed_tasks AND total_tasks > 0 THEN 1 ELSE 0 END as completed_all
+      FROM daily_completion
+    )
+    SELECT date, completed_all
+    FROM completion_status
+    ORDER BY date DESC
+    LIMIT 90`,
+    [childId, householdId],
+  );
+
+  let streak = 0;
+  for (const row of result.rows) {
+    if (row.completed_all === 1) {
+      streak++;
+    } else {
+      break;
+    }
+  }
+  return streak;
+}
+
+/**
+ * GET /api/stats/dashboard
+ * Get dashboard statistics for current user's household
+ */
+async function getDashboardStats(
+  request: FastifyRequest<{ Querystring: DashboardQuerystring }>,
+  reply: FastifyReply,
+) {
+  const userId = request.user?.userId;
+
+  if (!userId) {
+    return reply.status(401).send({
+      error: 'Unauthorized',
+      message: 'Authentication required',
+    });
+  }
+
+  try {
+    const householdId = await getUserHouseholdId(userId, request.query.householdId);
+
+    if (!householdId) {
+      return reply.status(404).send({
+        error: 'Not Found',
+        message: 'No household found for user',
+      });
+    }
+
+    // Get today's date
+    const today = new Date().toISOString().split('T')[0];
+
+    // Calculate start of current week (Monday)
+    const now = new Date();
+    const dayOfWeek = now.getDay();
+    const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+    const weekStart = new Date(now);
+    weekStart.setDate(now.getDate() + mondayOffset);
+    const weekStartStr = weekStart.toISOString().split('T')[0];
+
+    // Get active tasks count
+    const activeTasksResult = await db.query(
+      `SELECT COUNT(*) as count
+       FROM task_assignments
+       WHERE household_id = $1 AND date = $2 AND status = 'pending'`,
+      [householdId, today],
+    );
+    const activeTasks = parseInt(activeTasksResult.rows[0]?.count || '0', 10);
+
+    // Get weekly completed tasks count
+    const weeklyCompletedResult = await db.query(
+      `SELECT COUNT(*) as count
+       FROM task_assignments
+       WHERE household_id = $1 AND date >= $2 AND status = 'completed'`,
+      [householdId, weekStartStr],
+    );
+    const weeklyCompleted = parseInt(weeklyCompletedResult.rows[0]?.count || '0', 10);
+
+    // Get total points earned this week
+    const totalPointsResult = await db.query(
+      `SELECT COALESCE(SUM(tc.points_earned), 0) as total
+       FROM task_completions tc
+       WHERE tc.household_id = $1 AND tc.completed_at >= $2`,
+      [householdId, weekStartStr],
+    );
+    const totalPoints = parseInt(totalPointsResult.rows[0]?.total || '0', 10);
+
+    // Get today's tasks
+    const todaysTasksResult = await db.query(
+      `SELECT
+        ta.id,
+        t.name as title,
+        t.description,
+        t.points,
+        ta.status,
+        c.name as assignee_name,
+        c.id as assignee_id
+       FROM task_assignments ta
+       JOIN tasks t ON ta.task_id = t.id
+       LEFT JOIN children c ON ta.child_id = c.id
+       WHERE ta.household_id = $1 AND ta.date = $2
+       ORDER BY ta.status ASC, t.name ASC
+       LIMIT 10`,
+      [householdId, today],
+    );
+
+    const todaysTasks = todaysTasksResult.rows.map((row) => ({
+      id: row.id,
+      title: row.title,
+      description: row.description,
+      points: row.points,
+      status: row.status,
+      assigneeName: row.assignee_name,
+      assigneeId: row.assignee_id,
+    }));
+
+    // Get upcoming tasks (next 7 days excluding today)
+    const tomorrow = new Date(now);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const tomorrowStr = tomorrow.toISOString().split('T')[0];
+
+    const nextWeek = new Date(now);
+    nextWeek.setDate(nextWeek.getDate() + 7);
+    const nextWeekStr = nextWeek.toISOString().split('T')[0];
+
+    const upcomingTasksResult = await db.query(
+      `SELECT
+        ta.id,
+        t.name as title,
+        t.description,
+        t.points,
+        ta.date,
+        ta.status,
+        c.name as assignee_name,
+        c.id as assignee_id
+       FROM task_assignments ta
+       JOIN tasks t ON ta.task_id = t.id
+       LEFT JOIN children c ON ta.child_id = c.id
+       WHERE ta.household_id = $1 AND ta.date >= $2 AND ta.date < $3
+       ORDER BY ta.date ASC, t.name ASC
+       LIMIT 10`,
+      [householdId, tomorrowStr, nextWeekStr],
+    );
+
+    const upcomingTasks = upcomingTasksResult.rows.map((row) => ({
+      id: row.id,
+      title: row.title,
+      description: row.description,
+      points: row.points,
+      date: row.date,
+      status: row.status,
+      assigneeName: row.assignee_name,
+      assigneeId: row.assignee_id,
+    }));
+
+    return reply.send({
+      activeTasks,
+      weeklyCompleted,
+      totalPoints,
+      todaysTasks,
+      upcomingTasks,
+    });
+  } catch (error) {
+    request.log.error(error, 'Failed to get dashboard stats');
+    return reply.status(500).send({
+      error: 'Internal Server Error',
+      message: 'Failed to retrieve dashboard statistics',
+    });
+  }
+}
+
+/**
+ * GET /api/stats/leaderboard
+ * Get leaderboard rankings for household
+ */
+async function getLeaderboard(
+  request: FastifyRequest<{ Querystring: LeaderboardQuerystring }>,
+  reply: FastifyReply,
+) {
+  const userId = request.user?.userId;
+
+  if (!userId) {
+    return reply.status(401).send({
+      error: 'Unauthorized',
+      message: 'Authentication required',
+    });
+  }
+
+  try {
+    const householdId = await getUserHouseholdId(userId, request.query.householdId);
+
+    if (!householdId) {
+      return reply.status(404).send({
+        error: 'Not Found',
+        message: 'No household found for user',
+      });
+    }
+
+    const period = request.query.period || 'week';
+
+    // Calculate date range based on period
+    const now = new Date();
+    let startDate: Date;
+
+    if (period === 'week') {
+      const dayOfWeek = now.getDay();
+      const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+      startDate = new Date(now);
+      startDate.setDate(now.getDate() + mondayOffset);
+    } else if (period === 'month') {
+      startDate = new Date(now.getFullYear(), now.getMonth(), 1);
+    } else {
+      // alltime - use a far past date
+      startDate = new Date('2020-01-01');
+    }
+
+    const startDateStr = startDate.toISOString().split('T')[0];
+
+    // Get rankings with points and tasks completed
+    const result = await db.query(
+      `SELECT
+        c.id as user_id,
+        c.name,
+        COALESCE(SUM(tc.points_earned), 0) as points,
+        COUNT(tc.id) as tasks_completed
+       FROM children c
+       LEFT JOIN task_completions tc ON c.id = tc.child_id AND tc.completed_at >= $2
+       WHERE c.household_id = $1
+       GROUP BY c.id, c.name
+       ORDER BY points DESC, tasks_completed DESC, c.name ASC`,
+      [householdId, startDateStr],
+    );
+
+    const rankings = result.rows.map((row) => ({
+      userId: row.user_id,
+      name: row.name,
+      points: parseInt(row.points || '0', 10),
+      tasksCompleted: parseInt(row.tasks_completed || '0', 10),
+    }));
+
+    return reply.send({ rankings });
+  } catch (error) {
+    request.log.error(error, 'Failed to get leaderboard');
+    return reply.status(500).send({
+      error: 'Internal Server Error',
+      message: 'Failed to retrieve leaderboard',
+    });
+  }
+}
+
+/**
+ * GET /api/stats/achievements
+ * Get achievements for a user (child)
+ */
+async function getAchievements(
+  request: FastifyRequest<{ Querystring: AchievementsQuerystring }>,
+  reply: FastifyReply,
+) {
+  const currentUserId = request.user?.userId;
+
+  if (!currentUserId) {
+    return reply.status(401).send({
+      error: 'Unauthorized',
+      message: 'Authentication required',
+    });
+  }
+
+  try {
+    const householdId = await getUserHouseholdId(currentUserId, request.query.householdId);
+
+    if (!householdId) {
+      return reply.status(404).send({
+        error: 'Not Found',
+        message: 'No household found for user',
+      });
+    }
+
+    // If userId specified, get that child's achievements
+    // Otherwise get achievements for the current user's child profile
+    let childId: string | null = null;
+
+    if (request.query.userId) {
+      // Verify requested child belongs to same household
+      const childResult = await db.query(
+        'SELECT id FROM children WHERE id = $1 AND household_id = $2',
+        [request.query.userId, householdId],
+      );
+
+      if (childResult.rows.length === 0) {
+        return reply.status(404).send({
+          error: 'Not Found',
+          message: 'User not found in household',
+        });
+      }
+      childId = request.query.userId;
+    } else {
+      // Get child profile for current user
+      const childResult = await db.query(
+        'SELECT id FROM children WHERE user_id = $1 AND household_id = $2',
+        [currentUserId, householdId],
+      );
+
+      if (childResult.rows.length > 0) {
+        childId = childResult.rows[0].id;
+      }
+    }
+
+    if (!childId) {
+      // User is not a child - return empty achievements
+      return reply.send({
+        unlocked: [],
+        locked: ACHIEVEMENTS.map((a) => ({
+          id: a.id,
+          name: a.name,
+          description: a.description,
+          icon: a.icon,
+        })),
+        progress: [],
+      });
+    }
+
+    // Get child's stats for achievement progress
+    const statsResult = await db.query(
+      `SELECT
+        COUNT(tc.id) as tasks_completed,
+        COALESCE(SUM(tc.points_earned), 0) as points_earned
+       FROM task_completions tc
+       WHERE tc.child_id = $1`,
+      [childId],
+    );
+
+    const tasksCompleted = parseInt(statsResult.rows[0]?.tasks_completed || '0', 10);
+    const pointsEarned = parseInt(statsResult.rows[0]?.points_earned || '0', 10);
+
+    // Calculate streak
+    const currentStreak = await calculateStreak(childId, householdId);
+
+    // Determine achievement status
+    const unlocked: typeof ACHIEVEMENTS = [];
+    const locked: typeof ACHIEVEMENTS = [];
+    const progress: { achievementId: string; current: number; required: number }[] = [];
+
+    for (const achievement of ACHIEVEMENTS) {
+      let current = 0;
+
+      if (achievement.type === 'tasks_completed') {
+        current = tasksCompleted;
+      } else if (achievement.type === 'points_earned') {
+        current = pointsEarned;
+      } else if (achievement.type === 'streak') {
+        current = currentStreak;
+      }
+
+      if (current >= achievement.requirement) {
+        unlocked.push(achievement);
+      } else {
+        locked.push(achievement);
+        progress.push({
+          achievementId: achievement.id,
+          current,
+          required: achievement.requirement,
+        });
+      }
+    }
+
+    return reply.send({
+      unlocked: unlocked.map((a) => ({
+        id: a.id,
+        name: a.name,
+        description: a.description,
+        icon: a.icon,
+      })),
+      locked: locked.map((a) => ({
+        id: a.id,
+        name: a.name,
+        description: a.description,
+        icon: a.icon,
+      })),
+      progress,
+    });
+  } catch (error) {
+    request.log.error(error, 'Failed to get achievements');
+    return reply.status(500).send({
+      error: 'Internal Server Error',
+      message: 'Failed to retrieve achievements',
+    });
+  }
+}
+
+/**
+ * Register stats routes
+ */
+export default async function statsRoutes(server: FastifyInstance) {
+  // Define schemas
+  const DashboardQuerySchema = z.object({
+    householdId: z.string().uuid().optional(),
+  });
+
+  const LeaderboardQuerySchema = z.object({
+    householdId: z.string().uuid().optional(),
+    period: z.enum(['week', 'month', 'alltime']).optional(),
+  });
+
+  const AchievementsQuerySchema = z.object({
+    userId: z.string().uuid().optional(),
+    householdId: z.string().uuid().optional(),
+  });
+
+  const DashboardResponseSchema = z.object({
+    activeTasks: z.number(),
+    weeklyCompleted: z.number(),
+    totalPoints: z.number(),
+    todaysTasks: z.array(
+      z.object({
+        id: z.string().uuid(),
+        title: z.string(),
+        description: z.string().nullable(),
+        points: z.number(),
+        status: z.string(),
+        assigneeName: z.string().nullable(),
+        assigneeId: z.string().uuid().nullable(),
+      }),
+    ),
+    upcomingTasks: z.array(
+      z.object({
+        id: z.string().uuid(),
+        title: z.string(),
+        description: z.string().nullable(),
+        points: z.number(),
+        date: z.string(),
+        status: z.string(),
+        assigneeName: z.string().nullable(),
+        assigneeId: z.string().uuid().nullable(),
+      }),
+    ),
+  });
+
+  const LeaderboardResponseSchema = z.object({
+    rankings: z.array(
+      z.object({
+        userId: z.string().uuid(),
+        name: z.string(),
+        points: z.number(),
+        tasksCompleted: z.number(),
+      }),
+    ),
+  });
+
+  const AchievementSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    description: z.string(),
+    icon: z.string(),
+  });
+
+  const AchievementsResponseSchema = z.object({
+    unlocked: z.array(AchievementSchema),
+    locked: z.array(AchievementSchema),
+    progress: z.array(
+      z.object({
+        achievementId: z.string(),
+        current: z.number(),
+        required: z.number(),
+      }),
+    ),
+  });
+
+  // Dashboard stats endpoint
+  server.get('/api/stats/dashboard', {
+    schema: stripResponseValidation({
+      summary: 'Get dashboard statistics',
+      description:
+        'Get dashboard statistics including active tasks, weekly completed, and upcoming tasks',
+      tags: ['stats'],
+      security: [{ bearerAuth: [] }],
+      querystring: zodToOpenAPI(DashboardQuerySchema),
+      response: {
+        200: zodToOpenAPI(DashboardResponseSchema),
+        ...CommonErrors.Unauthorized,
+        ...CommonErrors.NotFound,
+        ...CommonErrors.InternalServerError,
+      },
+    }),
+    preHandler: [authenticateUser],
+    handler: getDashboardStats,
+  });
+
+  // Leaderboard endpoint
+  server.get('/api/stats/leaderboard', {
+    schema: stripResponseValidation({
+      summary: 'Get leaderboard rankings',
+      description: 'Get leaderboard rankings for household members by period',
+      tags: ['stats'],
+      security: [{ bearerAuth: [] }],
+      querystring: zodToOpenAPI(LeaderboardQuerySchema),
+      response: {
+        200: zodToOpenAPI(LeaderboardResponseSchema),
+        ...CommonErrors.Unauthorized,
+        ...CommonErrors.NotFound,
+        ...CommonErrors.InternalServerError,
+      },
+    }),
+    preHandler: [authenticateUser],
+    handler: getLeaderboard,
+  });
+
+  // Achievements endpoint
+  server.get('/api/stats/achievements', {
+    schema: stripResponseValidation({
+      summary: 'Get user achievements',
+      description: 'Get unlocked and locked achievements with progress',
+      tags: ['stats'],
+      security: [{ bearerAuth: [] }],
+      querystring: zodToOpenAPI(AchievementsQuerySchema),
+      response: {
+        200: zodToOpenAPI(AchievementsResponseSchema),
+        ...CommonErrors.Unauthorized,
+        ...CommonErrors.NotFound,
+        ...CommonErrors.InternalServerError,
+      },
+    }),
+    preHandler: [authenticateUser],
+    handler: getAchievements,
+  });
+}

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -14,6 +14,7 @@ import { invitationRoutes } from './routes/invitations.js';
 import assignmentRoutes from './routes/assignments.js';
 import analyticsRoutes from './routes/analytics.js';
 import rewardRoutes from './routes/rewards.js';
+import statsRoutes from './routes/stats.js';
 import {
   registerSchema,
   loginSchema,
@@ -739,6 +740,7 @@ async function buildApp() {
   await fastify.register(assignmentRoutes);
   await fastify.register(rewardRoutes);
   await fastify.register(analyticsRoutes);
+  await fastify.register(statsRoutes);
 
   // Example items endpoint
   interface Item {


### PR DESCRIPTION
## Summary

Adds new `/api/stats` endpoints for the redesigned dashboard:

- **GET /api/stats/dashboard** - Dashboard statistics (active tasks, weekly completed, points)
- **GET /api/stats/leaderboard** - Household leaderboard with period filtering (week/month/alltime)
- **GET /api/stats/achievements** - User achievements and progress tracking

## Changes

- Added `apps/backend/src/routes/stats.ts` with dashboard, leaderboard, and achievements endpoints
- Added comprehensive test suite in `apps/backend/src/routes/stats.test.ts`
- Registered stats routes in server.ts

## Acceptance Criteria from #197

- [x] All endpoints implemented (dashboard, leaderboard, achievements)
- [x] Zod validation on all inputs
- [x] SQL injection prevention (parameterized queries)
- [x] Proper error handling
- [x] Unit tests for all endpoints (302 tests pass)
- [x] Type safety with `@st44/types`

## Test Plan

- [x] All 302 backend tests pass locally
- [x] Dashboard endpoint returns correct stats structure
- [x] Leaderboard endpoint supports period filtering
- [x] Achievements endpoint returns unlocked/locked/progress data

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)