### PR TITLE
feat(frontend): add child rewards store and routing (#168)

### DIFF
--- a/apps/frontend/src/app/app.routes.ts
+++ b/apps/frontend/src/app/app.routes.ts
@@ -90,6 +90,14 @@ export const routes: Routes = [
     loadComponent: () => import('./pages/tasks/tasks').then((m) => m.Tasks),
     canActivate: [roleGuard(['admin', 'parent'])],
   },
+  {
+    path: 'household/rewards',
+    loadComponent: () =>
+      import('./pages/rewards-management/rewards-management').then(
+        (m) => m.RewardsManagementComponent,
+      ),
+    canActivate: [roleGuard(['admin', 'parent'])],
+  },
 
   // Protected routes - Child only
   {
@@ -104,6 +112,11 @@ export const routes: Routes = [
       import('./components/child-task-list/child-task-list.component').then(
         (m) => m.ChildTaskListComponent,
       ),
+    canActivate: [roleGuard(['child'])],
+  },
+  {
+    path: 'my-rewards',
+    loadComponent: () => import('./pages/child-rewards/child-rewards').then((m) => m.ChildRewards),
     canActivate: [roleGuard(['child'])],
   },
 

--- a/apps/frontend/src/app/pages/child-rewards/child-rewards.css
+++ b/apps/frontend/src/app/pages/child-rewards/child-rewards.css
@@ -1,0 +1,318 @@
+.child-rewards-container {
+  padding: 20px;
+  max-width: 1200px;
+  margin: 0 auto;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+
+/* Header */
+.rewards-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 24px;
+  padding: 16px;
+  background-color: rgba(255, 255, 255, 0.95);
+  border-radius: 16px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.back-button {
+  background: none;
+  border: none;
+  font-size: 16px;
+  cursor: pointer;
+  color: #667eea;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  transition: background-color 0.2s;
+}
+
+.back-button:hover {
+  background-color: rgba(102, 126, 234, 0.1);
+}
+
+.rewards-header h1 {
+  margin: 0;
+  font-size: 24px;
+  color: #333;
+}
+
+.points-balance {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: linear-gradient(135deg, #ffd700 0%, #ffb800 100%);
+  padding: 12px 24px;
+  border-radius: 12px;
+  box-shadow: 0 4px 8px rgba(255, 184, 0, 0.3);
+}
+
+.balance-label {
+  font-size: 12px;
+  text-transform: uppercase;
+  color: #664d00;
+  font-weight: 600;
+}
+
+.balance-value {
+  font-size: 32px;
+  font-weight: 700;
+  color: #333;
+}
+
+/* Success Message */
+.success-message {
+  background-color: #d4edda;
+  color: #155724;
+  padding: 16px;
+  border-radius: 12px;
+  margin-bottom: 20px;
+  text-align: center;
+  font-weight: 500;
+  animation: slideIn 0.3s ease-out;
+}
+
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Loading State */
+.loading {
+  text-align: center;
+  padding: 60px 20px;
+  background-color: rgba(255, 255, 255, 0.95);
+  border-radius: 16px;
+  color: #666;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid #e0e0e0;
+  border-top-color: #667eea;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+.spinner-small {
+  width: 18px;
+  height: 18px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  display: inline-block;
+  margin-right: 8px;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Error State */
+.error {
+  text-align: center;
+  padding: 20px;
+  background-color: #f8d7da;
+  color: #721c24;
+  border-radius: 12px;
+  margin-bottom: 20px;
+}
+
+/* Empty State */
+.empty-state {
+  text-align: center;
+  padding: 60px 20px;
+  background-color: rgba(255, 255, 255, 0.95);
+  border-radius: 16px;
+  color: #666;
+}
+
+.empty-icon::before {
+  content: '🎁';
+  font-size: 64px;
+  display: block;
+  margin-bottom: 16px;
+}
+
+.empty-state p {
+  margin: 8px 0;
+  font-size: 18px;
+}
+
+.empty-hint {
+  color: #888;
+  font-size: 14px !important;
+}
+
+/* Rewards Grid */
+.rewards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 20px;
+}
+
+/* Reward Card */
+.reward-card {
+  background-color: white;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  transition:
+    transform 0.2s,
+    box-shadow 0.2s;
+  display: flex;
+  flex-direction: column;
+}
+
+.reward-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+}
+
+.reward-card.cannot-afford {
+  opacity: 0.7;
+}
+
+.reward-card.unavailable {
+  opacity: 0.5;
+}
+
+.reward-card.redeeming {
+  pointer-events: none;
+}
+
+.reward-content {
+  padding: 20px;
+  flex: 1;
+}
+
+.reward-name {
+  margin: 0 0 8px 0;
+  font-size: 20px;
+  color: #333;
+  font-weight: 600;
+}
+
+.reward-description {
+  margin: 0 0 16px 0;
+  color: #666;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.reward-cost {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.cost-value {
+  font-size: 28px;
+  font-weight: 700;
+  color: #667eea;
+}
+
+.cost-label {
+  font-size: 14px;
+  color: #888;
+}
+
+.reward-actions {
+  padding: 16px 20px;
+  background-color: #f8f9fa;
+  display: flex;
+  justify-content: center;
+}
+
+/* Redeem Button */
+.redeem-button {
+  width: 100%;
+  padding: 14px 24px;
+  font-size: 16px;
+  font-weight: 600;
+  color: white;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+  transition:
+    opacity 0.2s,
+    transform 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.redeem-button:hover:not(:disabled) {
+  opacity: 0.9;
+  transform: scale(1.02);
+}
+
+.redeem-button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+/* Status Badges */
+.status-badge {
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  text-align: center;
+}
+
+.status-badge.out-of-stock {
+  background-color: #f8d7da;
+  color: #721c24;
+}
+
+.status-badge.need-more {
+  background-color: #fff3cd;
+  color: #856404;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .child-rewards-container {
+    padding: 12px;
+  }
+
+  .rewards-header {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .back-button {
+    align-self: flex-start;
+  }
+
+  .points-balance {
+    width: 100%;
+  }
+
+  .rewards-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/frontend/src/app/pages/child-rewards/child-rewards.html
+++ b/apps/frontend/src/app/pages/child-rewards/child-rewards.html
@@ -1,0 +1,92 @@
+<div class="child-rewards-container">
+  <!-- Header with balance -->
+  <header class="rewards-header">
+    <button class="back-button" (click)="goBack()" aria-label="Go back">
+      <span aria-hidden="true">&larr;</span> Back
+    </button>
+    <h1>Rewards Store</h1>
+    <div class="points-balance" aria-live="polite">
+      <span class="balance-label">Your Points</span>
+      <span class="balance-value">{{ pointsBalance() }}</span>
+    </div>
+  </header>
+
+  <!-- Success Message -->
+  @if (successMessage()) {
+    <div class="success-message" role="status" aria-live="polite">
+      {{ successMessage() }}
+    </div>
+  }
+
+  <!-- Loading State -->
+  @if (loading()) {
+    <div class="loading" role="status" aria-live="polite">
+      <span class="spinner" aria-hidden="true"></span>
+      Loading rewards...
+    </div>
+  }
+
+  <!-- Error State -->
+  @if (error()) {
+    <div class="error" role="alert">
+      {{ error() }}
+    </div>
+  }
+
+  <!-- Rewards Grid -->
+  @if (!loading() && !error()) {
+    @if (childRewards().length === 0) {
+      <div class="empty-state">
+        <div class="empty-icon" aria-hidden="true"></div>
+        <p>No rewards available yet!</p>
+        <p class="empty-hint">Ask your parents to set up some rewards for you.</p>
+      </div>
+    } @else {
+      <div class="rewards-grid">
+        @for (reward of childRewards(); track reward.id) {
+          <article
+            class="reward-card"
+            [class.cannot-afford]="!reward.canAfford"
+            [class.unavailable]="!reward.available"
+            [class.redeeming]="redeemingRewardId() === reward.id"
+          >
+            <div class="reward-content">
+              <h2 class="reward-name">{{ reward.name }}</h2>
+              @if (reward.description) {
+                <p class="reward-description">{{ reward.description }}</p>
+              }
+              <div class="reward-cost">
+                <span class="cost-value">{{ reward.pointsCost }}</span>
+                <span class="cost-label">points</span>
+              </div>
+            </div>
+            <div class="reward-actions">
+              @if (!reward.available) {
+                <span class="status-badge out-of-stock">Out of Stock</span>
+              } @else if (!reward.canAfford) {
+                <span class="status-badge need-more"
+                  >Need {{ reward.pointsCost - pointsBalance() }} more</span
+                >
+              } @else if (redeemingRewardId() === reward.id) {
+                <button class="redeem-button" disabled>
+                  <span class="spinner-small" aria-hidden="true"></span>
+                  Redeeming...
+                </button>
+              } @else {
+                <button
+                  class="redeem-button"
+                  (click)="redeemReward(reward)"
+                  [attr.aria-label]="
+                    'Redeem ' + reward.name + ' for ' + reward.pointsCost + ' points'
+                  "
+                >
+                  Redeem
+                </button>
+              }
+            </div>
+          </article>
+        }
+      </div>
+    }
+  }
+</div>

--- a/apps/frontend/src/app/pages/child-rewards/child-rewards.ts
+++ b/apps/frontend/src/app/pages/child-rewards/child-rewards.ts
@@ -1,0 +1,83 @@
+import { Component, OnInit, signal, inject, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+import { RewardService, ChildReward } from '../../services/reward.service';
+
+/**
+ * Child Rewards Store Component
+ *
+ * Allows children to:
+ * - View their current points balance
+ * - Browse available rewards
+ * - Redeem rewards with their points
+ */
+@Component({
+  selector: 'app-child-rewards',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './child-rewards.html',
+  styleUrls: ['./child-rewards.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ChildRewards implements OnInit {
+  private rewardService = inject(RewardService);
+  private router = inject(Router);
+
+  // Local component state
+  redeemingRewardId = signal<string | null>(null);
+  successMessage = signal<string | null>(null);
+
+  // Service signals (exposed for template)
+  childRewards = this.rewardService.childRewards;
+  pointsBalance = this.rewardService.pointsBalance;
+  loading = this.rewardService.childRewardsLoading;
+  error = this.rewardService.childRewardsError;
+
+  ngOnInit(): void {
+    this.rewardService.loadChildRewards().subscribe({
+      error: (err) => {
+        console.error('Failed to load rewards:', err);
+      },
+    });
+  }
+
+  /**
+   * Redeem a reward
+   */
+  redeemReward(reward: ChildReward): void {
+    if (!reward.canAfford || !reward.available) {
+      return;
+    }
+
+    if (!confirm(`Redeem "${reward.name}" for ${reward.pointsCost} points?`)) {
+      return;
+    }
+
+    this.redeemingRewardId.set(reward.id);
+    this.successMessage.set(null);
+
+    this.rewardService.redeemReward(reward.id).subscribe({
+      next: (response) => {
+        this.redeemingRewardId.set(null);
+        this.successMessage.set(
+          `Redeemed "${reward.name}"! Your new balance is ${response.newBalance} points.`,
+        );
+        // Reload rewards to update canAfford status
+        this.rewardService.loadChildRewards().subscribe();
+        // Clear success message after 5 seconds
+        setTimeout(() => this.successMessage.set(null), 5000);
+      },
+      error: (err) => {
+        this.redeemingRewardId.set(null);
+        alert(`Failed to redeem reward: ${err.message || 'Unknown error'}`);
+      },
+    });
+  }
+
+  /**
+   * Navigate back to dashboard
+   */
+  goBack(): void {
+    this.router.navigate(['/my-tasks']);
+  }
+}

--- a/apps/frontend/src/app/services/reward.service.ts
+++ b/apps/frontend/src/app/services/reward.service.ts
@@ -12,6 +12,12 @@ import type {
   RedeemRewardResponse,
 } from '@st44/types';
 
+// Extended reward type with availability info for child view
+export interface ChildReward extends Reward {
+  available: boolean;
+  canAfford: boolean;
+}
+
 /**
  * Service for managing rewards and redemptions with signals-based state management
  *
@@ -39,7 +45,7 @@ export class RewardService {
   private redemptionsErrorSignal = signal<string | null>(null);
 
   // Child rewards state signals (private writable)
-  private childRewardsSignal = signal<Reward[]>([]);
+  private childRewardsSignal = signal<ChildReward[]>([]);
   private pointsBalanceSignal = signal<number>(0);
   private childRewardsLoadingSignal = signal<boolean>(false);
   private childRewardsErrorSignal = signal<string | null>(null);


### PR DESCRIPTION
## Summary
- Add route `/household/rewards` for parent rewards management page
- Add route `/my-rewards` for child rewards store
- Create ChildRewards component for children to view and redeem rewards
- Add ChildReward type for proper typing of extended API response

## Changes
- `app.routes.ts`: Add two new routes for rewards pages
- `reward.service.ts`: Add ChildReward interface for extended reward type
- `child-rewards/`: New component with template and styles

## Features
**Child Rewards Store (`/my-rewards`)**
- Displays current points balance prominently
- Shows all available rewards with points cost
- Allows redemption if child has sufficient points
- Shows "Need X more" for unaffordable rewards
- Shows "Out of Stock" for unavailable rewards
- Responsive design for mobile/tablet/desktop

**Parent Rewards Management (`/household/rewards`)**
- Already implemented - this PR adds routing

## Test plan
- [x] Build succeeds (`npm run build`)
- [x] Frontend tests pass (`npm test`)
- [ ] Manual testing of child rewards store flow
- [ ] Manual testing of parent rewards management

Part of #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)