### PR TITLE
fix(ci): add types package build step to E2E workflow (#219)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,12 +34,21 @@ jobs:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: |
+            packages/types/package-lock.json
             apps/frontend/package-lock.json
             apps/backend/package-lock.json
 
       - name: Install Playwright Browsers
         working-directory: apps/frontend
         run: npx playwright install --with-deps chromium
+
+      - name: Install types package dependencies
+        working-directory: packages/types
+        run: npm ci
+
+      - name: Build types package
+        working-directory: packages/types
+        run: npm run build
 
       - name: Install frontend dependencies
         working-directory: apps/frontend


### PR DESCRIPTION
## Summary
Fix E2E workflow failing because backend build couldn't find `@st44/types` package.

## Changes
- Add `packages/types/package-lock.json` to npm cache dependency paths
- Add step to install types package dependencies
- Add step to build types package before backend build

## Root Cause
The workflow tried to build the backend without first building the `@st44/types` package that it depends on.

## Test plan
- [ ] Trigger E2E workflow manually after merge
- [ ] Verify backend build step succeeds
- [ ] Verify E2E tests can run

Fixes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)