### PR TITLE
fix(ci): build frontend and serve static files in E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,6 +54,10 @@ jobs:
         working-directory: apps/frontend
         run: npm ci
 
+      - name: Build frontend
+        working-directory: apps/frontend
+        run: npx ng build
+
       - name: Install backend dependencies
         working-directory: apps/backend
         run: npm ci
@@ -104,10 +108,8 @@ jobs:
 
       - name: Start frontend server
         working-directory: apps/frontend
-        env:
-          PORT: 4200
         run: |
-          npm start &
+          npx serve dist/home -l 4200 &
           echo $! > frontend.pid
           echo "Frontend started on port 4200"
 


### PR DESCRIPTION
## Summary
Fix E2E workflow failing because `ng` command wasn't found when running `npm start`.

## Root Cause
Angular CLI (`ng`) wasn't in PATH when the workflow tried to run `npm start` → `ng serve`.

## Fix
- Add step to build frontend with `npx ng build`
- Serve the built static files with `npx serve` instead of `ng serve`

## Benefits
This is also better practice for E2E tests:
- Serving a production build is faster startup
- More representative of actual deployment
- No dev server overhead

## Test plan
- [ ] Trigger E2E workflow manually after merge
- [ ] Verify frontend build succeeds
- [ ] Verify frontend server starts on port 4200
- [ ] Verify E2E tests can run

🤖 Generated with [Claude Code](https://claude.com/claude-code)