### PR TITLE
fix(ci): install dependencies before Playwright browsers in e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,10 +38,6 @@ jobs:
             apps/frontend/package-lock.json
             apps/backend/package-lock.json
 
-      - name: Install Playwright Browsers
-        working-directory: apps/frontend
-        run: npx playwright install --with-deps chromium
-
       - name: Install types package dependencies
         working-directory: packages/types
         run: npm ci
@@ -53,6 +49,10 @@ jobs:
       - name: Install frontend dependencies
         working-directory: apps/frontend
         run: npm ci
+
+      - name: Install Playwright Browsers
+        working-directory: apps/frontend
+        run: npx playwright install --with-deps chromium
 
       - name: Build frontend
         working-directory: apps/frontend


### PR DESCRIPTION
## Summary

- Reorder CI steps so `npm ci` runs before `npx playwright install`
- This ensures Playwright uses the version from package.json (@playwright/test ^1.48.0) instead of downloading the latest version (1.57.0) via npx

## Root Cause

The e2e workflow was running `npx playwright install --with-deps chromium` before `npm ci`. Since Playwright wasn't installed yet, npx would download and use the latest Playwright version (1.57.0), which is incompatible with the test configuration expecting ^1.48.0.

## Fix

Move the "Install Playwright Browsers" step after the dependency installation steps:
1. Install types package dependencies
2. Build types package
3. Install frontend dependencies
4. **Install Playwright Browsers** ← moved here

## Test Plan

- [ ] PR CI passes
- [ ] Manually trigger E2E workflow after merge and verify it passes

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)