### PR TITLE
fix(frontend): remove auth container padding to eliminate white border

### DIFF
--- a/apps/frontend/src/app/auth/login.component.css
+++ b/apps/frontend/src/app/auth/login.component.css
@@ -13,7 +13,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--space-lg);
+  padding: 0;
   background: var(--gradient-primary);
   position: relative;
   overflow: hidden;

--- a/apps/frontend/src/app/auth/register.component.css
+++ b/apps/frontend/src/app/auth/register.component.css
@@ -13,7 +13,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--space-lg);
+  padding: 0;
   background: var(--gradient-primary);
   position: relative;
   overflow: hidden;


### PR DESCRIPTION
## Summary

- Remove padding from `.auth-container` on login and register pages
- The padding was creating a visible white border around the gradient background by exposing the body's background color

## Root Cause

The `.auth-container` had `padding: var(--space-lg)` (24px) which created a gap around the gradient background. Since the body uses `background: var(--color-background)` (#f8f9ff - a light blue/white), this created a visible white border around the auth pages.

## Fix

Changed `padding: var(--space-lg)` to `padding: 0` in:
- `login.component.css`
- `register.component.css`

## Test Plan

- [x] Frontend build succeeds
- [x] All 426 frontend tests pass
- [ ] Visually verify login page has no white border

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)