### PR TITLE
chore(backend): add .prettierignore to exclude dist folder

### DIFF
--- a/apps/backend/.prettierignore
+++ b/apps/backend/.prettierignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+coverage


### PR DESCRIPTION
## Summary
Adds .prettierignore file to exclude dist/node_modules/coverage from Prettier checks.

## Changes
- `apps/backend/.prettierignore`: Exclude build output and dependencies

## Test Plan
- [ ] `npm run format:check` passes in backend

Part of #200 (Final Integration pre-deployment checklist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)