### PR TITLE
fix(frontend): remove 16px padding from app-root

### DIFF
--- a/apps/frontend/src/app/app.css
+++ b/apps/frontend/src/app/app.css
@@ -1,9 +1,8 @@
 :host {
   display: block;
-  padding: 16px;
+  padding: 0;
   font-family: Arial, sans-serif;
   background-color: #f9f9f9;
-  text-align: center;
 }
 
 h1 {


### PR DESCRIPTION
## Summary

Removed 16px padding from app-root that was causing a white border around the app.

## Changes

- Set `:host` padding to 0 in `app.css`
- Removed `text-align: center` (leftover from old app version)

## Test Plan

- [ ] Open app - no white border visible
- [ ] App fills entire viewport

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)