### PR TITLE
feat: add pagination infrastructure for list endpoints

### DIFF
--- a/packages/types/src/schemas/index.ts
+++ b/packages/types/src/schemas/index.ts
@@ -27,3 +27,6 @@ export * from './reward.schema.js';
 
 // Analytics schemas
 export * from './analytics.schema.js';
+
+// Pagination schemas
+export * from './pagination.schema.js';

--- a/packages/types/src/schemas/pagination.schema.ts
+++ b/packages/types/src/schemas/pagination.schema.ts
@@ -1,0 +1,90 @@
+/**
+ * Pagination schemas - Zod validation schemas for paginated API responses
+ *
+ * Provides reusable pagination infrastructure for all list endpoints.
+ *
+ * @module @st44/types/schemas/pagination
+ */
+
+import { z } from '../generators/openapi.generator.js';
+
+/**
+ * Standard pagination query parameters
+ */
+export const PaginationQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1).describe('Page number (1-indexed)'),
+  pageSize: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .default(20)
+    .describe('Number of items per page (max 100)'),
+  sortBy: z.string().optional().describe('Field to sort by'),
+  sortOrder: z.enum(['asc', 'desc']).default('desc').describe('Sort direction'),
+});
+
+export type PaginationQuery = z.infer<typeof PaginationQuerySchema>;
+
+/**
+ * Pagination metadata in response
+ */
+export const PaginationMetaSchema = z.object({
+  page: z.number().int().min(1).describe('Current page number'),
+  pageSize: z.number().int().min(1).describe('Items per page'),
+  total: z.number().int().min(0).describe('Total number of items'),
+  totalPages: z.number().int().min(0).describe('Total number of pages'),
+  hasNextPage: z.boolean().describe('Whether more pages exist'),
+  hasPreviousPage: z.boolean().describe('Whether previous pages exist'),
+});
+
+export type PaginationMeta = z.infer<typeof PaginationMetaSchema>;
+
+/**
+ * Create a paginated response schema for any item type
+ * @param itemSchema - Zod schema for the items
+ * @param itemsKey - Key name for the items array (e.g., 'tasks', 'users')
+ */
+export function createPaginatedResponseSchema<T extends z.ZodTypeAny>(
+  itemSchema: T,
+  itemsKey: string,
+) {
+  return z.object({
+    [itemsKey]: z.array(itemSchema),
+    pagination: PaginationMetaSchema,
+  });
+}
+
+/**
+ * Generic paginated response type
+ */
+export interface PaginatedResponse<T> {
+  items: T[];
+  pagination: PaginationMeta;
+}
+
+/**
+ * Helper to calculate pagination metadata
+ */
+export function calculatePaginationMeta(
+  page: number,
+  pageSize: number,
+  total: number,
+): PaginationMeta {
+  const totalPages = Math.ceil(total / pageSize);
+  return {
+    page,
+    pageSize,
+    total,
+    totalPages,
+    hasNextPage: page < totalPages,
+    hasPreviousPage: page > 1,
+  };
+}
+
+/**
+ * Helper to calculate SQL OFFSET from page and pageSize
+ */
+export function calculateOffset(page: number, pageSize: number): number {
+  return (page - 1) * pageSize;
+}


### PR DESCRIPTION
## Summary

Phase 1 of performance optimizations (#254) - adds pagination support to the codebase:

### Shared Types (@st44/types)
- Add `PaginationQuerySchema` for query params (page, pageSize, sortBy, sortOrder)
- Add `PaginationMetaSchema` for response metadata  
- Add helper functions: `calculatePaginationMeta`, `calculateOffset`
- Add `PaginatedResponse<T>` generic type

### Backend (tasks endpoint)
- Add pagination params to `GET /api/households/:householdId/tasks`
- Return paginated response with `tasks[]` and `pagination` metadata
- Support `sortBy` (name, points, createdAt, updatedAt) and `sortOrder` (asc, desc)
- Validate sort fields to prevent SQL injection
- Defaults: page=1, pageSize=20, sortOrder=desc

### Frontend (TaskService)
- Update `getTasks()` to accept `PaginationOptions`
- Add `pagination` signal to expose pagination state
- Return `PaginatedTasksResponse` from `getTasks()`
- Update all tests for new response format

## Backward Compatibility

This change is fully backward compatible - existing code works unchanged since:
- Pagination params are optional with sensible defaults
- Frontend components use service signals (not direct return values)

## Future Work (Phase 2+)
- Add pagination to other list endpoints (assignments, children, households)
- Implement virtual scrolling for long lists
- Add request caching/deduplication

## Test plan

- [x] All 398 frontend tests pass
- [x] Types package tests pass (103 tests)
- [x] Build succeeds
- [x] Pre-commit hooks pass

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)