### PR TITLE
fix(frontend): replace text icon names with emoji icons

### DIFF
--- a/apps/frontend/src/app/pages/home/home.html
+++ b/apps/frontend/src/app/pages/home/home.html
@@ -34,9 +34,9 @@
     <div class="content">
       <!-- Stats Grid -->
       <div class="stats-grid">
-        <app-stat-card [icon]="'target'" [value]="stats().activeCount" [label]="'Active'" />
-        <app-stat-card [icon]="'chart'" [value]="stats().weekProgress + '%'" [label]="'Week'" />
-        <app-stat-card [icon]="'star'" [value]="stats().totalPoints" [label]="'Points'" />
+        <app-stat-card [icon]="'🎯'" [value]="stats().activeCount" [label]="'Active'" />
+        <app-stat-card [icon]="'📊'" [value]="stats().weekProgress + '%'" [label]="'Week'" />
+        <app-stat-card [icon]="'⭐'" [value]="stats().totalPoints" [label]="'Points'" />
       </div>
 
       <!-- Today's Tasks Section -->
@@ -59,7 +59,7 @@
           </div>
         } @else {
           <div class="empty-state" role="status">
-            <div class="empty-icon" aria-hidden="true">sparkle</div>
+            <div class="empty-icon" aria-hidden="true">✨</div>
             <h3>All done!</h3>
             <p>You've completed all your tasks for today.</p>
           </div>

--- a/apps/frontend/src/app/pages/progress/progress.spec.ts
+++ b/apps/frontend/src/app/pages/progress/progress.spec.ts
@@ -283,21 +283,21 @@ describe('Progress', () => {
   });
 
   describe('getMedalForRank', () => {
-    it('should return 1st for rank 1', () => {
-      expect(component['getMedalForRank'](1)).toBe('1st');
+    it('should return gold medal for rank 1', () => {
+      expect(component['getMedalForRank'](1)).toBe('🥇');
     });
 
-    it('should return 2nd for rank 2', () => {
-      expect(component['getMedalForRank'](2)).toBe('2nd');
+    it('should return silver medal for rank 2', () => {
+      expect(component['getMedalForRank'](2)).toBe('🥈');
     });
 
-    it('should return 3rd for rank 3', () => {
-      expect(component['getMedalForRank'](3)).toBe('3rd');
+    it('should return bronze medal for rank 3', () => {
+      expect(component['getMedalForRank'](3)).toBe('🥉');
     });
 
-    it('should return number with th suffix for rank 4+', () => {
-      expect(component['getMedalForRank'](4)).toBe('4th');
-      expect(component['getMedalForRank'](5)).toBe('5th');
+    it('should return hash with number for rank 4+', () => {
+      expect(component['getMedalForRank'](4)).toBe('#4');
+      expect(component['getMedalForRank'](5)).toBe('#5');
     });
   });
 

--- a/apps/frontend/src/app/pages/progress/progress.ts
+++ b/apps/frontend/src/app/pages/progress/progress.ts
@@ -173,7 +173,7 @@ export class Progress implements OnInit {
         id: '1',
         name: 'Getting Started',
         description: 'Complete all tasks for 1 day',
-        icon: 'star',
+        icon: '⭐',
         unlocked: currentStreak >= 1 || longestStreak >= 1,
         progress: Math.min(100, (Math.max(currentStreak, longestStreak) / 1) * 100),
         criteria: '1 day streak',
@@ -182,7 +182,7 @@ export class Progress implements OnInit {
         id: '2',
         name: 'Early Bird',
         description: 'Complete all tasks 5 days in a row',
-        icon: 'bird',
+        icon: '🐦',
         unlocked: longestStreak >= 5,
         progress: Math.min(100, (longestStreak / 5) * 100),
         criteria: '5 day streak',
@@ -191,7 +191,7 @@ export class Progress implements OnInit {
         id: '3',
         name: 'Week Warrior',
         description: '7 day completion streak',
-        icon: 'fire',
+        icon: '🔥',
         unlocked: longestStreak >= 7,
         progress: Math.min(100, (longestStreak / 7) * 100),
         criteria: '7 day streak',
@@ -200,7 +200,7 @@ export class Progress implements OnInit {
         id: '4',
         name: 'Consistent Champion',
         description: '14 day completion streak',
-        icon: 'trophy',
+        icon: '🏆',
         unlocked: longestStreak >= 14,
         progress: Math.min(100, (longestStreak / 14) * 100),
         criteria: '14 day streak',
@@ -209,7 +209,7 @@ export class Progress implements OnInit {
         id: '5',
         name: 'Streak Master',
         description: '30 day completion streak',
-        icon: 'hundred',
+        icon: '💯',
         unlocked: longestStreak >= 30,
         progress: Math.min(100, (longestStreak / 30) * 100),
         criteria: '30 day streak',
@@ -218,7 +218,7 @@ export class Progress implements OnInit {
         id: '6',
         name: 'Legend',
         description: '60 day completion streak',
-        icon: 'sparkle',
+        icon: '✨',
         unlocked: longestStreak >= 60,
         progress: Math.min(100, (longestStreak / 60) * 100),
         criteria: '60 day streak',
@@ -251,13 +251,13 @@ export class Progress implements OnInit {
   protected getMedalForRank(rank: number): string {
     switch (rank) {
       case 1:
-        return '1st';
+        return '🥇';
       case 2:
-        return '2nd';
+        return '🥈';
       case 3:
-        return '3rd';
+        return '🥉';
       default:
-        return `${rank}th`;
+        return `#${rank}`;
     }
   }
 }


### PR DESCRIPTION
## Summary

Fix visual regression where icon names were displayed as text instead of actual emoji icons.

### Home Page Fixes
- Replace `'target'` → `'🎯'` for Active stats
- Replace `'chart'` → `'📊'` for Week stats  
- Replace `'star'` → `'⭐'` for Points stats
- Replace `'sparkle'` → `'✨'` in empty state

### Progress Page Fixes

**Achievement Icons:**
- `'star'` → `'⭐'` (Getting Started)
- `'bird'` → `'🐦'` (Early Bird)
- `'fire'` → `'🔥'` (Week Warrior)
- `'trophy'` → `'🏆'` (Consistent Champion)
- `'hundred'` → `'💯'` (Streak Master)
- `'sparkle'` → `'✨'` (Legend)

**Leaderboard Rank Icons:**
- `'1st'` → `'🥇'`
- `'2nd'` → `'🥈'`
- `'3rd'` → `'🥉'`
- `'4th+'` → `'#N'`

## Test plan

- [x] All 631 frontend tests pass
- [x] Build succeeds
- [x] Pre-commit hooks pass

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)