### PR TITLE
chore: disable scheduled E2E tests to unblock CI (#274)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,9 +1,11 @@
 name: E2E Tests
 
+# DISABLED: E2E tests timing out after 30 minutes (see issue #274)
+# Re-enable schedule once underlying issues are fixed
 on:
-  workflow_dispatch: # Manual trigger
-  schedule:
-    - cron: '0 2 * * *' # Run daily at 2 AM UTC
+  workflow_dispatch: # Manual trigger only for now
+  # schedule:
+  #   - cron: '0 2 * * *' # Run daily at 2 AM UTC
 
 jobs:
   e2e:


### PR DESCRIPTION
## Summary

- Temporarily disable the daily scheduled E2E test runs (2 AM UTC) that were timing out after 30 minutes
- Manual `workflow_dispatch` trigger preserved for developers who need to run E2E tests
- Clear comments added explaining why it's disabled and referencing the issue

## Test Plan

- [x] Workflow file syntax is valid (no structural changes, just comments)
- [ ] Verify scheduled runs no longer trigger automatically
- [ ] Manual workflow dispatch should still work if needed

## Future Work

Once this is merged, investigate and fix the underlying E2E timeout issues:
- Test performance issues
- Potential infinite loops or hanging tests
- Service startup timing issues
- Database connection problems in test environment

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)