### PR TITLE
feat: add user profile editing functionality (#243)

### DIFF
--- a/apps/backend/src/routes/user.test.ts
+++ b/apps/backend/src/routes/user.test.ts
@@ -1,0 +1,196 @@
+import { test, describe, before, after } from 'node:test';
+import assert from 'node:assert';
+import { build } from '../server.ts';
+import type { FastifyInstance } from 'fastify';
+import pg from 'pg';
+import { registerAndLogin } from '../test-helpers/auth.ts';
+
+/**
+ * User Profile API Tests
+ */
+
+describe('User Profile API', () => {
+  let app: FastifyInstance;
+  let pool: pg.Pool;
+  let userToken: string;
+  let userId: string;
+  let userEmail: string;
+
+  before(async () => {
+    app = await build();
+    await app.ready();
+
+    pool = new pg.Pool({
+      host: process.env.TEST_DB_HOST || process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.TEST_DB_PORT || '55432'),
+      database: process.env.TEST_DB_NAME || 'st44_test',
+      user: process.env.TEST_DB_USER || process.env.DB_USER || 'postgres',
+      password: process.env.TEST_DB_PASSWORD || process.env.DB_PASSWORD || 'postgres',
+    });
+
+    // Create test user
+    userEmail = `test-profile-user-${Date.now()}@example.com`;
+    const testPassword = 'TestPass123!';
+
+    const userData = await registerAndLogin(app, userEmail, testPassword);
+    userToken = userData.accessToken;
+
+    // Get user ID for cleanup
+    const userResult = await pool.query('SELECT id FROM users WHERE email = $1', [userEmail]);
+    userId = userResult.rows[0].id;
+  });
+
+  after(async () => {
+    await pool.query('DELETE FROM users WHERE id = $1', [userId]);
+    await pool.end();
+    await app.close();
+  });
+
+  describe('GET /api/user/profile', () => {
+    test('should get current user profile', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/user/profile',
+        headers: { Authorization: `Bearer ${userToken}` },
+      });
+
+      assert.strictEqual(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+      assert.strictEqual(body.id, userId);
+      assert.strictEqual(body.email, userEmail);
+      assert.ok(body.createdAt);
+      assert.ok(body.updatedAt);
+    });
+
+    test('should reject without authentication', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/user/profile',
+      });
+      assert.strictEqual(response.statusCode, 401);
+    });
+
+    test('should reject with invalid token', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/user/profile',
+        headers: { Authorization: 'Bearer invalid-token' },
+      });
+      assert.strictEqual(response.statusCode, 401);
+    });
+  });
+
+  describe('PUT /api/user/profile', () => {
+    test('should update user name', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/user/profile',
+        headers: { Authorization: `Bearer ${userToken}` },
+        payload: { name: 'John Doe' },
+      });
+
+      assert.strictEqual(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+      assert.strictEqual(body.name, 'John Doe');
+      assert.strictEqual(body.email, userEmail);
+    });
+
+    test('should reject empty update', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/user/profile',
+        headers: { Authorization: `Bearer ${userToken}` },
+        payload: {},
+      });
+      assert.strictEqual(response.statusCode, 400);
+    });
+
+    test('should reject without authentication', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/user/profile',
+        payload: { name: 'Test Name' },
+      });
+      assert.strictEqual(response.statusCode, 401);
+    });
+
+    test('should update user email', async () => {
+      const newEmail = `updated-profile-${Date.now()}@example.com`;
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/user/profile',
+        headers: { Authorization: `Bearer ${userToken}` },
+        payload: { email: newEmail },
+      });
+
+      assert.strictEqual(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+      assert.strictEqual(body.email, newEmail);
+
+      // Update our reference for cleanup
+      userEmail = newEmail;
+    });
+
+    test('should reject duplicate email', async () => {
+      // Create another user
+      const otherEmail = `other-user-${Date.now()}@example.com`;
+      await registerAndLogin(app, otherEmail, 'TestPass123!');
+
+      // Try to update to the other user's email
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/user/profile',
+        headers: { Authorization: `Bearer ${userToken}` },
+        payload: { email: otherEmail },
+      });
+
+      assert.strictEqual(response.statusCode, 409);
+      const body = JSON.parse(response.body);
+      assert.ok(body.message.includes('already in use'));
+
+      // Clean up other user
+      await pool.query('DELETE FROM users WHERE email = $1', [otherEmail]);
+    });
+
+    test('should reject invalid email format', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/user/profile',
+        headers: { Authorization: `Bearer ${userToken}` },
+        payload: { email: 'invalid-email' },
+      });
+      assert.strictEqual(response.statusCode, 400);
+    });
+
+    test('should update password with valid format', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/user/profile',
+        headers: { Authorization: `Bearer ${userToken}` },
+        payload: { password: 'NewSecure123!' },
+      });
+
+      assert.strictEqual(response.statusCode, 200);
+    });
+
+    test('should reject weak password', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/user/profile',
+        headers: { Authorization: `Bearer ${userToken}` },
+        payload: { password: 'weak' },
+      });
+      assert.strictEqual(response.statusCode, 400);
+    });
+
+    test('should reject name too long', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: '/api/user/profile',
+        headers: { Authorization: `Bearer ${userToken}` },
+        payload: { name: 'a'.repeat(256) },
+      });
+      assert.strictEqual(response.statusCode, 400);
+    });
+  });
+});

--- a/apps/backend/src/routes/user.ts
+++ b/apps/backend/src/routes/user.ts
@@ -1,0 +1,243 @@
+import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { db } from '../database.js';
+import { authenticateUser } from '../middleware/auth.js';
+import { UpdateUserRequestSchema, UserProfileResponseSchema } from '@st44/types';
+import { z, zodToOpenAPI, CommonErrors } from '@st44/types/generators';
+import { validateRequest, handleZodError } from '../utils/validation.js';
+import { stripResponseValidation } from '../schemas/common.js';
+import bcrypt from 'bcrypt';
+
+interface UpdateProfileRequest {
+  Body: {
+    name?: string;
+    email?: string;
+    password?: string;
+  };
+}
+
+/**
+ * GET /api/user/profile - Get current user's profile
+ * Returns the authenticated user's profile data
+ */
+async function getProfile(request: FastifyRequest, reply: FastifyReply) {
+  const userId = request.user?.userId;
+
+  if (!userId) {
+    return reply.status(401).send({
+      statusCode: 401,
+      error: 'Unauthorized',
+      message: 'Authentication required',
+    });
+  }
+
+  try {
+    const result = await db.query(
+      `SELECT id, email, name, created_at, updated_at
+       FROM users
+       WHERE id = $1`,
+      [userId],
+    );
+
+    if (result.rows.length === 0) {
+      return reply.status(404).send({
+        statusCode: 404,
+        error: 'Not Found',
+        message: 'User not found',
+      });
+    }
+
+    const user = result.rows[0];
+
+    return reply.send({
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      createdAt: user.created_at?.toISOString?.() ?? user.created_at,
+      updatedAt: user.updated_at?.toISOString?.() ?? user.updated_at,
+    });
+  } catch (error) {
+    request.log.error(error, 'Failed to get user profile');
+    return reply.status(500).send({
+      statusCode: 500,
+      error: 'Internal Server Error',
+      message: 'Failed to retrieve user profile',
+    });
+  }
+}
+
+/**
+ * PUT /api/user/profile - Update current user's profile
+ * Updates the authenticated user's profile data
+ */
+async function updateProfile(request: FastifyRequest<UpdateProfileRequest>, reply: FastifyReply) {
+  const userId = request.user?.userId;
+
+  if (!userId) {
+    return reply.status(401).send({
+      statusCode: 401,
+      error: 'Unauthorized',
+      message: 'Authentication required',
+    });
+  }
+
+  try {
+    const validatedData = validateRequest(UpdateUserRequestSchema, request.body);
+
+    // Check if there's anything to update
+    if (Object.keys(validatedData).length === 0) {
+      return reply.status(400).send({
+        statusCode: 400,
+        error: 'Bad Request',
+        message: 'No fields to update',
+      });
+    }
+
+    // Build update query dynamically
+    const updates: string[] = [];
+    const values: unknown[] = [];
+    let paramIndex = 1;
+
+    if (validatedData.name !== undefined) {
+      updates.push(`name = $${paramIndex++}`);
+      values.push(validatedData.name);
+    }
+
+    if (validatedData.email !== undefined) {
+      // Check if email is already in use by another user
+      const emailCheck = await db.query('SELECT id FROM users WHERE email = $1 AND id != $2', [
+        validatedData.email,
+        userId,
+      ]);
+      if (emailCheck.rows.length > 0) {
+        return reply.status(409).send({
+          statusCode: 409,
+          error: 'Conflict',
+          message: 'Email is already in use',
+        });
+      }
+      updates.push(`email = $${paramIndex++}`);
+      values.push(validatedData.email);
+    }
+
+    if (validatedData.password !== undefined) {
+      // Validate password strength
+      const hasUpperCase = /[A-Z]/.test(validatedData.password);
+      const hasLowerCase = /[a-z]/.test(validatedData.password);
+      const hasNumber = /\d/.test(validatedData.password);
+      if (validatedData.password.length < 8 || !hasUpperCase || !hasLowerCase || !hasNumber) {
+        return reply.status(400).send({
+          statusCode: 400,
+          error: 'Bad Request',
+          message:
+            'Password must be at least 8 characters and contain uppercase, lowercase, and number',
+        });
+      }
+      const passwordHash = await bcrypt.hash(validatedData.password, 12);
+      updates.push(`password_hash = $${paramIndex++}`);
+      values.push(passwordHash);
+    }
+
+    // Always update updated_at
+    updates.push(`updated_at = NOW()`);
+
+    // Add userId for WHERE clause
+    values.push(userId);
+
+    const query = `
+      UPDATE users
+      SET ${updates.join(', ')}
+      WHERE id = $${paramIndex}
+      RETURNING id, email, name, created_at, updated_at
+    `;
+
+    const result = await db.query(query, values);
+
+    if (result.rows.length === 0) {
+      return reply.status(404).send({
+        statusCode: 404,
+        error: 'Not Found',
+        message: 'User not found',
+      });
+    }
+
+    const user = result.rows[0];
+
+    return reply.send({
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      createdAt: user.created_at?.toISOString?.() ?? user.created_at,
+      updatedAt: user.updated_at?.toISOString?.() ?? user.updated_at,
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return handleZodError(error, reply);
+    }
+    request.log.error(error, 'Failed to update user profile');
+    return reply.status(500).send({
+      statusCode: 500,
+      error: 'Internal Server Error',
+      message: 'Failed to update user profile',
+    });
+  }
+}
+
+// OpenAPI schemas
+const getProfileSchema = stripResponseValidation({
+  summary: 'Get user profile',
+  description: 'Get the current authenticated user profile',
+  tags: ['user'],
+  security: [{ bearerAuth: [] }],
+  response: {
+    200: {
+      description: 'User profile retrieved successfully',
+      ...zodToOpenAPI(UserProfileResponseSchema),
+    },
+    ...CommonErrors.Unauthorized,
+    ...CommonErrors.NotFound,
+    ...CommonErrors.InternalServerError,
+  },
+});
+
+const updateProfileSchema = stripResponseValidation({
+  summary: 'Update user profile',
+  description: 'Update the current authenticated user profile',
+  tags: ['user'],
+  security: [{ bearerAuth: [] }],
+  body: zodToOpenAPI(UpdateUserRequestSchema),
+  response: {
+    200: {
+      description: 'User profile updated successfully',
+      ...zodToOpenAPI(UserProfileResponseSchema),
+    },
+    ...CommonErrors.BadRequest,
+    ...CommonErrors.Unauthorized,
+    ...CommonErrors.NotFound,
+    409: {
+      description: 'Email already in use',
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', enum: [409] },
+        error: { type: 'string' },
+        message: { type: 'string' },
+      },
+    },
+    ...CommonErrors.InternalServerError,
+  },
+});
+
+export default async function userRoutes(fastify: FastifyInstance): Promise<void> {
+  // GET /api/user/profile - Get current user profile
+  fastify.get('/api/user/profile', {
+    preHandler: [authenticateUser],
+    schema: getProfileSchema,
+    handler: getProfile,
+  });
+
+  // PUT /api/user/profile - Update current user profile
+  fastify.put('/api/user/profile', {
+    preHandler: [authenticateUser],
+    schema: updateProfileSchema,
+    handler: updateProfile,
+  });
+}

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -15,6 +15,7 @@ import assignmentRoutes from './routes/assignments.js';
 import analyticsRoutes from './routes/analytics.js';
 import rewardRoutes from './routes/rewards.js';
 import statsRoutes from './routes/stats.js';
+import userRoutes from './routes/user.js';
 import {
   registerSchema,
   loginSchema,
@@ -113,6 +114,7 @@ async function buildApp() {
         },
         tags: [
           { name: 'auth', description: 'Authentication endpoints' },
+          { name: 'user', description: 'User profile management' },
           { name: 'households', description: 'Household management' },
           { name: 'children', description: 'Child profile management' },
           { name: 'tasks', description: 'Task template management' },
@@ -741,6 +743,7 @@ async function buildApp() {
   await fastify.register(rewardRoutes);
   await fastify.register(analyticsRoutes);
   await fastify.register(statsRoutes);
+  await fastify.register(userRoutes);
 
   // Example items endpoint
   interface Item {

--- a/apps/frontend/src/app/app.routes.ts
+++ b/apps/frontend/src/app/app.routes.ts
@@ -89,6 +89,11 @@ export const routes: Routes = [
             (m) => m.InvitationInboxComponent,
           ),
       },
+      {
+        path: 'settings',
+        title: 'Settings - Diddit!',
+        loadComponent: () => import('./pages/settings/settings').then((m) => m.Settings),
+      },
       // Default redirect for authenticated parent/admin users
       {
         path: '',

--- a/apps/frontend/src/app/components/navigation/sidebar-nav/sidebar-nav.css
+++ b/apps/frontend/src/app/components/navigation/sidebar-nav/sidebar-nav.css
@@ -111,6 +111,31 @@
   display: flex;
   align-items: center;
   gap: var(--space-md, 16px);
+  border: none;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  width: 100%;
+  text-align: left;
+}
+
+.sidebar-user:hover {
+  background: var(--color-surface-hover, #f3f4f6);
+}
+
+.sidebar-user:focus-visible {
+  outline: 2px solid var(--color-primary, #6366f1);
+  outline-offset: 2px;
+}
+
+.settings-icon {
+  margin-left: auto;
+  font-size: 20px;
+  color: var(--color-text-secondary, #6b7280);
+  transition: color 0.2s ease;
+}
+
+.sidebar-user:hover .settings-icon {
+  color: var(--color-text-primary, #1f2937);
 }
 
 .sidebar-avatar {

--- a/apps/frontend/src/app/components/navigation/sidebar-nav/sidebar-nav.html
+++ b/apps/frontend/src/app/components/navigation/sidebar-nav/sidebar-nav.html
@@ -21,7 +21,12 @@
     + Add Task
   </button>
 
-  <div class="sidebar-user">
+  <button
+    type="button"
+    class="sidebar-user"
+    (click)="handleSettingsClick()"
+    aria-label="Open settings"
+  >
     <div class="sidebar-avatar" [attr.aria-label]="'Avatar for ' + user().name">
       {{ userInitials() }}
     </div>
@@ -29,5 +34,6 @@
       <h4>{{ user().name }}</h4>
       <app-household-switcher></app-household-switcher>
     </div>
-  </div>
+    <span class="settings-icon" aria-hidden="true">gear</span>
+  </button>
 </nav>

--- a/apps/frontend/src/app/components/navigation/sidebar-nav/sidebar-nav.ts
+++ b/apps/frontend/src/app/components/navigation/sidebar-nav/sidebar-nav.ts
@@ -40,6 +40,11 @@ export class SidebarNav {
   addTask = output<void>();
 
   /**
+   * Emitted when user clicks the settings/profile area
+   */
+  settings = output<void>();
+
+  /**
    * Navigation items configuration
    */
   readonly navItems: NavItem[] = [
@@ -73,6 +78,13 @@ export class SidebarNav {
    */
   handleAddTask() {
     this.addTask.emit();
+  }
+
+  /**
+   * Handle settings/profile click
+   */
+  handleSettingsClick() {
+    this.settings.emit();
   }
 
   /**

--- a/apps/frontend/src/app/layouts/main-layout/main-layout.html
+++ b/apps/frontend/src/app/layouts/main-layout/main-layout.html
@@ -6,6 +6,7 @@
       [user]="sidebarUser()"
       (navigate)="onNavigate($event)"
       (addTask)="openQuickAdd()"
+      (settings)="onSettings()"
     />
   </div>
 

--- a/apps/frontend/src/app/layouts/main-layout/main-layout.ts
+++ b/apps/frontend/src/app/layouts/main-layout/main-layout.ts
@@ -188,4 +188,11 @@ export class MainLayout implements OnInit, OnDestroy {
         },
       });
   }
+
+  /**
+   * Navigate to settings page
+   */
+  protected onSettings(): void {
+    void this.router.navigate(['/settings']);
+  }
 }

--- a/apps/frontend/src/app/pages/settings/settings.css
+++ b/apps/frontend/src/app/pages/settings/settings.css
@@ -1,0 +1,368 @@
+/**
+ * Settings Screen Styles
+ * Diddit! Design System - Playful & Modern
+ */
+
+/* ===== LOADING & ERROR STATES ===== */
+
+.loading-container,
+.error-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: var(--space-xl);
+  text-align: center;
+  background: var(--color-background);
+}
+
+.spinner {
+  width: 48px;
+  height: 48px;
+  border: 4px solid var(--color-surface);
+  border-top-color: var(--color-primary);
+  border-radius: var(--radius-full);
+  animation: spin 1s linear infinite;
+  margin-bottom: var(--space-md);
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.error-icon {
+  font-size: 4rem;
+  margin-bottom: var(--space-md);
+}
+
+.error-container h2 {
+  font-family: var(--font-heading);
+  font-size: var(--font-size-2xl);
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-sm);
+}
+
+.error-container p {
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-lg);
+}
+
+.btn-retry {
+  padding: var(--space-sm) var(--space-lg);
+  background: var(--gradient-primary);
+  color: white;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition:
+    transform 0.2s,
+    box-shadow 0.2s;
+}
+
+.btn-retry:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+/* ===== MAIN LAYOUT ===== */
+
+.settings-page {
+  min-height: 100vh;
+  background: var(--color-background);
+}
+
+/* ===== HEADER ===== */
+
+.header {
+  background: var(--gradient-primary);
+  padding: var(--space-xl) var(--space-md) var(--space-lg);
+  color: white;
+}
+
+@media (min-width: 768px) {
+  .header {
+    padding: var(--space-xl) var(--space-xl) var(--space-lg);
+  }
+}
+
+.header-content {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.page-title {
+  font-family: var(--font-heading);
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  margin: 0;
+  color: white;
+}
+
+/* ===== CONTENT ===== */
+
+.content {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: var(--space-md);
+  width: 100%;
+}
+
+@media (min-width: 768px) {
+  .content {
+    padding: var(--space-xl);
+  }
+}
+
+/* ===== ALERTS ===== */
+
+.alert {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-sm);
+  margin-bottom: var(--space-lg);
+  animation: fadeIn 0.3s ease-out;
+}
+
+.alert-success {
+  background: var(--color-success-light, #dcfce7);
+  color: var(--color-success-dark, #166534);
+  border: 1px solid var(--color-success, #22c55e);
+}
+
+.alert-error {
+  background: var(--color-danger-light, #fef2f2);
+  color: var(--color-danger-dark, #991b1b);
+  border: 1px solid var(--color-danger, #ef4444);
+}
+
+.alert-dismiss {
+  background: none;
+  border: none;
+  font-size: var(--font-size-lg);
+  cursor: pointer;
+  opacity: 0.7;
+  padding: 0 var(--space-xs);
+}
+
+.alert-dismiss:hover {
+  opacity: 1;
+}
+
+/* ===== SETTINGS SECTION ===== */
+
+.settings-section {
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  padding: var(--space-lg);
+  margin-bottom: var(--space-lg);
+  box-shadow: var(--shadow-sm);
+}
+
+.settings-section h2 {
+  font-family: var(--font-heading);
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-primary);
+  margin: 0 0 var(--space-lg) 0;
+  padding-bottom: var(--space-sm);
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+}
+
+/* ===== FORM STYLES ===== */
+
+.settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.form-group label {
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.form-group input {
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: var(--font-size-base);
+  color: var(--color-text-primary);
+  background: white;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s;
+}
+
+.form-group input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-light, rgba(168, 85, 247, 0.2));
+}
+
+.form-group input::placeholder {
+  color: var(--color-text-muted, #9ca3af);
+}
+
+.form-hint {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+/* ===== PASSWORD SECTION ===== */
+
+.btn-link {
+  background: none;
+  border: none;
+  color: var(--color-primary);
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  padding: 0;
+  text-align: left;
+}
+
+.btn-link:hover {
+  text-decoration: underline;
+}
+
+.password-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+  padding: var(--space-md);
+  background: var(--color-background);
+  border-radius: var(--radius-sm);
+  animation: fadeIn 0.3s ease-out;
+}
+
+/* ===== FORM ACTIONS ===== */
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-sm);
+  padding-top: var(--space-md);
+}
+
+/* ===== BUTTONS ===== */
+
+.btn {
+  padding: var(--space-sm) var(--space-lg);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition:
+    transform 0.2s,
+    box-shadow 0.2s,
+    opacity 0.2s;
+  border: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: var(--gradient-primary);
+  color: white;
+  box-shadow: var(--shadow-sm);
+}
+
+.btn-primary:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+.btn-primary:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: var(--shadow-sm);
+}
+
+.btn-danger {
+  background: var(--color-danger, #ef4444);
+  color: white;
+  box-shadow: var(--shadow-sm);
+}
+
+.btn-danger:hover:not(:disabled) {
+  background: var(--color-danger-dark, #dc2626);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+/* ===== ACCOUNT INFO ===== */
+
+.account-info {
+  margin-bottom: var(--space-lg);
+}
+
+.info-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-sm) 0;
+}
+
+.info-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.info-value {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+/* ===== DANGER ZONE ===== */
+
+.danger-zone {
+  padding-top: var(--space-md);
+  border-top: 1px solid var(--color-border, #e5e7eb);
+}
+
+/* ===== ANIMATIONS ===== */
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.settings-section {
+  animation: fadeIn 0.4s ease-out;
+}
+
+.settings-section:nth-child(2) {
+  animation-delay: 0.1s;
+}

--- a/apps/frontend/src/app/pages/settings/settings.html
+++ b/apps/frontend/src/app/pages/settings/settings.html
@@ -1,0 +1,143 @@
+<!-- Loading State -->
+@if (loading()) {
+  <div class="loading-container" role="status" aria-live="polite">
+    <div class="spinner" aria-hidden="true"></div>
+    <p>Loading your profile...</p>
+  </div>
+}
+
+<!-- Error State (full page) -->
+@if (error() && !loading() && !profile()) {
+  <div class="error-container" role="alert" aria-live="assertive">
+    <div class="error-icon" aria-hidden="true">!</div>
+    <h2>Oops!</h2>
+    <p>{{ error() }}</p>
+    <button class="btn-retry" (click)="loadProfile()">Try Again</button>
+  </div>
+}
+
+<!-- Main Content -->
+@if (!loading() && profile()) {
+  <div class="settings-page">
+    <!-- Header with Gradient -->
+    <header class="header">
+      <div class="header-content">
+        <h1 class="page-title">Settings</h1>
+      </div>
+    </header>
+
+    <!-- Content -->
+    <div class="content">
+      <!-- Success Message -->
+      @if (successMessage()) {
+        <div class="alert alert-success" role="status" aria-live="polite">
+          <span>{{ successMessage() }}</span>
+          <button class="alert-dismiss" (click)="dismissSuccess()" aria-label="Dismiss">x</button>
+        </div>
+      }
+
+      <!-- Error Message (inline) -->
+      @if (error() && profile()) {
+        <div class="alert alert-error" role="alert" aria-live="assertive">
+          <span>{{ error() }}</span>
+          <button class="alert-dismiss" (click)="dismissError()" aria-label="Dismiss">x</button>
+        </div>
+      }
+
+      <!-- Profile Section -->
+      <section class="settings-section">
+        <h2>Profile</h2>
+
+        <form class="settings-form" (submit)="saveProfile(); $event.preventDefault()">
+          <!-- Name Field -->
+          <div class="form-group">
+            <label for="name">Display Name</label>
+            <input
+              type="text"
+              id="name"
+              name="name"
+              [(ngModel)]="name"
+              placeholder="Enter your name"
+              maxlength="255"
+            />
+            <small class="form-hint">This is how you'll appear to other family members</small>
+          </div>
+
+          <!-- Email Field -->
+          <div class="form-group">
+            <label for="email">Email Address</label>
+            <input
+              type="email"
+              id="email"
+              name="email"
+              [(ngModel)]="email"
+              placeholder="Enter your email"
+              required
+            />
+          </div>
+
+          <!-- Password Section Toggle -->
+          <button type="button" class="btn-link" (click)="togglePasswordSection()">
+            {{ showPasswordSection() ? '- Hide password section' : '+ Change password' }}
+          </button>
+
+          <!-- Password Fields (conditionally shown) -->
+          @if (showPasswordSection()) {
+            <div class="password-section">
+              <div class="form-group">
+                <label for="newPassword">New Password</label>
+                <input
+                  type="password"
+                  id="newPassword"
+                  name="newPassword"
+                  [(ngModel)]="newPassword"
+                  placeholder="Enter new password"
+                  minlength="8"
+                  autocomplete="new-password"
+                />
+                <small class="form-hint">
+                  Minimum 8 characters, must include uppercase, lowercase, and number
+                </small>
+              </div>
+
+              <div class="form-group">
+                <label for="confirmPassword">Confirm New Password</label>
+                <input
+                  type="password"
+                  id="confirmPassword"
+                  name="confirmPassword"
+                  [(ngModel)]="confirmPassword"
+                  placeholder="Confirm new password"
+                  autocomplete="new-password"
+                />
+              </div>
+            </div>
+          }
+
+          <!-- Save Button -->
+          <div class="form-actions">
+            <button type="submit" class="btn btn-primary" [disabled]="saving()">
+              {{ saving() ? 'Saving...' : 'Save Changes' }}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <!-- Account Section -->
+      <section class="settings-section">
+        <h2>Account</h2>
+
+        <div class="account-info">
+          <div class="info-row">
+            <span class="info-label">Member since</span>
+            <span class="info-value">{{ profile()?.createdAt | date: 'mediumDate' }}</span>
+          </div>
+        </div>
+
+        <div class="danger-zone">
+          <button type="button" class="btn btn-danger" (click)="logout()">Log Out</button>
+        </div>
+      </section>
+    </div>
+  </div>
+}

--- a/apps/frontend/src/app/pages/settings/settings.ts
+++ b/apps/frontend/src/app/pages/settings/settings.ts
@@ -1,0 +1,192 @@
+import { Component, ChangeDetectionStrategy, signal, inject, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { Router } from '@angular/router';
+import { UserService, type UserProfile } from '../../services/user.service';
+import { AuthService } from '../../services/auth.service';
+
+/**
+ * Settings Screen
+ *
+ * Allows users to view and edit their profile:
+ * - Display name
+ * - Email address
+ * - Password change
+ *
+ * Design matches the "Diddit!" playful aesthetic from UX redesign.
+ * Navigation is handled by the parent MainLayout component.
+ */
+@Component({
+  selector: 'app-settings',
+  imports: [FormsModule, DatePipe],
+  templateUrl: './settings.html',
+  styleUrl: './settings.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class Settings implements OnInit {
+  private readonly userService = inject(UserService);
+  private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
+
+  // State signals
+  protected readonly loading = signal(true);
+  protected readonly saving = signal(false);
+  protected readonly error = signal<string | null>(null);
+  protected readonly successMessage = signal<string | null>(null);
+
+  // Profile data
+  protected readonly profile = signal<UserProfile | null>(null);
+
+  // Form fields
+  protected name = '';
+  protected email = '';
+  protected currentPassword = '';
+  protected newPassword = '';
+  protected confirmPassword = '';
+
+  // Password section toggle
+  protected readonly showPasswordSection = signal(false);
+
+  async ngOnInit(): Promise<void> {
+    await this.loadProfile();
+  }
+
+  /**
+   * Load user profile data
+   */
+  protected async loadProfile(): Promise<void> {
+    try {
+      this.loading.set(true);
+      this.error.set(null);
+
+      const profile = await this.userService.getProfile();
+      this.profile.set(profile);
+
+      // Initialize form fields
+      this.name = profile.name ?? '';
+      this.email = profile.email;
+    } catch (err) {
+      console.error('Failed to load profile:', err);
+      this.error.set('Failed to load profile. Please try again.');
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  /**
+   * Save profile changes
+   */
+  protected async saveProfile(): Promise<void> {
+    const currentProfile = this.profile();
+    if (!currentProfile) return;
+
+    try {
+      this.saving.set(true);
+      this.error.set(null);
+      this.successMessage.set(null);
+
+      // Build update request with only changed fields
+      const updates: { name?: string; email?: string; password?: string } = {};
+
+      if (this.name !== (currentProfile.name ?? '')) {
+        updates.name = this.name;
+      }
+
+      if (this.email !== currentProfile.email) {
+        updates.email = this.email;
+      }
+
+      // Validate password if changing
+      if (this.showPasswordSection() && this.newPassword) {
+        if (this.newPassword !== this.confirmPassword) {
+          this.error.set('New passwords do not match');
+          return;
+        }
+
+        if (this.newPassword.length < 8) {
+          this.error.set('Password must be at least 8 characters');
+          return;
+        }
+
+        if (!/[A-Z]/.test(this.newPassword)) {
+          this.error.set('Password must contain at least one uppercase letter');
+          return;
+        }
+
+        if (!/[a-z]/.test(this.newPassword)) {
+          this.error.set('Password must contain at least one lowercase letter');
+          return;
+        }
+
+        if (!/\d/.test(this.newPassword)) {
+          this.error.set('Password must contain at least one number');
+          return;
+        }
+
+        updates.password = this.newPassword;
+      }
+
+      // Check if there are any changes
+      if (Object.keys(updates).length === 0) {
+        this.error.set('No changes to save');
+        return;
+      }
+
+      const updatedProfile = await this.userService.updateProfile(updates);
+      this.profile.set(updatedProfile);
+      this.name = updatedProfile.name ?? '';
+      this.email = updatedProfile.email;
+
+      // Clear password fields
+      this.currentPassword = '';
+      this.newPassword = '';
+      this.confirmPassword = '';
+      this.showPasswordSection.set(false);
+
+      this.successMessage.set('Profile updated successfully!');
+    } catch (err: unknown) {
+      console.error('Failed to save profile:', err);
+      const errorMessage =
+        err instanceof Error && 'status' in err && (err as { status: number }).status === 409
+          ? 'Email is already in use'
+          : 'Failed to save profile. Please try again.';
+      this.error.set(errorMessage);
+    } finally {
+      this.saving.set(false);
+    }
+  }
+
+  /**
+   * Toggle password change section
+   */
+  protected togglePasswordSection(): void {
+    this.showPasswordSection.update((v) => !v);
+    if (!this.showPasswordSection()) {
+      this.currentPassword = '';
+      this.newPassword = '';
+      this.confirmPassword = '';
+    }
+  }
+
+  /**
+   * Logout and redirect to login
+   */
+  protected logout(): void {
+    this.authService.logout();
+    void this.router.navigate(['/login']);
+  }
+
+  /**
+   * Dismiss success message
+   */
+  protected dismissSuccess(): void {
+    this.successMessage.set(null);
+  }
+
+  /**
+   * Dismiss error message
+   */
+  protected dismissError(): void {
+    this.error.set(null);
+  }
+}

--- a/apps/frontend/src/app/services/user.service.ts
+++ b/apps/frontend/src/app/services/user.service.ts
@@ -1,0 +1,40 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { environment } from '../../environments/environment.development';
+
+export interface UserProfile {
+  id: string;
+  email: string;
+  name: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpdateProfileRequest {
+  name?: string;
+  email?: string;
+  password?: string;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class UserService {
+  private readonly http = inject(HttpClient);
+  private readonly apiUrl = `${environment.apiUrl}/api/user`;
+
+  /**
+   * Get the current user's profile
+   */
+  async getProfile(): Promise<UserProfile> {
+    return firstValueFrom(this.http.get<UserProfile>(`${this.apiUrl}/profile`));
+  }
+
+  /**
+   * Update the current user's profile
+   */
+  async updateProfile(data: UpdateProfileRequest): Promise<UserProfile> {
+    return firstValueFrom(this.http.put<UserProfile>(`${this.apiUrl}/profile`, data));
+  }
+}

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -29,20 +29,22 @@ VALUES
   ('021', 'rename_due_date_to_date', NOW()),
   ('022', 'add_user_id_to_children', NOW()),
   ('023', 'add_rewards_system', NOW()),
-  ('038', 'create_password_reset_tokens_table', NOW())
+  ('038', 'create_password_reset_tokens_table', NOW()),
+  ('039', 'add_name_to_users', NOW())
 ON CONFLICT (version) DO NOTHING;
 
 -- Users table for authentication (supports email/password and OAuth)
 CREATE TABLE IF NOT EXISTS users (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   email VARCHAR(255) UNIQUE NOT NULL,
+  name VARCHAR(255), -- User display name (nullable for backwards compatibility)
   password_hash VARCHAR(255), -- Nullable for OAuth users
   oauth_provider VARCHAR(50), -- 'google', 'microsoft', etc.
   oauth_provider_id VARCHAR(255), -- User ID from OAuth provider
   created_at TIMESTAMP NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
   CONSTRAINT check_auth_method CHECK (
-    (password_hash IS NOT NULL) OR 
+    (password_hash IS NOT NULL) OR
     (oauth_provider IS NOT NULL AND oauth_provider_id IS NOT NULL)
   )
 );

--- a/docker/postgres/migrations/039_add_name_to_users.sql
+++ b/docker/postgres/migrations/039_add_name_to_users.sql
@@ -1,0 +1,23 @@
+-- Migration: 039_add_name_to_users
+-- Description: Add name column to users table for profile display
+-- Created: 2025-01-29
+
+BEGIN;
+
+-- Guard: Check if migration has already been applied
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM schema_migrations WHERE version = '039') THEN
+        RAISE EXCEPTION 'Migration 039 has already been applied';
+    END IF;
+END $$;
+
+-- Add name column to users table (nullable to support existing users)
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS name VARCHAR(255);
+
+-- Record migration as applied
+INSERT INTO schema_migrations (version, name, applied_at)
+VALUES ('039', 'add_name_to_users', NOW());
+
+COMMIT;

--- a/packages/types/src/schemas/user.schema.ts
+++ b/packages/types/src/schemas/user.schema.ts
@@ -10,6 +10,7 @@ import { z } from '../generators/openapi.generator.js';
 export const UserSchema = z.object({
   id: z.string().uuid(),
   email: z.string().email(),
+  name: z.string().max(255).nullable(),
   googleId: z.string().nullable(),
   passwordHash: z.string().nullable(),
   createdAt: z.string().datetime(),
@@ -43,12 +44,27 @@ export type CreateUserRequest = z.infer<typeof CreateUserRequestSchema>;
  */
 export const UpdateUserRequestSchema = z
   .object({
+    name: z.string().max(255).optional(),
     email: z.string().email().optional(),
     password: z.string().min(8).max(128).optional(),
   })
   .strict();
 
 export type UpdateUserRequest = z.infer<typeof UpdateUserRequestSchema>;
+
+/**
+ * User Profile Response Schema
+ * Returns user profile data (safe for API response)
+ */
+export const UserProfileResponseSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  name: z.string().nullable(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export type UserProfileResponse = z.infer<typeof UserProfileResponseSchema>;
 
 /**
  * Login Request


### PR DESCRIPTION
## Summary

Add ability for users to view and edit their profile information:

**Backend:**
- Add migration 039 to add `name` column to users table
- Create GET/PUT `/api/user/profile` endpoints for profile management
- Add `UserProfileResponseSchema` to `@st44/types`
- Add comprehensive backend tests for profile endpoints

**Frontend:**
- Create Settings page with profile editing form
- Add `UserService` for profile API operations
- Update sidebar navigation with clickable user section for settings access
- Add `/settings` route to app routes

**Users can now:**
- View their profile information
- Edit their display name
- Change their email address
- Update their password

## Test plan
- [x] Backend builds successfully
- [x] Frontend builds successfully
- [x] Frontend tests pass (631 tests)
- [x] Backend tests added for profile endpoints
- [ ] Manual verification of settings page UI
- [ ] E2E tests via CI

## Screenshots
N/A - UI changes require manual verification

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)