### PR TITLE
feat(frontend): add task reassignment UI to Tasks page (#272)

### DIFF
--- a/apps/frontend/src/app/components/modals/reassign-task-modal/reassign-task-modal.css
+++ b/apps/frontend/src/app/components/modals/reassign-task-modal/reassign-task-modal.css
@@ -1,0 +1,111 @@
+/**
+ * Reassign Task Modal Styles
+ * Diddit! Design System
+ */
+
+.reassign-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg, 20px);
+}
+
+.reassign-description {
+  font-family: var(--font-body, 'Outfit', sans-serif);
+  font-size: var(--font-size-base, 16px);
+  color: var(--color-text-secondary, #6b7280);
+  margin: 0;
+}
+
+.reassign-description strong {
+  color: var(--color-text-primary, #1f2937);
+}
+
+.error-message {
+  padding: var(--space-sm, 8px) var(--space-md, 16px);
+  background: var(--color-danger-light, #fef2f2);
+  color: var(--color-danger-dark, #991b1b);
+  border: 1px solid var(--color-danger, #ef4444);
+  border-radius: var(--radius-sm, 8px);
+  font-size: var(--font-size-sm, 14px);
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs, 4px);
+}
+
+.form-group label {
+  font-family: var(--font-body, 'Outfit', sans-serif);
+  font-size: var(--font-size-sm, 14px);
+  font-weight: var(--font-weight-semibold, 600);
+  color: var(--color-text-primary, #1f2937);
+}
+
+.form-group select {
+  padding: var(--space-sm, 8px) var(--space-md, 16px);
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: var(--radius-sm, 8px);
+  font-family: var(--font-body, 'Outfit', sans-serif);
+  font-size: var(--font-size-base, 16px);
+  color: var(--color-text-primary, #1f2937);
+  background: white;
+  cursor: pointer;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s;
+}
+
+.form-group select:focus {
+  outline: none;
+  border-color: var(--color-primary, #6366f1);
+  box-shadow: 0 0 0 3px var(--color-primary-light, rgba(99, 102, 241, 0.2));
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-sm, 8px);
+  padding-top: var(--space-md, 16px);
+  border-top: 1px solid var(--color-border, #e5e7eb);
+}
+
+.btn {
+  padding: var(--space-sm, 8px) var(--space-lg, 20px);
+  border-radius: var(--radius-sm, 8px);
+  font-family: var(--font-body, 'Outfit', sans-serif);
+  font-size: var(--font-size-sm, 14px);
+  font-weight: var(--font-weight-semibold, 600);
+  cursor: pointer;
+  transition:
+    transform 0.2s,
+    box-shadow 0.2s,
+    opacity 0.2s;
+  border: none;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  background: var(--color-surface, #f9fafb);
+  color: var(--color-text-secondary, #6b7280);
+  border: 1px solid var(--color-border, #d1d5db);
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background: var(--color-background, #f3f4f6);
+}
+
+.btn-primary {
+  background: var(--gradient-primary, linear-gradient(135deg, #6366f1 0%, #ec4899 100%));
+  color: white;
+  box-shadow: var(--shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.05));
+}
+
+.btn-primary:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md, 0 4px 6px rgba(0, 0, 0, 0.1));
+}

--- a/apps/frontend/src/app/components/modals/reassign-task-modal/reassign-task-modal.html
+++ b/apps/frontend/src/app/components/modals/reassign-task-modal/reassign-task-modal.html
@@ -1,0 +1,43 @@
+<app-modal [open]="open()" (closeRequested)="onCancel()" title="Reassign Task">
+  <div class="reassign-form">
+    <p class="reassign-description">
+      Reassign <strong>{{ taskName() }}</strong> to a different child.
+    </p>
+
+    @if (error()) {
+      <div class="error-message" role="alert">
+        {{ error() }}
+      </div>
+    }
+
+    <div class="form-group">
+      <label for="child-select">Select Child</label>
+      <select
+        id="child-select"
+        name="childId"
+        [ngModel]="selectedChildId()"
+        (ngModelChange)="onChildChange($event)"
+        required
+      >
+        <option value="" disabled selected>Choose a child...</option>
+        @for (child of children(); track child.id) {
+          @if (child.id !== currentChildId()) {
+            <option [value]="child.id">{{ child.name }}</option>
+          }
+        }
+      </select>
+    </div>
+
+    <div class="form-actions">
+      <button type="button" class="btn btn-secondary" (click)="onCancel()">Cancel</button>
+      <button
+        type="button"
+        class="btn btn-primary"
+        (click)="onSubmit()"
+        [disabled]="!selectedChildId()"
+      >
+        Reassign
+      </button>
+    </div>
+  </div>
+</app-modal>

--- a/apps/frontend/src/app/components/modals/reassign-task-modal/reassign-task-modal.ts
+++ b/apps/frontend/src/app/components/modals/reassign-task-modal/reassign-task-modal.ts
@@ -1,0 +1,94 @@
+import { Component, input, output, signal, ChangeDetectionStrategy } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Modal } from '../modal/modal';
+import type { Child } from '@st44/types';
+
+/**
+ * Reassign Task Modal
+ *
+ * Allows users to reassign a task assignment to a different child.
+ * Shows a dropdown of available children in the household.
+ *
+ * Emits the selected child ID when reassignment is confirmed.
+ */
+@Component({
+  selector: 'app-reassign-task-modal',
+  imports: [Modal, FormsModule],
+  templateUrl: './reassign-task-modal.html',
+  styleUrl: './reassign-task-modal.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ReassignTaskModal {
+  /**
+   * Whether the modal is open
+   */
+  open = input<boolean>(false);
+
+  /**
+   * Task/assignment name for display
+   */
+  taskName = input<string>('');
+
+  /**
+   * Current child ID (to exclude from selection)
+   */
+  currentChildId = input<string | null>(null);
+
+  /**
+   * Available children to reassign to
+   */
+  children = input<Child[]>([]);
+
+  /**
+   * Event emitted when modal should close
+   */
+  closeRequested = output<void>();
+
+  /**
+   * Event emitted when reassignment is confirmed
+   */
+  reassigned = output<string>();
+
+  /**
+   * Selected child ID
+   */
+  protected selectedChildId = signal<string | null>(null);
+
+  /**
+   * Error message
+   */
+  protected error = signal<string | null>(null);
+
+  /**
+   * Handle child selection change
+   */
+  protected onChildChange(childId: string): void {
+    this.selectedChildId.set(childId);
+    this.error.set(null);
+  }
+
+  /**
+   * Handle form submission
+   */
+  protected onSubmit(): void {
+    const childId = this.selectedChildId();
+
+    if (!childId) {
+      this.error.set('Please select a child');
+      return;
+    }
+
+    this.reassigned.emit(childId);
+    this.selectedChildId.set(null);
+    this.error.set(null);
+  }
+
+  /**
+   * Handle cancel/close
+   */
+  protected onCancel(): void {
+    this.selectedChildId.set(null);
+    this.error.set(null);
+    this.closeRequested.emit();
+  }
+}

--- a/apps/frontend/src/app/components/task-card/task-card.component.css
+++ b/apps/frontend/src/app/components/task-card/task-card.component.css
@@ -194,12 +194,52 @@
   }
 }
 
+/* Reassign Button */
+.task-reassign-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--color-border, #d1d5db);
+  background: var(--color-surface, white);
+  color: var(--color-text-secondary, #6b7280);
+  font-size: 16px;
+  cursor: pointer;
+  transition: all var(--transition-base);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  margin-left: var(--space-sm);
+}
+
+.task-reassign-btn:hover {
+  background: var(--color-background, #f9fafb);
+  border-color: var(--color-primary, #6366f1);
+  color: var(--color-primary, #6366f1);
+  transform: scale(1.05);
+}
+
+.task-reassign-btn:active {
+  transform: scale(1);
+}
+
+.task-reassign-btn:focus {
+  outline: 2px solid var(--color-primary, #6366f1);
+  outline-offset: 2px;
+}
+
+.task-reassign-btn .reassign-icon {
+  line-height: 1;
+}
+
 /* Accessibility: Reduced motion support */
 @media (prefers-reduced-motion: reduce) {
   .task-card,
   .task-complete-btn,
+  .task-reassign-btn,
   .task-card.clickable:hover,
-  .task-complete-btn:hover {
+  .task-complete-btn:hover,
+  .task-reassign-btn:hover {
     transition: none;
     transform: none;
   }

--- a/apps/frontend/src/app/components/task-card/task-card.component.html
+++ b/apps/frontend/src/app/components/task-card/task-card.component.html
@@ -47,4 +47,17 @@
       <span class="points">{{ taskPoints() }}</span>
     </div>
   }
+
+  <!-- Reassign Button (for assignments only) -->
+  @if (showReassignButton() && isAssignment() && !completed()) {
+    <button
+      class="task-reassign-btn"
+      (click)="onReassignClick($event)"
+      [attr.aria-label]="'Reassign ' + taskName()"
+      type="button"
+      title="Reassign to another child"
+    >
+      <span class="reassign-icon">🔄</span>
+    </button>
+  }
 </div>

--- a/apps/frontend/src/app/components/task-card/task-card.component.ts
+++ b/apps/frontend/src/app/components/task-card/task-card.component.ts
@@ -103,6 +103,11 @@ export class TaskCardComponent {
   });
 
   /**
+   * Whether to show the reassign button (for assignments only)
+   */
+  showReassignButton = input<boolean>(false);
+
+  /**
    * Event emitted when user clicks the complete button
    */
   complete = output<string>();
@@ -111,6 +116,11 @@ export class TaskCardComponent {
    * Event emitted when user clicks the task card to edit
    */
   edit = output<string>();
+
+  /**
+   * Event emitted when user clicks the reassign button
+   */
+  reassign = output<string>();
 
   /**
    * Handle completion button click
@@ -137,5 +147,13 @@ export class TaskCardComponent {
       event.preventDefault();
       this.edit.emit(this.task().id);
     }
+  }
+
+  /**
+   * Handle reassign button click
+   */
+  onReassignClick(event: Event): void {
+    event.stopPropagation();
+    this.reassign.emit(this.task().id);
   }
 }

--- a/apps/frontend/src/app/pages/tasks/tasks.html
+++ b/apps/frontend/src/app/pages/tasks/tasks.html
@@ -71,8 +71,10 @@
             [task]="task"
             [showCompleteButton]="true"
             [clickable]="true"
+            [showReassignButton]="activeFilter() !== 'all'"
             (complete)="onTaskComplete($event)"
             (edit)="onTaskEdit($event)"
+            (reassign)="onTaskReassign($event)"
           />
         }
       }
@@ -86,5 +88,15 @@
     (closeRequested)="onModalClose()"
     (taskUpdated)="onTaskUpdate($event)"
     (taskDeleted)="onTaskDelete()"
+  />
+
+  <!-- Reassign Task Modal -->
+  <app-reassign-task-modal
+    [open]="reassignModalOpen()"
+    [taskName]="reassigningAssignment()?.title ?? ''"
+    [currentChildId]="reassigningAssignment()?.childId ?? null"
+    [children]="members()"
+    (closeRequested)="onReassignModalClose()"
+    (reassigned)="onReassignConfirm($event)"
   />
 </div>


### PR DESCRIPTION
## Summary

- Add `ReassignTaskModal` component with child selection dropdown for reassigning task assignments
- Add reassign button (🔄) to `TaskCardComponent` for assignment cards
- Integrate reassign modal into Tasks page with full workflow (open modal, select child, confirm)
- Only show reassign button on filtered views (mine, person, completed) - not "all" which shows task templates

## Test Plan

- [ ] Navigate to Tasks page and switch to "My Tasks" filter
- [ ] Verify reassign button (🔄) appears on assignment cards
- [ ] Click reassign button and verify modal opens with child dropdown
- [ ] Select a different child and click "Reassign"
- [ ] Verify task list refreshes with updated assignment
- [ ] Verify modal closes after successful reassignment
- [ ] Test cancel button closes modal without changes

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)