### PR TITLE
feat(backend): add centralized error handling

### DIFF
--- a/apps/backend/src/errors/authentication-error.ts
+++ b/apps/backend/src/errors/authentication-error.ts
@@ -1,0 +1,20 @@
+/**
+ * Authentication Error (401 Unauthorized)
+ *
+ * Thrown when a request lacks valid authentication credentials.
+ * Use cases:
+ * - Missing or invalid JWT token
+ * - Expired token
+ * - Invalid credentials (login)
+ */
+
+import { BaseError, type ErrorDetails } from './base-error.js';
+
+export class AuthenticationError extends BaseError {
+  readonly statusCode = 401;
+  readonly errorType = 'AUTHENTICATION_ERROR';
+
+  constructor(message = 'Authentication required', details?: ErrorDetails) {
+    super(message, details);
+  }
+}

--- a/apps/backend/src/errors/authorization-error.ts
+++ b/apps/backend/src/errors/authorization-error.ts
@@ -1,0 +1,25 @@
+/**
+ * Authorization Error (403 Forbidden)
+ *
+ * Thrown when an authenticated user lacks permission for an action.
+ * Use cases:
+ * - User trying to access another user's resources
+ * - Insufficient role (e.g., non-admin trying admin action)
+ * - Household membership required
+ */
+
+import { BaseError, type ErrorDetails } from './base-error.js';
+
+export class AuthorizationError extends BaseError {
+  readonly statusCode = 403;
+  readonly errorType = 'AUTHORIZATION_ERROR';
+
+  constructor(message = 'Access denied', details?: ErrorDetails) {
+    super(message, details);
+  }
+}
+
+/**
+ * Alias for AuthorizationError - commonly used name
+ */
+export const ForbiddenError = AuthorizationError;

--- a/apps/backend/src/errors/base-error.ts
+++ b/apps/backend/src/errors/base-error.ts
@@ -1,0 +1,77 @@
+/**
+ * Base Error Class
+ *
+ * Abstract base class for all custom API errors.
+ * Provides standardized error structure for consistent API error responses.
+ */
+
+export interface ErrorDetails {
+  [key: string]: unknown;
+}
+
+/**
+ * Abstract base error class that all custom API errors extend.
+ *
+ * Provides:
+ * - HTTP status code
+ * - Error type identifier (for machine-readable error categorization)
+ * - Human-readable message
+ * - Optional details object for additional context
+ * - Stack trace (in development)
+ */
+export abstract class BaseError extends Error {
+  /** HTTP status code (e.g., 400, 401, 404, 500) */
+  abstract readonly statusCode: number;
+
+  /** Machine-readable error type (e.g., 'VALIDATION_ERROR', 'NOT_FOUND') */
+  abstract readonly errorType: string;
+
+  /** Optional additional details about the error */
+  readonly details?: ErrorDetails;
+
+  constructor(message: string, details?: ErrorDetails) {
+    super(message);
+    this.name = this.constructor.name;
+    this.details = details;
+
+    // Maintains proper stack trace for where our error was thrown (only in V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+
+  /**
+   * Converts the error to a JSON-serializable object for API responses.
+   * Does NOT include stack trace (security - internal details).
+   */
+  toJSON(): {
+    error: string;
+    message: string;
+    statusCode: number;
+    details?: ErrorDetails;
+  } {
+    const response: {
+      error: string;
+      message: string;
+      statusCode: number;
+      details?: ErrorDetails;
+    } = {
+      error: this.errorType,
+      message: this.message,
+      statusCode: this.statusCode,
+    };
+
+    if (this.details) {
+      response.details = this.details;
+    }
+
+    return response;
+  }
+}
+
+/**
+ * Type guard to check if an error is a BaseError instance
+ */
+export function isBaseError(error: unknown): error is BaseError {
+  return error instanceof BaseError;
+}

--- a/apps/backend/src/errors/conflict-error.ts
+++ b/apps/backend/src/errors/conflict-error.ts
@@ -1,0 +1,36 @@
+/**
+ * Conflict Error (409)
+ *
+ * Thrown when a request conflicts with current resource state.
+ * Use cases:
+ * - Duplicate email registration
+ * - Unique constraint violations
+ * - Resource already exists
+ * - Concurrent modification conflicts
+ */
+
+import { BaseError, type ErrorDetails } from './base-error.js';
+
+export class ConflictError extends BaseError {
+  readonly statusCode = 409;
+  readonly errorType = 'CONFLICT';
+
+  /** The field that caused the conflict (e.g., 'email') */
+  readonly conflictField?: string;
+
+  constructor(message = 'Resource conflict', conflictField?: string, details?: ErrorDetails) {
+    const fullDetails: ErrorDetails = { ...details };
+    if (conflictField) fullDetails.conflictField = conflictField;
+
+    super(message, Object.keys(fullDetails).length > 0 ? fullDetails : undefined);
+    this.conflictField = conflictField;
+  }
+
+  /**
+   * Creates a ConflictError for a duplicate field value.
+   */
+  static forDuplicate(field: string, value?: string): ConflictError {
+    const message = value ? `${field} already exists: ${value}` : `${field} already exists`;
+    return new ConflictError(message, field);
+  }
+}

--- a/apps/backend/src/errors/index.ts
+++ b/apps/backend/src/errors/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Custom Error Classes
+ *
+ * Centralized export for all custom API error classes.
+ * Use these errors throughout the backend for consistent error handling.
+ */
+
+// Base error and utilities
+export { BaseError, isBaseError, type ErrorDetails } from './base-error.js';
+
+// HTTP 400 - Bad Request
+export { ValidationError, type ValidationErrorDetail } from './validation-error.js';
+
+// HTTP 401 - Unauthorized
+export { AuthenticationError } from './authentication-error.js';
+
+// HTTP 403 - Forbidden
+export { AuthorizationError, ForbiddenError } from './authorization-error.js';
+
+// HTTP 404 - Not Found
+export { NotFoundError } from './not-found-error.js';
+
+// HTTP 409 - Conflict
+export { ConflictError } from './conflict-error.js';
+
+// HTTP 500 - Internal Server Error
+export { InternalError } from './internal-error.js';

--- a/apps/backend/src/errors/internal-error.ts
+++ b/apps/backend/src/errors/internal-error.ts
@@ -1,0 +1,38 @@
+/**
+ * Internal Server Error (500)
+ *
+ * Thrown for unexpected server errors.
+ * Use cases:
+ * - Database connection failures
+ * - Unexpected exceptions
+ * - Third-party service failures
+ *
+ * Note: In production, the original error message should NOT be exposed
+ * to clients. The global error handler will sanitize these.
+ */
+
+import { BaseError, type ErrorDetails } from './base-error.js';
+
+export class InternalError extends BaseError {
+  readonly statusCode = 500;
+  readonly errorType = 'INTERNAL_ERROR';
+
+  /** The original error that caused this (not exposed to clients) */
+  readonly originalError?: Error;
+
+  constructor(message = 'Internal server error', originalError?: Error, details?: ErrorDetails) {
+    super(message, details);
+    this.originalError = originalError;
+  }
+
+  /**
+   * Creates an InternalError wrapping another error.
+   * The original error message is preserved for logging but not API response.
+   */
+  static wrap(error: unknown, message = 'Internal server error'): InternalError {
+    if (error instanceof Error) {
+      return new InternalError(message, error);
+    }
+    return new InternalError(message);
+  }
+}

--- a/apps/backend/src/errors/not-found-error.ts
+++ b/apps/backend/src/errors/not-found-error.ts
@@ -1,0 +1,42 @@
+/**
+ * Not Found Error (404)
+ *
+ * Thrown when a requested resource does not exist.
+ * Use cases:
+ * - Entity not found by ID
+ * - Route not found
+ * - Resource deleted or never existed
+ */
+
+import { BaseError, type ErrorDetails } from './base-error.js';
+
+export class NotFoundError extends BaseError {
+  readonly statusCode = 404;
+  readonly errorType = 'NOT_FOUND';
+
+  /** The type of resource that was not found (e.g., 'User', 'Task') */
+  readonly resourceType?: string;
+
+  /** The identifier used to search for the resource */
+  readonly resourceId?: string;
+
+  constructor(message = 'Resource not found', resourceType?: string, resourceId?: string) {
+    const details: ErrorDetails = {};
+    if (resourceType) details.resourceType = resourceType;
+    if (resourceId) details.resourceId = resourceId;
+
+    super(message, Object.keys(details).length > 0 ? details : undefined);
+    this.resourceType = resourceType;
+    this.resourceId = resourceId;
+  }
+
+  /**
+   * Creates a NotFoundError for a specific resource type and ID.
+   */
+  static forResource(resourceType: string, resourceId?: string): NotFoundError {
+    const message = resourceId
+      ? `${resourceType} not found: ${resourceId}`
+      : `${resourceType} not found`;
+    return new NotFoundError(message, resourceType, resourceId);
+  }
+}

--- a/apps/backend/src/errors/validation-error.ts
+++ b/apps/backend/src/errors/validation-error.ts
@@ -1,0 +1,64 @@
+/**
+ * Validation Error (400 Bad Request)
+ *
+ * Thrown when request data fails validation.
+ * Use cases:
+ * - Invalid request body format
+ * - Missing required fields
+ * - Field value constraints not met
+ * - Zod schema validation failures
+ */
+
+import { BaseError, type ErrorDetails } from './base-error.js';
+
+export interface ValidationErrorDetail {
+  path: string;
+  message: string;
+}
+
+export class ValidationError extends BaseError {
+  readonly statusCode = 400;
+  readonly errorType = 'VALIDATION_ERROR';
+
+  /** Specific field validation errors */
+  readonly validationErrors?: ValidationErrorDetail[];
+
+  constructor(
+    message = 'Validation failed',
+    validationErrors?: ValidationErrorDetail[],
+    details?: ErrorDetails,
+  ) {
+    super(message, details);
+    this.validationErrors = validationErrors;
+  }
+
+  /**
+   * Creates a ValidationError from a list of field errors.
+   */
+  static fromFieldErrors(errors: ValidationErrorDetail[]): ValidationError {
+    const message =
+      errors.length === 1
+        ? `Validation failed: ${errors[0].message}`
+        : `Validation failed: ${errors.length} errors`;
+    return new ValidationError(message, errors);
+  }
+
+  override toJSON(): {
+    error: string;
+    message: string;
+    statusCode: number;
+    details?: ErrorDetails;
+  } {
+    const json = super.toJSON();
+
+    // Include validation errors in details if present
+    if (this.validationErrors && this.validationErrors.length > 0) {
+      json.details = {
+        ...json.details,
+        validationErrors: this.validationErrors,
+      };
+    }
+
+    return json;
+  }
+}

--- a/apps/backend/src/types/error-response.ts
+++ b/apps/backend/src/types/error-response.ts
@@ -1,0 +1,54 @@
+/**
+ * Standardized Error Response Types
+ *
+ * These types define the consistent error response format
+ * used across all API endpoints.
+ */
+
+/**
+ * Standard API error response format.
+ * All error responses from the API follow this structure.
+ */
+export interface ErrorResponse {
+  /** Machine-readable error type (e.g., 'VALIDATION_ERROR', 'NOT_FOUND') */
+  error: string;
+
+  /** Human-readable error message */
+  message: string;
+
+  /** HTTP status code */
+  statusCode: number;
+
+  /** Optional additional details about the error */
+  details?: unknown;
+}
+
+/**
+ * Validation error with field-level details.
+ */
+export interface ValidationErrorResponse extends ErrorResponse {
+  error: 'VALIDATION_ERROR';
+  statusCode: 400;
+  details: {
+    validationErrors: Array<{
+      path: string;
+      message: string;
+    }>;
+  };
+}
+
+/**
+ * Type guard to check if a response is an ErrorResponse
+ */
+export function isErrorResponse(response: unknown): response is ErrorResponse {
+  return (
+    typeof response === 'object' &&
+    response !== null &&
+    'error' in response &&
+    'message' in response &&
+    'statusCode' in response &&
+    typeof (response as ErrorResponse).error === 'string' &&
+    typeof (response as ErrorResponse).message === 'string' &&
+    typeof (response as ErrorResponse).statusCode === 'number'
+  );
+}


### PR DESCRIPTION
## Summary

Implements centralized error handling with custom error classes and a global error handler for consistent error responses across all endpoints.

## New Error Classes

| Class | Status | Type | Use Case |
|-------|--------|------|----------|
| AuthenticationError | 401 | AUTHENTICATION_ERROR | Invalid/missing credentials |
| AuthorizationError | 403 | AUTHORIZATION_ERROR | Permission denied |
| ValidationError | 400 | VALIDATION_ERROR | Invalid request data |
| NotFoundError | 404 | NOT_FOUND | Resource not found |
| ConflictError | 409 | CONFLICT | Duplicate resource |
| InternalError | 500 | INTERNAL_ERROR | Unexpected failures |

## Global Error Handler

Added `setErrorHandler()` in server.ts that:
- Handles custom `BaseError` instances
- Handles Zod validation errors
- Handles Fastify errors
- Logs errors with request context
- Hides internal details in production mode

## Standard Error Response

```typescript
{
  error: 'VALIDATION_ERROR',    // Machine-readable type
  message: 'Validation failed', // Human-readable message
  statusCode: 400,              // HTTP status code
  details?: { ... }             // Optional context
}
```

## Usage Example

**Before (manual handling):**
```typescript
const user = await db.query(...);
if (!user.rows.length) {
  return reply.code(404).send({ error: 'Not found' });
}
```

**After (throwing):**
```typescript
const user = await userService.getById(userId);
if (!user) {
  throw new NotFoundError('User not found');
}
```

## Test Plan

- [x] All 450 backend tests pass
- [x] Type-check passes
- [x] Build succeeds
- [x] Format check passes

## Future Work

Other routes can be incrementally updated to use the new error classes. The `user.ts` route demonstrates the pattern.

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)