### PR TITLE
feat(backend): implement repository/DAO pattern for data access layer (#283)

### DIFF
--- a/apps/backend/src/repositories/assignment.repository.ts
+++ b/apps/backend/src/repositories/assignment.repository.ts
@@ -1,0 +1,531 @@
+import type { Pool, PoolClient } from 'pg';
+import type {
+  TaskAssignmentRow,
+  TaskAssignmentStatus,
+  TaskCompletionRow,
+} from '../types/database.js';
+
+/**
+ * AssignmentRepository - Data access layer for task_assignments and task_completions tables
+ *
+ * Encapsulates all SQL queries for assignment operations.
+ * Services should use this repository instead of direct database access.
+ */
+
+export interface Assignment {
+  id: string;
+  householdId: string;
+  taskId: string;
+  childId: string | null;
+  date: string;
+  status: TaskAssignmentStatus;
+  createdAt: string;
+}
+
+export interface AssignmentWithDetails extends Assignment {
+  taskName: string;
+  taskDescription: string | null;
+  taskPoints: number;
+  childName: string | null;
+  completedAt: string | null;
+}
+
+export interface TaskCompletion {
+  id: string;
+  householdId: string;
+  taskAssignmentId: string;
+  childId: string;
+  completedAt: string;
+  pointsEarned: number;
+}
+
+export interface CreateAssignmentDto {
+  householdId: string;
+  taskId: string;
+  childId: string | null;
+  date: string;
+  status?: TaskAssignmentStatus;
+}
+
+export interface CreateCompletionDto {
+  householdId: string;
+  taskAssignmentId: string;
+  childId: string | null;
+  completedAt: Date;
+  pointsEarned: number;
+}
+
+export interface AssignmentFilters {
+  childId?: string;
+  status?: TaskAssignmentStatus;
+  taskId?: string;
+}
+
+/**
+ * Database executor type - supports both Pool and PoolClient
+ */
+type DbExecutor = Pool | PoolClient;
+
+/**
+ * Convert date to ISO string
+ */
+function toDateTimeString(value: unknown): string {
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'string') return value;
+  return new Date(String(value)).toISOString();
+}
+
+/**
+ * Map database row to Assignment domain object
+ */
+function mapRowToAssignment(row: TaskAssignmentRow & { created_at?: Date }): Assignment {
+  return {
+    id: row.id,
+    householdId: row.household_id,
+    taskId: row.task_id,
+    childId: row.child_id,
+    date: row.date,
+    status: row.status,
+    createdAt: row.created_at ? toDateTimeString(row.created_at) : new Date().toISOString(),
+  };
+}
+
+export class AssignmentRepository {
+  constructor(private db: DbExecutor) {}
+
+  /**
+   * Create a new instance with a different executor (for transactions)
+   */
+  withClient(client: PoolClient): AssignmentRepository {
+    return new AssignmentRepository(client);
+  }
+
+  /**
+   * Find an assignment by ID
+   */
+  async findById(assignmentId: string): Promise<Assignment | null> {
+    const result = await this.db.query<TaskAssignmentRow & { created_at: Date }>(
+      `SELECT id, household_id, task_id, child_id, date::text as date, status, created_at
+       FROM task_assignments WHERE id = $1`,
+      [assignmentId],
+    );
+
+    if (result.rows.length === 0) return null;
+    return mapRowToAssignment(result.rows[0]);
+  }
+
+  /**
+   * Find an assignment by ID with task and child details
+   */
+  async findByIdWithDetails(assignmentId: string): Promise<AssignmentWithDetails | null> {
+    const result = await this.db.query<{
+      id: string;
+      household_id: string;
+      task_id: string;
+      child_id: string | null;
+      date: string;
+      status: TaskAssignmentStatus;
+      created_at: Date;
+      task_name: string;
+      task_description: string | null;
+      task_points: number;
+      child_name: string | null;
+      completed_at: Date | null;
+    }>(
+      `SELECT
+        ta.id, ta.household_id, ta.task_id, ta.child_id, ta.date::text as date, ta.status, ta.created_at,
+        t.name as task_name, t.description as task_description, t.points as task_points,
+        c.name as child_name,
+        tc.completed_at
+      FROM task_assignments ta
+      JOIN tasks t ON ta.task_id = t.id
+      LEFT JOIN children c ON ta.child_id = c.id
+      LEFT JOIN task_completions tc ON ta.id = tc.task_assignment_id
+      WHERE ta.id = $1`,
+      [assignmentId],
+    );
+
+    if (result.rows.length === 0) return null;
+
+    const row = result.rows[0];
+    return {
+      id: row.id,
+      householdId: row.household_id,
+      taskId: row.task_id,
+      childId: row.child_id,
+      date: row.date,
+      status: row.status,
+      createdAt: toDateTimeString(row.created_at),
+      taskName: row.task_name,
+      taskDescription: row.task_description,
+      taskPoints: row.task_points,
+      childName: row.child_name,
+      completedAt: row.completed_at ? toDateTimeString(row.completed_at) : null,
+    };
+  }
+
+  /**
+   * Find assignments for a child within a date range
+   */
+  async findByChild(
+    childId: string,
+    startDate: string,
+    endDate: string,
+  ): Promise<AssignmentWithDetails[]> {
+    const result = await this.db.query<{
+      id: string;
+      household_id: string;
+      task_id: string;
+      child_id: string;
+      date: string;
+      status: TaskAssignmentStatus;
+      created_at: Date;
+      task_name: string;
+      task_description: string | null;
+      task_points: number;
+      child_name: string;
+      completed_at: Date | null;
+    }>(
+      `SELECT
+        ta.id, ta.household_id, ta.task_id, ta.child_id, ta.date::text as date, ta.status, ta.created_at,
+        t.name as task_name, t.description as task_description, t.points as task_points,
+        c.name as child_name,
+        tc.completed_at
+      FROM task_assignments ta
+      JOIN tasks t ON ta.task_id = t.id
+      LEFT JOIN children c ON ta.child_id = c.id
+      LEFT JOIN task_completions tc ON ta.id = tc.task_assignment_id
+      WHERE ta.child_id = $1 AND ta.date >= $2 AND ta.date <= $3
+      ORDER BY ta.date ASC, t.name ASC`,
+      [childId, startDate, endDate],
+    );
+
+    return result.rows.map((row) => ({
+      id: row.id,
+      householdId: row.household_id,
+      taskId: row.task_id,
+      childId: row.child_id,
+      date: row.date,
+      status: row.status,
+      createdAt: toDateTimeString(row.created_at),
+      taskName: row.task_name,
+      taskDescription: row.task_description,
+      taskPoints: row.task_points,
+      childName: row.child_name,
+      completedAt: row.completed_at ? toDateTimeString(row.completed_at) : null,
+    }));
+  }
+
+  /**
+   * Find assignments for a household within a date range
+   */
+  async findByHousehold(
+    householdId: string,
+    startDate: string,
+    endDate: string,
+    filters: AssignmentFilters = {},
+  ): Promise<AssignmentWithDetails[]> {
+    let query = `
+      SELECT
+        ta.id, ta.household_id, ta.task_id, ta.child_id, ta.date::text as date, ta.status, ta.created_at,
+        t.name as task_name, t.description as task_description, t.points as task_points,
+        c.name as child_name,
+        tc.completed_at
+      FROM task_assignments ta
+      JOIN tasks t ON ta.task_id = t.id
+      LEFT JOIN children c ON ta.child_id = c.id
+      LEFT JOIN task_completions tc ON ta.id = tc.task_assignment_id
+      WHERE ta.household_id = $1 AND ta.date >= $2 AND ta.date <= $3
+    `;
+
+    const params: string[] = [householdId, startDate, endDate];
+    let paramIndex = 4;
+
+    if (filters.childId) {
+      query += ` AND ta.child_id = $${paramIndex++}`;
+      params.push(filters.childId);
+    }
+
+    if (filters.status) {
+      query += ` AND ta.status = $${paramIndex++}`;
+      params.push(filters.status);
+    }
+
+    if (filters.taskId) {
+      query += ` AND ta.task_id = $${paramIndex++}`;
+      params.push(filters.taskId);
+    }
+
+    query += ' ORDER BY ta.date ASC, c.name ASC, t.name ASC';
+
+    const result = await this.db.query<{
+      id: string;
+      household_id: string;
+      task_id: string;
+      child_id: string | null;
+      date: string;
+      status: TaskAssignmentStatus;
+      created_at: Date;
+      task_name: string;
+      task_description: string | null;
+      task_points: number;
+      child_name: string | null;
+      completed_at: Date | null;
+    }>(query, params);
+
+    return result.rows.map((row) => ({
+      id: row.id,
+      householdId: row.household_id,
+      taskId: row.task_id,
+      childId: row.child_id,
+      date: row.date,
+      status: row.status,
+      createdAt: toDateTimeString(row.created_at),
+      taskName: row.task_name,
+      taskDescription: row.task_description,
+      taskPoints: row.task_points,
+      childName: row.child_name,
+      completedAt: row.completed_at ? toDateTimeString(row.completed_at) : null,
+    }));
+  }
+
+  /**
+   * Find pending assignments for a child
+   */
+  async findPending(childId: string): Promise<Assignment[]> {
+    const result = await this.db.query<TaskAssignmentRow & { created_at: Date }>(
+      `SELECT id, household_id, task_id, child_id, date::text as date, status, created_at
+       FROM task_assignments
+       WHERE child_id = $1 AND status = 'pending'
+       ORDER BY date ASC`,
+      [childId],
+    );
+
+    return result.rows.map(mapRowToAssignment);
+  }
+
+  /**
+   * Create a new assignment
+   */
+  async create(data: CreateAssignmentDto): Promise<Assignment> {
+    const result = await this.db.query<TaskAssignmentRow & { created_at: Date }>(
+      `INSERT INTO task_assignments (household_id, task_id, child_id, date, status)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING id, household_id, task_id, child_id, date::text as date, status, created_at`,
+      [data.householdId, data.taskId, data.childId, data.date, data.status || 'pending'],
+    );
+
+    return mapRowToAssignment(result.rows[0]);
+  }
+
+  /**
+   * Create multiple assignments in batch
+   */
+  async batchCreate(assignments: CreateAssignmentDto[]): Promise<Assignment[]> {
+    if (assignments.length === 0) return [];
+
+    const values: string[] = [];
+    const params: (string | null)[] = [];
+    let paramIndex = 1;
+
+    for (const assignment of assignments) {
+      values.push(
+        `($${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++})`,
+      );
+      params.push(
+        assignment.householdId,
+        assignment.taskId,
+        assignment.childId,
+        assignment.date,
+        assignment.status || 'pending',
+      );
+    }
+
+    const result = await this.db.query<TaskAssignmentRow & { created_at: Date }>(
+      `INSERT INTO task_assignments (household_id, task_id, child_id, date, status)
+       VALUES ${values.join(', ')}
+       ON CONFLICT (task_id, child_id, date) WHERE child_id IS NOT NULL DO NOTHING
+       RETURNING id, household_id, task_id, child_id, date::text as date, status, created_at`,
+      params,
+    );
+
+    return result.rows.map(mapRowToAssignment);
+  }
+
+  /**
+   * Update assignment status
+   */
+  async updateStatus(assignmentId: string, status: TaskAssignmentStatus): Promise<boolean> {
+    const result = await this.db.query(
+      `UPDATE task_assignments SET status = $2 WHERE id = $1 RETURNING id`,
+      [assignmentId, status],
+    );
+
+    return result.rows.length > 0;
+  }
+
+  /**
+   * Update assignment status if pending (atomic check-and-update)
+   */
+  async completeIfPending(assignmentId: string): Promise<Assignment | null> {
+    const result = await this.db.query<TaskAssignmentRow & { created_at: Date }>(
+      `UPDATE task_assignments
+       SET status = 'completed'
+       WHERE id = $1 AND status = 'pending'
+       RETURNING id, household_id, task_id, child_id, date::text as date, status, created_at`,
+      [assignmentId],
+    );
+
+    if (result.rows.length === 0) return null;
+    return mapRowToAssignment(result.rows[0]);
+  }
+
+  /**
+   * Reassign an assignment to a different child
+   */
+  async reassign(assignmentId: string, childId: string): Promise<Assignment | null> {
+    const result = await this.db.query<TaskAssignmentRow & { created_at: Date }>(
+      `UPDATE task_assignments
+       SET child_id = $2
+       WHERE id = $1 AND status = 'pending'
+       RETURNING id, household_id, task_id, child_id, date::text as date, status, created_at`,
+      [assignmentId, childId],
+    );
+
+    if (result.rows.length === 0) return null;
+    return mapRowToAssignment(result.rows[0]);
+  }
+
+  /**
+   * Delete an assignment
+   */
+  async delete(assignmentId: string): Promise<boolean> {
+    const result = await this.db.query('DELETE FROM task_assignments WHERE id = $1 RETURNING id', [
+      assignmentId,
+    ]);
+
+    return result.rows.length > 0;
+  }
+
+  /**
+   * Get household ID for an assignment
+   */
+  async getHouseholdId(assignmentId: string): Promise<string | null> {
+    const result = await this.db.query<{ household_id: string }>(
+      'SELECT household_id FROM task_assignments WHERE id = $1',
+      [assignmentId],
+    );
+
+    if (result.rows.length === 0) return null;
+    return result.rows[0].household_id;
+  }
+
+  /**
+   * Check if assignment exists for task, child, and date
+   */
+  async exists(taskId: string, childId: string | null, date: string): Promise<boolean> {
+    const result = await this.db.query(
+      childId
+        ? 'SELECT 1 FROM task_assignments WHERE task_id = $1 AND child_id = $2 AND date = $3'
+        : 'SELECT 1 FROM task_assignments WHERE task_id = $1 AND child_id IS NULL AND date = $2',
+      childId ? [taskId, childId, date] : [taskId, date],
+    );
+
+    return result.rows.length > 0;
+  }
+
+  // ============================================================================
+  // Task Completions
+  // ============================================================================
+
+  /**
+   * Create a task completion record
+   */
+  async createCompletion(data: CreateCompletionDto): Promise<TaskCompletion> {
+    const result = await this.db.query<TaskCompletionRow>(
+      `INSERT INTO task_completions (household_id, task_assignment_id, child_id, completed_at, points_earned)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING id, household_id, task_assignment_id, child_id, completed_at, points_earned`,
+      [data.householdId, data.taskAssignmentId, data.childId, data.completedAt, data.pointsEarned],
+    );
+
+    const row = result.rows[0];
+    return {
+      id: row.id,
+      householdId: row.household_id,
+      taskAssignmentId: row.task_assignment_id,
+      childId: row.child_id,
+      completedAt: toDateTimeString(row.completed_at),
+      pointsEarned: row.points_earned,
+    };
+  }
+
+  /**
+   * Find completion by assignment ID
+   */
+  async findCompletionByAssignment(assignmentId: string): Promise<TaskCompletion | null> {
+    const result = await this.db.query<TaskCompletionRow>(
+      `SELECT id, household_id, task_assignment_id, child_id, completed_at, points_earned
+       FROM task_completions WHERE task_assignment_id = $1`,
+      [assignmentId],
+    );
+
+    if (result.rows.length === 0) return null;
+
+    const row = result.rows[0];
+    return {
+      id: row.id,
+      householdId: row.household_id,
+      taskAssignmentId: row.task_assignment_id,
+      childId: row.child_id,
+      completedAt: toDateTimeString(row.completed_at),
+      pointsEarned: row.points_earned,
+    };
+  }
+
+  /**
+   * Get assignment with task points (for completion)
+   */
+  async getAssignmentWithPoints(assignmentId: string): Promise<{
+    id: string;
+    householdId: string;
+    childId: string | null;
+    taskId: string;
+    status: TaskAssignmentStatus;
+    points: number;
+  } | null> {
+    const result = await this.db.query<{
+      id: string;
+      household_id: string;
+      child_id: string | null;
+      task_id: string;
+      status: TaskAssignmentStatus;
+      points: number;
+    }>(
+      `SELECT ta.id, ta.household_id, ta.child_id, ta.task_id, ta.status, t.points
+       FROM task_assignments ta
+       JOIN tasks t ON ta.task_id = t.id
+       WHERE ta.id = $1`,
+      [assignmentId],
+    );
+
+    if (result.rows.length === 0) return null;
+
+    const row = result.rows[0];
+    return {
+      id: row.id,
+      householdId: row.household_id,
+      childId: row.child_id,
+      taskId: row.task_id,
+      status: row.status,
+      points: row.points,
+    };
+  }
+}
+
+/**
+ * Factory function for creating AssignmentRepository instances
+ */
+export function createAssignmentRepository(db: Pool | PoolClient): AssignmentRepository {
+  return new AssignmentRepository(db);
+}

--- a/apps/backend/src/repositories/child.repository.ts
+++ b/apps/backend/src/repositories/child.repository.ts
@@ -1,0 +1,342 @@
+import type { Pool, PoolClient } from 'pg';
+import type { ChildRow } from '../types/database.js';
+
+/**
+ * ChildRepository - Data access layer for children table
+ *
+ * Encapsulates all SQL queries for child operations.
+ * Services should use this repository instead of direct database access.
+ */
+
+export interface Child {
+  id: string;
+  householdId: string;
+  userId: string | null;
+  name: string;
+  birthYear: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ChildWithPoints extends Child {
+  pointsEarned: number;
+  pointsSpent: number;
+  pointsBalance: number;
+}
+
+export interface CreateChildDto {
+  householdId: string;
+  name: string;
+  birthYear?: number | null;
+  userId?: string | null;
+}
+
+export interface UpdateChildDto {
+  name?: string;
+  birthYear?: number | null;
+  userId?: string | null;
+}
+
+/**
+ * Database executor type - supports both Pool and PoolClient
+ */
+type DbExecutor = Pool | PoolClient;
+
+/**
+ * Convert date to ISO string
+ */
+function toDateTimeString(value: unknown): string {
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'string') return value;
+  return new Date(String(value)).toISOString();
+}
+
+/**
+ * Map database row to Child domain object
+ */
+function mapRowToChild(row: ChildRow): Child {
+  return {
+    id: row.id,
+    householdId: row.household_id,
+    userId: row.user_id,
+    name: row.name,
+    birthYear: row.birth_year,
+    createdAt: toDateTimeString(row.created_at),
+    updatedAt: toDateTimeString(row.updated_at),
+  };
+}
+
+export class ChildRepository {
+  constructor(private db: DbExecutor) {}
+
+  /**
+   * Create a new instance with a different executor (for transactions)
+   */
+  withClient(client: PoolClient): ChildRepository {
+    return new ChildRepository(client);
+  }
+
+  /**
+   * Find a child by ID
+   */
+  async findById(childId: string): Promise<Child | null> {
+    const result = await this.db.query<ChildRow>(
+      'SELECT id, household_id, user_id, name, birth_year, created_at, updated_at FROM children WHERE id = $1',
+      [childId],
+    );
+
+    if (result.rows.length === 0) return null;
+    return mapRowToChild(result.rows[0]);
+  }
+
+  /**
+   * Find a child by ID and household (ownership check)
+   */
+  async findByIdAndHousehold(childId: string, householdId: string): Promise<Child | null> {
+    const result = await this.db.query<ChildRow>(
+      'SELECT id, household_id, user_id, name, birth_year, created_at, updated_at FROM children WHERE id = $1 AND household_id = $2',
+      [childId, householdId],
+    );
+
+    if (result.rows.length === 0) return null;
+    return mapRowToChild(result.rows[0]);
+  }
+
+  /**
+   * Find all children for a household
+   */
+  async findByHousehold(householdId: string): Promise<Child[]> {
+    const result = await this.db.query<ChildRow>(
+      'SELECT id, household_id, user_id, name, birth_year, created_at, updated_at FROM children WHERE household_id = $1 ORDER BY name ASC',
+      [householdId],
+    );
+
+    return result.rows.map(mapRowToChild);
+  }
+
+  /**
+   * Find all children for a household with points balance
+   */
+  async findByHouseholdWithPoints(householdId: string): Promise<ChildWithPoints[]> {
+    const result = await this.db.query<
+      ChildRow & {
+        points_earned: string;
+        points_spent: string;
+        points_balance: string;
+      }
+    >(
+      `SELECT
+        c.id, c.household_id, c.user_id, c.name, c.birth_year, c.created_at, c.updated_at,
+        COALESCE(pb.points_earned, 0)::text as points_earned,
+        COALESCE(pb.points_spent, 0)::text as points_spent,
+        COALESCE(pb.points_balance, 0)::text as points_balance
+      FROM children c
+      LEFT JOIN child_points_balance pb ON c.id = pb.child_id
+      WHERE c.household_id = $1
+      ORDER BY c.name ASC`,
+      [householdId],
+    );
+
+    return result.rows.map((row) => ({
+      ...mapRowToChild(row),
+      pointsEarned: parseInt(row.points_earned, 10),
+      pointsSpent: parseInt(row.points_spent, 10),
+      pointsBalance: parseInt(row.points_balance, 10),
+    }));
+  }
+
+  /**
+   * Find a child by user ID
+   */
+  async findByUserId(userId: string): Promise<Child | null> {
+    const result = await this.db.query<ChildRow>(
+      'SELECT id, household_id, user_id, name, birth_year, created_at, updated_at FROM children WHERE user_id = $1',
+      [userId],
+    );
+
+    if (result.rows.length === 0) return null;
+    return mapRowToChild(result.rows[0]);
+  }
+
+  /**
+   * Find a child by user ID and household
+   */
+  async findByUserIdAndHousehold(userId: string, householdId: string): Promise<Child | null> {
+    const result = await this.db.query<ChildRow>(
+      'SELECT id, household_id, user_id, name, birth_year, created_at, updated_at FROM children WHERE user_id = $1 AND household_id = $2',
+      [userId, householdId],
+    );
+
+    if (result.rows.length === 0) return null;
+    return mapRowToChild(result.rows[0]);
+  }
+
+  /**
+   * Create a new child
+   */
+  async create(data: CreateChildDto): Promise<Child> {
+    const result = await this.db.query<ChildRow>(
+      `INSERT INTO children (household_id, user_id, name, birth_year)
+       VALUES ($1, $2, $3, $4)
+       RETURNING id, household_id, user_id, name, birth_year, created_at, updated_at`,
+      [data.householdId, data.userId ?? null, data.name.trim(), data.birthYear ?? null],
+    );
+
+    return mapRowToChild(result.rows[0]);
+  }
+
+  /**
+   * Update a child
+   */
+  async update(childId: string, householdId: string, data: UpdateChildDto): Promise<Child | null> {
+    const updates: string[] = [];
+    const values: (string | number | null)[] = [];
+    let paramIndex = 1;
+
+    if (data.name !== undefined) {
+      updates.push(`name = $${paramIndex++}`);
+      values.push(data.name.trim());
+    }
+    if (data.birthYear !== undefined) {
+      updates.push(`birth_year = $${paramIndex++}`);
+      values.push(data.birthYear);
+    }
+    if (data.userId !== undefined) {
+      updates.push(`user_id = $${paramIndex++}`);
+      values.push(data.userId);
+    }
+
+    if (updates.length === 0) {
+      return this.findByIdAndHousehold(childId, householdId);
+    }
+
+    updates.push('updated_at = NOW()');
+    values.push(childId, householdId);
+
+    const result = await this.db.query<ChildRow>(
+      `UPDATE children
+       SET ${updates.join(', ')}
+       WHERE id = $${paramIndex++} AND household_id = $${paramIndex}
+       RETURNING id, household_id, user_id, name, birth_year, created_at, updated_at`,
+      values,
+    );
+
+    if (result.rows.length === 0) return null;
+    return mapRowToChild(result.rows[0]);
+  }
+
+  /**
+   * Delete a child
+   */
+  async delete(childId: string, householdId: string): Promise<boolean> {
+    const result = await this.db.query(
+      'DELETE FROM children WHERE id = $1 AND household_id = $2 RETURNING id',
+      [childId, householdId],
+    );
+
+    return result.rows.length > 0;
+  }
+
+  /**
+   * Link a child to a user account
+   */
+  async linkToUser(childId: string, userId: string): Promise<boolean> {
+    const result = await this.db.query(
+      'UPDATE children SET user_id = $2, updated_at = NOW() WHERE id = $1 RETURNING id',
+      [childId, userId],
+    );
+
+    return result.rows.length > 0;
+  }
+
+  /**
+   * Unlink a child from a user account
+   */
+  async unlinkFromUser(childId: string): Promise<boolean> {
+    const result = await this.db.query(
+      'UPDATE children SET user_id = NULL, updated_at = NOW() WHERE id = $1 RETURNING id',
+      [childId],
+    );
+
+    return result.rows.length > 0;
+  }
+
+  /**
+   * Get household ID for a child
+   */
+  async getHouseholdId(childId: string): Promise<string | null> {
+    const result = await this.db.query<{ household_id: string }>(
+      'SELECT household_id FROM children WHERE id = $1',
+      [childId],
+    );
+
+    if (result.rows.length === 0) return null;
+    return result.rows[0].household_id;
+  }
+
+  /**
+   * Check if child belongs to household
+   */
+  async belongsToHousehold(childId: string, householdId: string): Promise<boolean> {
+    const result = await this.db.query(
+      'SELECT 1 FROM children WHERE id = $1 AND household_id = $2',
+      [childId, householdId],
+    );
+
+    return result.rows.length > 0;
+  }
+
+  /**
+   * Count children in household
+   */
+  async countByHousehold(householdId: string): Promise<number> {
+    const result = await this.db.query<{ count: string }>(
+      'SELECT COUNT(*) as count FROM children WHERE household_id = $1',
+      [householdId],
+    );
+
+    return parseInt(result.rows[0].count, 10);
+  }
+
+  /**
+   * Get points balance for a child
+   */
+  async getPointsBalance(childId: string): Promise<{
+    pointsEarned: number;
+    pointsSpent: number;
+    pointsBalance: number;
+  } | null> {
+    const result = await this.db.query<{
+      points_earned: string;
+      points_spent: string;
+      points_balance: string;
+    }>(
+      `SELECT
+        COALESCE(points_earned, 0)::text as points_earned,
+        COALESCE(points_spent, 0)::text as points_spent,
+        COALESCE(points_balance, 0)::text as points_balance
+      FROM child_points_balance
+      WHERE child_id = $1`,
+      [childId],
+    );
+
+    if (result.rows.length === 0) {
+      // Child exists but no points data yet
+      return { pointsEarned: 0, pointsSpent: 0, pointsBalance: 0 };
+    }
+
+    const row = result.rows[0];
+    return {
+      pointsEarned: parseInt(row.points_earned, 10),
+      pointsSpent: parseInt(row.points_spent, 10),
+      pointsBalance: parseInt(row.points_balance, 10),
+    };
+  }
+}
+
+/**
+ * Factory function for creating ChildRepository instances
+ */
+export function createChildRepository(db: Pool | PoolClient): ChildRepository {
+  return new ChildRepository(db);
+}

--- a/apps/backend/src/repositories/household.repository.ts
+++ b/apps/backend/src/repositories/household.repository.ts
@@ -1,0 +1,308 @@
+import type { Pool, PoolClient } from 'pg';
+import type { HouseholdRow, HouseholdMemberRow, HouseholdRole } from '../types/database.js';
+
+/**
+ * HouseholdRepository - Data access layer for households and household_members tables
+ *
+ * Encapsulates all SQL queries for household operations.
+ * Services should use this repository instead of direct database access.
+ */
+
+export interface Household {
+  id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface HouseholdWithCounts extends Household {
+  memberCount: number;
+  childrenCount: number;
+}
+
+export interface HouseholdMember {
+  id: string;
+  userId: string;
+  householdId: string;
+  email: string;
+  displayName: string | null;
+  role: HouseholdRole;
+  joinedAt: string;
+}
+
+export interface HouseholdListItem extends Household {
+  role: HouseholdRole;
+  memberCount: number;
+  childrenCount: number;
+  joinedAt: string;
+}
+
+export interface CreateHouseholdDto {
+  name: string;
+}
+
+/**
+ * Database executor type - supports both Pool and PoolClient
+ */
+type DbExecutor = Pool | PoolClient;
+
+/**
+ * Convert date to ISO string
+ */
+function toDateTimeString(value: unknown): string {
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'string') return value;
+  return new Date(String(value)).toISOString();
+}
+
+/**
+ * Map database row to Household domain object
+ */
+function mapRowToHousehold(row: HouseholdRow): Household {
+  return {
+    id: row.id,
+    name: row.name,
+    createdAt: toDateTimeString(row.created_at),
+    updatedAt: toDateTimeString(row.updated_at),
+  };
+}
+
+export class HouseholdRepository {
+  constructor(private db: DbExecutor) {}
+
+  /**
+   * Create a new instance with a different executor (for transactions)
+   */
+  withClient(client: PoolClient): HouseholdRepository {
+    return new HouseholdRepository(client);
+  }
+
+  /**
+   * Find a household by ID
+   */
+  async findById(householdId: string): Promise<Household | null> {
+    const result = await this.db.query<HouseholdRow>(
+      'SELECT id, name, created_at, updated_at FROM households WHERE id = $1',
+      [householdId],
+    );
+
+    if (result.rows.length === 0) return null;
+    return mapRowToHousehold(result.rows[0]);
+  }
+
+  /**
+   * Find a household with member and children counts
+   */
+  async findByIdWithCounts(householdId: string): Promise<HouseholdWithCounts | null> {
+    const result = await this.db.query<
+      HouseholdRow & { member_count: string; children_count: string }
+    >(
+      `SELECT
+        h.id, h.name, h.created_at, h.updated_at,
+        (SELECT COUNT(*) FROM household_members WHERE household_id = h.id) as member_count,
+        (SELECT COUNT(*) FROM children WHERE household_id = h.id) as children_count
+      FROM households h
+      WHERE h.id = $1`,
+      [householdId],
+    );
+
+    if (result.rows.length === 0) return null;
+
+    const row = result.rows[0];
+    return {
+      ...mapRowToHousehold(row),
+      memberCount: parseInt(row.member_count, 10),
+      childrenCount: parseInt(row.children_count, 10),
+    };
+  }
+
+  /**
+   * Create a new household
+   */
+  async create(data: CreateHouseholdDto): Promise<Household> {
+    const result = await this.db.query<HouseholdRow>(
+      'INSERT INTO households (name) VALUES ($1) RETURNING id, name, created_at, updated_at',
+      [data.name.trim()],
+    );
+
+    return mapRowToHousehold(result.rows[0]);
+  }
+
+  /**
+   * Update a household
+   */
+  async update(householdId: string, name: string): Promise<Household | null> {
+    const result = await this.db.query<HouseholdRow>(
+      'UPDATE households SET name = $1, updated_at = NOW() WHERE id = $2 RETURNING id, name, created_at, updated_at',
+      [name.trim(), householdId],
+    );
+
+    if (result.rows.length === 0) return null;
+    return mapRowToHousehold(result.rows[0]);
+  }
+
+  /**
+   * Delete a household
+   */
+  async delete(householdId: string): Promise<boolean> {
+    const result = await this.db.query('DELETE FROM households WHERE id = $1 RETURNING id', [
+      householdId,
+    ]);
+
+    return result.rows.length > 0;
+  }
+
+  /**
+   * Find all households for a user
+   */
+  async findByUserId(userId: string): Promise<HouseholdListItem[]> {
+    const result = await this.db.query<
+      HouseholdRow & {
+        role: HouseholdRole;
+        joined_at: Date;
+        member_count: string;
+        children_count: string;
+      }
+    >(
+      `SELECT
+        h.id, h.name, h.created_at, h.updated_at,
+        hm.role, hm.joined_at,
+        (SELECT COUNT(*) FROM household_members WHERE household_id = h.id) as member_count,
+        (SELECT COUNT(*) FROM children WHERE household_id = h.id) as children_count
+      FROM households h
+      JOIN household_members hm ON h.id = hm.household_id
+      WHERE hm.user_id = $1
+      ORDER BY hm.joined_at DESC`,
+      [userId],
+    );
+
+    return result.rows.map((row) => ({
+      ...mapRowToHousehold(row),
+      role: row.role,
+      memberCount: parseInt(row.member_count, 10),
+      childrenCount: parseInt(row.children_count, 10),
+      joinedAt: toDateTimeString(row.joined_at),
+    }));
+  }
+
+  // ============================================================================
+  // Household Members
+  // ============================================================================
+
+  /**
+   * Add a member to a household
+   */
+  async addMember(householdId: string, userId: string, role: HouseholdRole): Promise<void> {
+    await this.db.query(
+      'INSERT INTO household_members (household_id, user_id, role, joined_at) VALUES ($1, $2, $3, NOW())',
+      [householdId, userId, role],
+    );
+  }
+
+  /**
+   * Remove a member from a household
+   */
+  async removeMember(householdId: string, userId: string): Promise<boolean> {
+    const result = await this.db.query(
+      'DELETE FROM household_members WHERE household_id = $1 AND user_id = $2 RETURNING id',
+      [householdId, userId],
+    );
+
+    return result.rows.length > 0;
+  }
+
+  /**
+   * Update a member's role
+   */
+  async updateMemberRole(
+    householdId: string,
+    userId: string,
+    role: HouseholdRole,
+  ): Promise<boolean> {
+    const result = await this.db.query(
+      'UPDATE household_members SET role = $3 WHERE household_id = $1 AND user_id = $2 RETURNING id',
+      [householdId, userId, role],
+    );
+
+    return result.rows.length > 0;
+  }
+
+  /**
+   * Get a member's role in a household
+   */
+  async getMemberRole(userId: string, householdId: string): Promise<HouseholdRole | null> {
+    const result = await this.db.query<{ role: HouseholdRole }>(
+      'SELECT role FROM household_members WHERE household_id = $1 AND user_id = $2',
+      [householdId, userId],
+    );
+
+    if (result.rows.length === 0) return null;
+    return result.rows[0].role;
+  }
+
+  /**
+   * Get all members of a household
+   */
+  async getMembers(householdId: string): Promise<HouseholdMember[]> {
+    const result = await this.db.query<{
+      id: string;
+      user_id: string;
+      household_id: string;
+      email: string;
+      name: string | null;
+      role: HouseholdRole;
+      joined_at: Date;
+    }>(
+      `SELECT
+        hm.id, hm.user_id, hm.household_id,
+        u.email, u.name,
+        hm.role, hm.joined_at
+      FROM household_members hm
+      JOIN users u ON hm.user_id = u.id
+      WHERE hm.household_id = $1
+      ORDER BY hm.role DESC, u.email ASC`,
+      [householdId],
+    );
+
+    return result.rows.map((row) => ({
+      id: row.id,
+      userId: row.user_id,
+      householdId: row.household_id,
+      email: row.email,
+      displayName: row.name,
+      role: row.role,
+      joinedAt: toDateTimeString(row.joined_at),
+    }));
+  }
+
+  /**
+   * Count admins in a household
+   */
+  async countAdmins(householdId: string): Promise<number> {
+    const result = await this.db.query<{ count: string }>(
+      "SELECT COUNT(*) as count FROM household_members WHERE household_id = $1 AND role = 'admin'",
+      [householdId],
+    );
+
+    return parseInt(result.rows[0].count, 10);
+  }
+
+  /**
+   * Check if a user is a member of a household
+   */
+  async isMember(userId: string, householdId: string): Promise<boolean> {
+    const result = await this.db.query(
+      'SELECT 1 FROM household_members WHERE household_id = $1 AND user_id = $2',
+      [householdId, userId],
+    );
+
+    return result.rows.length > 0;
+  }
+}
+
+/**
+ * Factory function for creating HouseholdRepository instances
+ */
+export function createHouseholdRepository(db: Pool | PoolClient): HouseholdRepository {
+  return new HouseholdRepository(db);
+}

--- a/apps/backend/src/repositories/index.ts
+++ b/apps/backend/src/repositories/index.ts
@@ -1,0 +1,68 @@
+/**
+ * Repository Layer - Data Access Objects
+ *
+ * This module provides repositories that encapsulate all database queries.
+ * Services should use these repositories instead of direct database access.
+ *
+ * Benefits:
+ * - Single point of change for schema modifications
+ * - Type-safe query results
+ * - Easier testing with mockable repositories
+ * - Consistent row-to-domain mapping
+ * - Transaction support via withClient()
+ */
+
+// Task Repository
+export {
+  TaskRepository,
+  createTaskRepository,
+  type Task,
+  type TaskRuleType,
+  type CreateTaskDto,
+  type UpdateTaskDto,
+  type TaskListOptions,
+  type TaskListResult,
+} from './task.repository.js';
+
+// Household Repository
+export {
+  HouseholdRepository,
+  createHouseholdRepository,
+  type Household,
+  type HouseholdWithCounts,
+  type HouseholdMember,
+  type HouseholdListItem,
+  type CreateHouseholdDto,
+} from './household.repository.js';
+
+// Child Repository
+export {
+  ChildRepository,
+  createChildRepository,
+  type Child,
+  type ChildWithPoints,
+  type CreateChildDto,
+  type UpdateChildDto,
+} from './child.repository.js';
+
+// Assignment Repository
+export {
+  AssignmentRepository,
+  createAssignmentRepository,
+  type Assignment,
+  type AssignmentWithDetails,
+  type TaskCompletion,
+  type CreateAssignmentDto,
+  type CreateCompletionDto,
+  type AssignmentFilters,
+} from './assignment.repository.js';
+
+// User Repository
+export {
+  UserRepository,
+  createUserRepository,
+  type User,
+  type CreateUserDto,
+  type UpdateUserDto,
+  type PasswordResetToken,
+} from './user.repository.js';

--- a/apps/backend/src/repositories/task.repository.ts
+++ b/apps/backend/src/repositories/task.repository.ts
@@ -1,0 +1,375 @@
+import type { Pool, PoolClient } from 'pg';
+import type { TaskRow, TaskRuleConfig } from '../types/database.js';
+
+/**
+ * TaskRepository - Data access layer for tasks table
+ *
+ * Encapsulates all SQL queries for task operations.
+ * Services should use this repository instead of direct database access.
+ */
+
+export type TaskRuleType = 'weekly_rotation' | 'repeating' | 'daily';
+
+export interface Task {
+  id: string;
+  householdId: string;
+  name: string;
+  description: string | null;
+  points: number;
+  ruleType: TaskRuleType;
+  ruleConfig: TaskRuleConfig | null;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateTaskDto {
+  householdId: string;
+  name: string;
+  description?: string | null;
+  points?: number;
+  ruleType: TaskRuleType;
+  ruleConfig?: TaskRuleConfig | null;
+}
+
+export interface UpdateTaskDto {
+  name?: string;
+  description?: string | null;
+  points?: number;
+  ruleType?: TaskRuleType;
+  ruleConfig?: TaskRuleConfig | null;
+  active?: boolean;
+}
+
+export interface TaskListOptions {
+  active?: boolean;
+  page?: number;
+  pageSize?: number;
+  sortBy?: 'name' | 'points' | 'createdAt' | 'updatedAt';
+  sortOrder?: 'asc' | 'desc';
+}
+
+export interface TaskListResult {
+  tasks: Task[];
+  total: number;
+}
+
+/**
+ * Database executor type - supports both Pool and PoolClient
+ */
+type DbExecutor = Pool | PoolClient;
+
+/**
+ * Convert date to ISO string
+ */
+function toDateTimeString(value: unknown): string {
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'string') return value;
+  return new Date(String(value)).toISOString();
+}
+
+/**
+ * Parse rule config from database (handles JSON string or object)
+ */
+function parseRuleConfig(value: unknown): TaskRuleConfig | null {
+  if (value === null || value === undefined) return null;
+
+  let parsed: unknown = value;
+  if (typeof value === 'string') {
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) return null;
+
+  const obj = parsed as Record<string, unknown>;
+  const result: TaskRuleConfig = {};
+
+  // Handle both camelCase and snake_case
+  const rotationType = obj.rotationType ?? obj.rotation_type;
+  const repeatDays = obj.repeatDays ?? obj.repeat_days;
+  const assignedChildren = obj.assignedChildren ?? obj.assigned_children;
+
+  if (rotationType === 'odd_even_week' || rotationType === 'alternating') {
+    result.rotation_type = rotationType;
+  }
+
+  if (Array.isArray(repeatDays)) {
+    result.repeat_days = repeatDays as number[];
+  }
+
+  if (Array.isArray(assignedChildren)) {
+    result.assigned_children = assignedChildren as string[];
+  }
+
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+/**
+ * Map database row to Task domain object
+ */
+function mapRowToTask(row: TaskRow): Task {
+  return {
+    id: row.id,
+    householdId: row.household_id,
+    name: row.name,
+    description: row.description,
+    points: row.points,
+    ruleType: row.rule_type,
+    ruleConfig: parseRuleConfig(row.rule_config),
+    active: row.active,
+    createdAt: toDateTimeString(row.created_at),
+    updatedAt: toDateTimeString(row.updated_at),
+  };
+}
+
+export class TaskRepository {
+  constructor(private db: DbExecutor) {}
+
+  /**
+   * Create a new instance with a different executor (for transactions)
+   */
+  withClient(client: PoolClient): TaskRepository {
+    return new TaskRepository(client);
+  }
+
+  /**
+   * Find a task by ID
+   */
+  async findById(taskId: string): Promise<Task | null> {
+    const result = await this.db.query<TaskRow>(
+      `SELECT id, household_id, name, description, points, rule_type, rule_config, active, created_at, updated_at
+       FROM tasks WHERE id = $1`,
+      [taskId],
+    );
+
+    if (result.rows.length === 0) return null;
+    return mapRowToTask(result.rows[0]);
+  }
+
+  /**
+   * Find a task by ID and household (ownership check)
+   */
+  async findByIdAndHousehold(taskId: string, householdId: string): Promise<Task | null> {
+    const result = await this.db.query<TaskRow>(
+      `SELECT id, household_id, name, description, points, rule_type, rule_config, active, created_at, updated_at
+       FROM tasks WHERE id = $1 AND household_id = $2`,
+      [taskId, householdId],
+    );
+
+    if (result.rows.length === 0) return null;
+    return mapRowToTask(result.rows[0]);
+  }
+
+  /**
+   * Find all tasks for a household
+   */
+  async findByHousehold(householdId: string): Promise<Task[]> {
+    const result = await this.db.query<TaskRow>(
+      `SELECT id, household_id, name, description, points, rule_type, rule_config, active, created_at, updated_at
+       FROM tasks WHERE household_id = $1
+       ORDER BY created_at DESC`,
+      [householdId],
+    );
+
+    return result.rows.map(mapRowToTask);
+  }
+
+  /**
+   * Find active tasks for a household
+   */
+  async findActiveByHousehold(householdId: string): Promise<Task[]> {
+    const result = await this.db.query<TaskRow>(
+      `SELECT id, household_id, name, description, points, rule_type, rule_config, active, created_at, updated_at
+       FROM tasks WHERE household_id = $1 AND active = true
+       ORDER BY created_at DESC`,
+      [householdId],
+    );
+
+    return result.rows.map(mapRowToTask);
+  }
+
+  /**
+   * Create a new task
+   */
+  async create(data: CreateTaskDto): Promise<Task> {
+    const ruleConfigJson =
+      data.ruleConfig === null || data.ruleConfig === undefined
+        ? null
+        : JSON.stringify(data.ruleConfig);
+
+    const result = await this.db.query<TaskRow>(
+      `INSERT INTO tasks (household_id, name, description, points, rule_type, rule_config)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING id, household_id, name, description, points, rule_type, rule_config, active, created_at, updated_at`,
+      [
+        data.householdId,
+        data.name.trim(),
+        data.description ?? null,
+        data.points ?? 10,
+        data.ruleType,
+        ruleConfigJson,
+      ],
+    );
+
+    return mapRowToTask(result.rows[0]);
+  }
+
+  /**
+   * Update a task
+   */
+  async update(taskId: string, householdId: string, data: UpdateTaskDto): Promise<Task | null> {
+    const updates: string[] = [];
+    const values: (string | number | boolean | null)[] = [];
+    let paramIndex = 1;
+
+    if (data.name !== undefined) {
+      updates.push(`name = $${paramIndex++}`);
+      values.push(data.name.trim());
+    }
+    if (data.description !== undefined) {
+      updates.push(`description = $${paramIndex++}`);
+      values.push(data.description ?? null);
+    }
+    if (data.points !== undefined) {
+      updates.push(`points = $${paramIndex++}`);
+      values.push(data.points);
+    }
+    if (data.ruleType !== undefined) {
+      updates.push(`rule_type = $${paramIndex++}`);
+      values.push(data.ruleType);
+    }
+    if (data.ruleConfig !== undefined) {
+      updates.push(`rule_config = $${paramIndex++}`);
+      values.push(data.ruleConfig === null ? null : JSON.stringify(data.ruleConfig));
+    }
+    if (data.active !== undefined) {
+      updates.push(`active = $${paramIndex++}`);
+      values.push(data.active);
+    }
+
+    if (updates.length === 0) {
+      return this.findByIdAndHousehold(taskId, householdId);
+    }
+
+    updates.push('updated_at = NOW()');
+    values.push(taskId, householdId);
+
+    const result = await this.db.query<TaskRow>(
+      `UPDATE tasks
+       SET ${updates.join(', ')}
+       WHERE id = $${paramIndex++} AND household_id = $${paramIndex}
+       RETURNING id, household_id, name, description, points, rule_type, rule_config, active, created_at, updated_at`,
+      values,
+    );
+
+    if (result.rows.length === 0) return null;
+    return mapRowToTask(result.rows[0]);
+  }
+
+  /**
+   * Soft delete a task (set active = false)
+   */
+  async deactivate(taskId: string, householdId: string): Promise<boolean> {
+    const result = await this.db.query(
+      `UPDATE tasks SET active = false, updated_at = NOW()
+       WHERE id = $1 AND household_id = $2
+       RETURNING id`,
+      [taskId, householdId],
+    );
+
+    return result.rows.length > 0;
+  }
+
+  /**
+   * List tasks with filtering, sorting, and pagination
+   */
+  async list(householdId: string, options: TaskListOptions = {}): Promise<TaskListResult> {
+    const { active, page = 1, pageSize = 20, sortBy = 'createdAt', sortOrder = 'desc' } = options;
+
+    // Build base query
+    let whereClause = 'household_id = $1';
+    const countParams: (string | boolean)[] = [householdId];
+    const dataParams: (string | boolean | number)[] = [householdId];
+
+    if (active !== undefined) {
+      whereClause += ' AND active = $2';
+      countParams.push(active);
+      dataParams.push(active);
+    }
+
+    // Get total count
+    const countResult = await this.db.query<{ count: string }>(
+      `SELECT COUNT(*) as count FROM tasks WHERE ${whereClause}`,
+      countParams,
+    );
+    const total = parseInt(countResult.rows[0].count, 10);
+
+    // Map sort fields
+    const sortFieldMap: Record<string, string> = {
+      name: 'name',
+      points: 'points',
+      createdAt: 'created_at',
+      updatedAt: 'updated_at',
+    };
+    const sortField = sortFieldMap[sortBy] || 'created_at';
+    const order = sortOrder === 'asc' ? 'ASC' : 'DESC';
+
+    // Calculate pagination
+    const offset = (page - 1) * pageSize;
+    const limitParamIndex = dataParams.length + 1;
+    const offsetParamIndex = dataParams.length + 2;
+    dataParams.push(pageSize, offset);
+
+    const dataResult = await this.db.query<TaskRow>(
+      `SELECT id, household_id, name, description, points, rule_type, rule_config, active, created_at, updated_at
+       FROM tasks WHERE ${whereClause}
+       ORDER BY ${sortField} ${order}
+       LIMIT $${limitParamIndex} OFFSET $${offsetParamIndex}`,
+      dataParams,
+    );
+
+    return {
+      tasks: dataResult.rows.map(mapRowToTask),
+      total,
+    };
+  }
+
+  /**
+   * Count children that belong to a household
+   * Used for validation in services
+   */
+  async countChildrenInHousehold(childIds: string[], householdId: string): Promise<number> {
+    if (childIds.length === 0) return 0;
+
+    const result = await this.db.query<{ count: string }>(
+      'SELECT COUNT(*) as count FROM children WHERE id = ANY($1) AND household_id = $2',
+      [childIds, householdId],
+    );
+
+    return parseInt(result.rows[0].count, 10);
+  }
+
+  /**
+   * Get household ID for a task
+   */
+  async getHouseholdId(taskId: string): Promise<string | null> {
+    const result = await this.db.query<{ household_id: string }>(
+      'SELECT household_id FROM tasks WHERE id = $1',
+      [taskId],
+    );
+
+    if (result.rows.length === 0) return null;
+    return result.rows[0].household_id;
+  }
+}
+
+/**
+ * Factory function for creating TaskRepository instances
+ */
+export function createTaskRepository(db: Pool | PoolClient): TaskRepository {
+  return new TaskRepository(db);
+}

--- a/apps/backend/src/repositories/user.repository.ts
+++ b/apps/backend/src/repositories/user.repository.ts
@@ -1,0 +1,336 @@
+import type { Pool, PoolClient } from 'pg';
+import type { UserRow, PasswordResetTokenRow } from '../types/database.js';
+
+/**
+ * UserRepository - Data access layer for users and password_reset_tokens tables
+ *
+ * Encapsulates all SQL queries for user operations.
+ * Services should use this repository instead of direct database access.
+ */
+
+export interface User {
+  id: string;
+  email: string;
+  name: string | null;
+  passwordHash: string | null;
+  oauthProvider: string | null;
+  oauthProviderId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateUserDto {
+  email: string;
+  name?: string | null;
+  passwordHash?: string | null;
+  oauthProvider?: string | null;
+  oauthProviderId?: string | null;
+}
+
+export interface UpdateUserDto {
+  email?: string;
+  name?: string | null;
+  passwordHash?: string | null;
+  oauthProvider?: string | null;
+  oauthProviderId?: string | null;
+}
+
+export interface PasswordResetToken {
+  id: string;
+  userId: string;
+  token: string;
+  expiresAt: string;
+  used: boolean;
+  createdAt: string;
+}
+
+/**
+ * Database executor type - supports both Pool and PoolClient
+ */
+type DbExecutor = Pool | PoolClient;
+
+/**
+ * Convert date to ISO string
+ */
+function toDateTimeString(value: unknown): string {
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'string') return value;
+  return new Date(String(value)).toISOString();
+}
+
+/**
+ * Map database row to User domain object
+ */
+function mapRowToUser(row: UserRow): User {
+  return {
+    id: row.id,
+    email: row.email,
+    name: row.name,
+    passwordHash: row.password_hash,
+    oauthProvider: row.oauth_provider,
+    oauthProviderId: row.oauth_provider_id,
+    createdAt: toDateTimeString(row.created_at),
+    updatedAt: toDateTimeString(row.updated_at),
+  };
+}
+
+/**
+ * Map database row to PasswordResetToken domain object
+ */
+function mapRowToPasswordResetToken(row: PasswordResetTokenRow): PasswordResetToken {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    token: row.token,
+    expiresAt: toDateTimeString(row.expires_at),
+    used: row.used,
+    createdAt: toDateTimeString(row.created_at),
+  };
+}
+
+export class UserRepository {
+  constructor(private db: DbExecutor) {}
+
+  /**
+   * Create a new instance with a different executor (for transactions)
+   */
+  withClient(client: PoolClient): UserRepository {
+    return new UserRepository(client);
+  }
+
+  /**
+   * Find a user by ID
+   */
+  async findById(userId: string): Promise<User | null> {
+    const result = await this.db.query<UserRow>(
+      `SELECT id, email, name, password_hash, oauth_provider, oauth_provider_id, created_at, updated_at
+       FROM users WHERE id = $1`,
+      [userId],
+    );
+
+    if (result.rows.length === 0) return null;
+    return mapRowToUser(result.rows[0]);
+  }
+
+  /**
+   * Find a user by email
+   */
+  async findByEmail(email: string): Promise<User | null> {
+    const result = await this.db.query<UserRow>(
+      `SELECT id, email, name, password_hash, oauth_provider, oauth_provider_id, created_at, updated_at
+       FROM users WHERE email = $1`,
+      [email.toLowerCase()],
+    );
+
+    if (result.rows.length === 0) return null;
+    return mapRowToUser(result.rows[0]);
+  }
+
+  /**
+   * Find a user by OAuth provider and provider ID
+   */
+  async findByOAuth(provider: string, providerId: string): Promise<User | null> {
+    const result = await this.db.query<UserRow>(
+      `SELECT id, email, name, password_hash, oauth_provider, oauth_provider_id, created_at, updated_at
+       FROM users WHERE oauth_provider = $1 AND oauth_provider_id = $2`,
+      [provider, providerId],
+    );
+
+    if (result.rows.length === 0) return null;
+    return mapRowToUser(result.rows[0]);
+  }
+
+  /**
+   * Create a new user
+   */
+  async create(data: CreateUserDto): Promise<User> {
+    const result = await this.db.query<UserRow>(
+      `INSERT INTO users (email, name, password_hash, oauth_provider, oauth_provider_id)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING id, email, name, password_hash, oauth_provider, oauth_provider_id, created_at, updated_at`,
+      [
+        data.email.toLowerCase(),
+        data.name ?? null,
+        data.passwordHash ?? null,
+        data.oauthProvider ?? null,
+        data.oauthProviderId ?? null,
+      ],
+    );
+
+    return mapRowToUser(result.rows[0]);
+  }
+
+  /**
+   * Update a user
+   */
+  async update(userId: string, data: UpdateUserDto): Promise<User | null> {
+    const updates: string[] = [];
+    const values: (string | null)[] = [];
+    let paramIndex = 1;
+
+    if (data.email !== undefined) {
+      updates.push(`email = $${paramIndex++}`);
+      values.push(data.email.toLowerCase());
+    }
+    if (data.name !== undefined) {
+      updates.push(`name = $${paramIndex++}`);
+      values.push(data.name);
+    }
+    if (data.passwordHash !== undefined) {
+      updates.push(`password_hash = $${paramIndex++}`);
+      values.push(data.passwordHash);
+    }
+    if (data.oauthProvider !== undefined) {
+      updates.push(`oauth_provider = $${paramIndex++}`);
+      values.push(data.oauthProvider);
+    }
+    if (data.oauthProviderId !== undefined) {
+      updates.push(`oauth_provider_id = $${paramIndex++}`);
+      values.push(data.oauthProviderId);
+    }
+
+    if (updates.length === 0) {
+      return this.findById(userId);
+    }
+
+    updates.push('updated_at = NOW()');
+    values.push(userId);
+
+    const result = await this.db.query<UserRow>(
+      `UPDATE users
+       SET ${updates.join(', ')}
+       WHERE id = $${paramIndex}
+       RETURNING id, email, name, password_hash, oauth_provider, oauth_provider_id, created_at, updated_at`,
+      values,
+    );
+
+    if (result.rows.length === 0) return null;
+    return mapRowToUser(result.rows[0]);
+  }
+
+  /**
+   * Update user's password
+   */
+  async updatePassword(userId: string, passwordHash: string): Promise<boolean> {
+    const result = await this.db.query(
+      `UPDATE users SET password_hash = $2, updated_at = NOW() WHERE id = $1 RETURNING id`,
+      [userId, passwordHash],
+    );
+
+    return result.rows.length > 0;
+  }
+
+  /**
+   * Delete a user
+   */
+  async delete(userId: string): Promise<boolean> {
+    const result = await this.db.query('DELETE FROM users WHERE id = $1 RETURNING id', [userId]);
+
+    return result.rows.length > 0;
+  }
+
+  /**
+   * Check if email exists
+   */
+  async emailExists(email: string): Promise<boolean> {
+    const result = await this.db.query('SELECT 1 FROM users WHERE email = $1', [
+      email.toLowerCase(),
+    ]);
+
+    return result.rows.length > 0;
+  }
+
+  // ============================================================================
+  // Password Reset Tokens
+  // ============================================================================
+
+  /**
+   * Create a password reset token
+   */
+  async createPasswordResetToken(
+    userId: string,
+    token: string,
+    expiresAt: Date,
+  ): Promise<PasswordResetToken> {
+    const result = await this.db.query<PasswordResetTokenRow>(
+      `INSERT INTO password_reset_tokens (user_id, token, expires_at)
+       VALUES ($1, $2, $3)
+       RETURNING id, user_id, token, expires_at, used, created_at`,
+      [userId, token, expiresAt],
+    );
+
+    return mapRowToPasswordResetToken(result.rows[0]);
+  }
+
+  /**
+   * Find a valid (unused, not expired) password reset token
+   */
+  async findValidPasswordResetToken(token: string): Promise<PasswordResetToken | null> {
+    const result = await this.db.query<PasswordResetTokenRow>(
+      `SELECT id, user_id, token, expires_at, used, created_at
+       FROM password_reset_tokens
+       WHERE token = $1 AND used = false AND expires_at > NOW()`,
+      [token],
+    );
+
+    if (result.rows.length === 0) return null;
+    return mapRowToPasswordResetToken(result.rows[0]);
+  }
+
+  /**
+   * Mark a password reset token as used
+   */
+  async markPasswordResetTokenUsed(tokenId: string): Promise<boolean> {
+    const result = await this.db.query(
+      'UPDATE password_reset_tokens SET used = true WHERE id = $1 RETURNING id',
+      [tokenId],
+    );
+
+    return result.rows.length > 0;
+  }
+
+  /**
+   * Delete expired password reset tokens for a user
+   */
+  async deleteExpiredPasswordResetTokens(userId: string): Promise<number> {
+    const result = await this.db.query(
+      'DELETE FROM password_reset_tokens WHERE user_id = $1 AND (used = true OR expires_at <= NOW()) RETURNING id',
+      [userId],
+    );
+
+    return result.rows.length;
+  }
+
+  /**
+   * Delete all password reset tokens for a user
+   */
+  async deleteAllPasswordResetTokens(userId: string): Promise<number> {
+    const result = await this.db.query(
+      'DELETE FROM password_reset_tokens WHERE user_id = $1 RETURNING id',
+      [userId],
+    );
+
+    return result.rows.length;
+  }
+
+  /**
+   * Get user ID by password reset token
+   */
+  async getUserIdByPasswordResetToken(token: string): Promise<string | null> {
+    const result = await this.db.query<{ user_id: string }>(
+      `SELECT user_id FROM password_reset_tokens
+       WHERE token = $1 AND used = false AND expires_at > NOW()`,
+      [token],
+    );
+
+    if (result.rows.length === 0) return null;
+    return result.rows[0].user_id;
+  }
+}
+
+/**
+ * Factory function for creating UserRepository instances
+ */
+export function createUserRepository(db: Pool | PoolClient): UserRepository {
+  return new UserRepository(db);
+}


### PR DESCRIPTION
## Summary

Creates a repository/DAO layer in `apps/backend/src/repositories/` with domain-specific repositories that encapsulate all SQL queries. This provides a foundation for cleaner data access patterns and easier testing.

### Changes

- **TaskRepository**: CRUD operations for tasks table with typed queries
- **HouseholdRepository**: Household and household_members operations  
- **ChildRepository**: Child profile management with points balance
- **AssignmentRepository**: Task assignments and completions
- **UserRepository**: User accounts and password reset tokens

### Benefits

- **Single point of change**: Schema modifications only touch repository files
- **Type safety**: Query results properly typed with compile-time checks
- **Transaction support**: `withClient()` method enables transaction composition
- **Caching ready**: Can add caching layer in repositories without touching services
- **Testability**: Services can mock repositories easily for unit testing

### Implementation Notes

The repository layer can be adopted incrementally - existing services continue to work with direct database access while new code can use the repositories. This allows gradual migration without risk of regressions.

Each repository supports both `Pool` and `PoolClient` for transaction support:
```typescript
const repo = createTaskRepository(pool);
const task = await repo.findById(taskId);

// For transactions:
const client = await pool.connect();
const txRepo = repo.withClient(client);
await txRepo.create(data);
```

## Test plan

- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [x] Types package tests pass (`npm run test:types`)
- [ ] Backend integration tests pass (requires test database configuration fix - pre-existing issue)

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)