### PR TITLE
feat(backend): add unit tests for repositories and test scripts (#289)

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -9,6 +9,8 @@
     "predev": "cd ../../packages/types && npm run build",
     "pretest": "cd ../../packages/types && npm run build",
     "test": "cross-env NODE_ENV=test tsx --test src/**/*.test.ts",
+    "test:unit": "tsx --test src/repositories/*.test.ts src/utils/*.test.ts",
+    "test:integration": "cross-env NODE_ENV=test tsx --test src/routes/*.test.ts",
     "test:coverage": "c8 npm test",
     "test:coverage:report": "c8 report --reporter=text --reporter=lcov",
     "type-check": "tsc --noEmit",

--- a/apps/backend/src/repositories/household.repository.test.ts
+++ b/apps/backend/src/repositories/household.repository.test.ts
@@ -1,0 +1,421 @@
+/**
+ * HouseholdRepository Unit Tests
+ *
+ * Tests the HouseholdRepository using mocked database connections.
+ * No actual database is required to run these tests.
+ */
+
+import { describe, it, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { HouseholdRepository, type CreateHouseholdDto } from './household.repository.js';
+
+// Mock Pool implementation
+function createMockPool() {
+  const queryMock = mock.fn();
+  return {
+    query: queryMock,
+    connect: mock.fn(),
+    end: mock.fn(),
+  };
+}
+
+// Sample household row data
+const sampleHouseholdRow = {
+  id: '123e4567-e89b-12d3-a456-426614174000',
+  name: 'Test Household',
+  created_at: new Date('2024-01-01T00:00:00Z'),
+  updated_at: new Date('2024-01-01T00:00:00Z'),
+};
+
+const sampleMemberRow = {
+  id: 'member-123',
+  user_id: 'user-123',
+  household_id: sampleHouseholdRow.id,
+  email: 'test@example.com',
+  name: 'Test User',
+  role: 'admin' as const,
+  joined_at: new Date('2024-01-01T00:00:00Z'),
+};
+
+describe('HouseholdRepository', () => {
+  let pool: ReturnType<typeof createMockPool>;
+  let repository: HouseholdRepository;
+
+  beforeEach(() => {
+    pool = createMockPool();
+    repository = new HouseholdRepository(pool as never);
+  });
+
+  describe('findById', () => {
+    it('should return a household when found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleHouseholdRow],
+        rowCount: 1,
+      }));
+
+      const result = await repository.findById(sampleHouseholdRow.id);
+
+      assert.ok(result);
+      assert.equal(result.id, sampleHouseholdRow.id);
+      assert.equal(result.name, sampleHouseholdRow.name);
+      assert.equal(typeof result.createdAt, 'string');
+      assert.equal(typeof result.updatedAt, 'string');
+    });
+
+    it('should return null when household not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.findById('non-existent-id');
+
+      assert.equal(result, null);
+    });
+  });
+
+  describe('findByIdWithCounts', () => {
+    it('should return household with member and children counts', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [
+          {
+            ...sampleHouseholdRow,
+            member_count: '3',
+            children_count: '2',
+          },
+        ],
+        rowCount: 1,
+      }));
+
+      const result = await repository.findByIdWithCounts(sampleHouseholdRow.id);
+
+      assert.ok(result);
+      assert.equal(result.id, sampleHouseholdRow.id);
+      assert.equal(result.memberCount, 3);
+      assert.equal(result.childrenCount, 2);
+    });
+
+    it('should return null when household not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.findByIdWithCounts('non-existent-id');
+
+      assert.equal(result, null);
+    });
+  });
+
+  describe('create', () => {
+    it('should create a new household', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleHouseholdRow],
+        rowCount: 1,
+      }));
+
+      const data: CreateHouseholdDto = {
+        name: 'New Household',
+      };
+
+      const result = await repository.create(data);
+
+      assert.ok(result);
+      assert.equal(pool.query.mock.callCount(), 1);
+      const call = pool.query.mock.calls[0];
+      assert.ok(call.arguments[0].includes('INSERT INTO households'));
+    });
+
+    it('should trim household name', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleHouseholdRow],
+        rowCount: 1,
+      }));
+
+      await repository.create({ name: '  Untrimmed Name  ' });
+
+      const call = pool.query.mock.calls[0];
+      const params = call.arguments[1] as unknown[];
+      assert.equal(params[0], 'Untrimmed Name');
+    });
+  });
+
+  describe('update', () => {
+    it('should update household name', async () => {
+      const updatedRow = { ...sampleHouseholdRow, name: 'Updated Name' };
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [updatedRow],
+        rowCount: 1,
+      }));
+
+      const result = await repository.update(sampleHouseholdRow.id, 'Updated Name');
+
+      assert.ok(result);
+      assert.equal(result.name, 'Updated Name');
+    });
+
+    it('should return null when household not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.update('non-existent', 'New Name');
+
+      assert.equal(result, null);
+    });
+  });
+
+  describe('delete', () => {
+    it('should return true when household is deleted', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ id: sampleHouseholdRow.id }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.delete(sampleHouseholdRow.id);
+
+      assert.equal(result, true);
+    });
+
+    it('should return false when household not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.delete('non-existent');
+
+      assert.equal(result, false);
+    });
+  });
+
+  describe('findByUserId', () => {
+    it('should return all households for a user', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [
+          {
+            ...sampleHouseholdRow,
+            role: 'admin' as const,
+            joined_at: new Date(),
+            member_count: '2',
+            children_count: '1',
+          },
+          {
+            ...sampleHouseholdRow,
+            id: 'household-2',
+            name: 'Second Household',
+            role: 'parent' as const,
+            joined_at: new Date(),
+            member_count: '3',
+            children_count: '2',
+          },
+        ],
+        rowCount: 2,
+      }));
+
+      const result = await repository.findByUserId('user-123');
+
+      assert.equal(result.length, 2);
+      assert.equal(result[0].name, 'Test Household');
+      assert.equal(result[0].role, 'admin');
+      assert.equal(result[1].name, 'Second Household');
+      assert.equal(result[1].role, 'parent');
+    });
+
+    it('should return empty array when user has no households', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.findByUserId('user-with-no-households');
+
+      assert.deepEqual(result, []);
+    });
+  });
+
+  describe('addMember', () => {
+    it('should add a member to a household', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 1,
+      }));
+
+      await repository.addMember(sampleHouseholdRow.id, 'user-123', 'parent');
+
+      assert.equal(pool.query.mock.callCount(), 1);
+      const call = pool.query.mock.calls[0];
+      assert.ok(call.arguments[0].includes('INSERT INTO household_members'));
+      const params = call.arguments[1] as unknown[];
+      assert.equal(params[0], sampleHouseholdRow.id);
+      assert.equal(params[1], 'user-123');
+      assert.equal(params[2], 'parent');
+    });
+  });
+
+  describe('removeMember', () => {
+    it('should return true when member is removed', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ id: 'member-id' }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.removeMember(sampleHouseholdRow.id, 'user-123');
+
+      assert.equal(result, true);
+    });
+
+    it('should return false when member not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.removeMember(sampleHouseholdRow.id, 'non-existent');
+
+      assert.equal(result, false);
+    });
+  });
+
+  describe('updateMemberRole', () => {
+    it('should return true when role is updated', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ id: 'member-id' }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.updateMemberRole(sampleHouseholdRow.id, 'user-123', 'parent');
+
+      assert.equal(result, true);
+    });
+
+    it('should return false when member not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.updateMemberRole(
+        sampleHouseholdRow.id,
+        'non-existent',
+        'parent',
+      );
+
+      assert.equal(result, false);
+    });
+  });
+
+  describe('getMemberRole', () => {
+    it('should return role when member exists', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ role: 'admin' }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.getMemberRole('user-123', sampleHouseholdRow.id);
+
+      assert.equal(result, 'admin');
+    });
+
+    it('should return null when member not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.getMemberRole('non-existent', sampleHouseholdRow.id);
+
+      assert.equal(result, null);
+    });
+  });
+
+  describe('getMembers', () => {
+    it('should return all members of a household', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [
+          sampleMemberRow,
+          {
+            ...sampleMemberRow,
+            id: 'member-456',
+            user_id: 'user-456',
+            email: 'member@example.com',
+            name: 'Member User',
+            role: 'parent',
+          },
+        ],
+        rowCount: 2,
+      }));
+
+      const result = await repository.getMembers(sampleHouseholdRow.id);
+
+      assert.equal(result.length, 2);
+      assert.equal(result[0].email, 'test@example.com');
+      assert.equal(result[0].role, 'admin');
+      assert.equal(result[1].email, 'member@example.com');
+      assert.equal(result[1].role, 'parent');
+    });
+
+    it('should return empty array when household has no members', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.getMembers('empty-household');
+
+      assert.deepEqual(result, []);
+    });
+  });
+
+  describe('countAdmins', () => {
+    it('should return count of admins', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ count: '2' }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.countAdmins(sampleHouseholdRow.id);
+
+      assert.equal(result, 2);
+    });
+  });
+
+  describe('isMember', () => {
+    it('should return true when user is a member', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ 1: 1 }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.isMember('user-123', sampleHouseholdRow.id);
+
+      assert.equal(result, true);
+    });
+
+    it('should return false when user is not a member', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.isMember('non-member', sampleHouseholdRow.id);
+
+      assert.equal(result, false);
+    });
+  });
+
+  describe('withClient', () => {
+    it('should create new repository with different executor', () => {
+      const mockClient = {
+        query: mock.fn(),
+        release: mock.fn(),
+      };
+
+      const clientRepo = repository.withClient(mockClient as never);
+
+      assert.ok(clientRepo instanceof HouseholdRepository);
+      assert.notEqual(clientRepo, repository);
+    });
+  });
+});

--- a/apps/backend/src/repositories/task.repository.test.ts
+++ b/apps/backend/src/repositories/task.repository.test.ts
@@ -1,0 +1,474 @@
+/**
+ * TaskRepository Unit Tests
+ *
+ * Tests the TaskRepository using mocked database connections.
+ * No actual database is required to run these tests.
+ */
+
+import { describe, it, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { TaskRepository, type CreateTaskDto, type UpdateTaskDto } from './task.repository.js';
+
+// Mock Pool implementation
+function createMockPool() {
+  const queryMock = mock.fn();
+  return {
+    query: queryMock,
+    connect: mock.fn(),
+    end: mock.fn(),
+  };
+}
+
+// Sample task row data
+const sampleTaskRow = {
+  id: '123e4567-e89b-12d3-a456-426614174000',
+  household_id: '123e4567-e89b-12d3-a456-426614174001',
+  name: 'Test Task',
+  description: 'A test task description',
+  points: 10,
+  rule_type: 'daily' as const,
+  rule_config: null,
+  active: true,
+  created_at: new Date('2024-01-01T00:00:00Z'),
+  updated_at: new Date('2024-01-01T00:00:00Z'),
+};
+
+describe('TaskRepository', () => {
+  let pool: ReturnType<typeof createMockPool>;
+  let repository: TaskRepository;
+
+  beforeEach(() => {
+    pool = createMockPool();
+    repository = new TaskRepository(pool as never);
+  });
+
+  describe('findById', () => {
+    it('should return a task when found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleTaskRow],
+        rowCount: 1,
+      }));
+
+      const result = await repository.findById(sampleTaskRow.id);
+
+      assert.ok(result);
+      assert.equal(result.id, sampleTaskRow.id);
+      assert.equal(result.householdId, sampleTaskRow.household_id);
+      assert.equal(result.name, sampleTaskRow.name);
+      assert.equal(result.points, sampleTaskRow.points);
+      assert.equal(result.ruleType, sampleTaskRow.rule_type);
+      assert.equal(result.active, true);
+    });
+
+    it('should return null when task not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.findById('non-existent-id');
+
+      assert.equal(result, null);
+    });
+
+    it('should call query with correct parameters', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      await repository.findById('test-id');
+
+      assert.equal(pool.query.mock.callCount(), 1);
+      const call = pool.query.mock.calls[0];
+      assert.ok(call.arguments[0].includes('FROM tasks WHERE id = $1'));
+      assert.deepEqual(call.arguments[1], ['test-id']);
+    });
+  });
+
+  describe('findByIdAndHousehold', () => {
+    it('should return task when found with matching household', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleTaskRow],
+        rowCount: 1,
+      }));
+
+      const result = await repository.findByIdAndHousehold(
+        sampleTaskRow.id,
+        sampleTaskRow.household_id,
+      );
+
+      assert.ok(result);
+      assert.equal(result.id, sampleTaskRow.id);
+    });
+
+    it('should return null when household does not match', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.findByIdAndHousehold(sampleTaskRow.id, 'wrong-household');
+
+      assert.equal(result, null);
+    });
+  });
+
+  describe('findByHousehold', () => {
+    it('should return all tasks for a household', async () => {
+      const secondTask = { ...sampleTaskRow, id: 'task-2', name: 'Second Task' };
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleTaskRow, secondTask],
+        rowCount: 2,
+      }));
+
+      const result = await repository.findByHousehold(sampleTaskRow.household_id);
+
+      assert.equal(result.length, 2);
+      assert.equal(result[0].name, 'Test Task');
+      assert.equal(result[1].name, 'Second Task');
+    });
+
+    it('should return empty array when no tasks found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.findByHousehold('household-with-no-tasks');
+
+      assert.deepEqual(result, []);
+    });
+  });
+
+  describe('findActiveByHousehold', () => {
+    it('should only return active tasks', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleTaskRow],
+        rowCount: 1,
+      }));
+
+      await repository.findActiveByHousehold(sampleTaskRow.household_id);
+
+      const call = pool.query.mock.calls[0];
+      assert.ok(call.arguments[0].includes('active = true'));
+    });
+  });
+
+  describe('create', () => {
+    it('should create a new task with default values', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleTaskRow],
+        rowCount: 1,
+      }));
+
+      const data: CreateTaskDto = {
+        householdId: sampleTaskRow.household_id,
+        name: 'New Task',
+        ruleType: 'daily',
+      };
+
+      const result = await repository.create(data);
+
+      assert.ok(result);
+      assert.equal(pool.query.mock.callCount(), 1);
+      const call = pool.query.mock.calls[0];
+      assert.ok(call.arguments[0].includes('INSERT INTO tasks'));
+    });
+
+    it('should create task with all provided values', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [
+          {
+            ...sampleTaskRow,
+            description: 'Custom description',
+            points: 25,
+            rule_config: { rotation_type: 'odd_even_week' },
+          },
+        ],
+        rowCount: 1,
+      }));
+
+      const data: CreateTaskDto = {
+        householdId: sampleTaskRow.household_id,
+        name: 'Task with config',
+        description: 'Custom description',
+        points: 25,
+        ruleType: 'weekly_rotation',
+        ruleConfig: { rotation_type: 'odd_even_week' },
+      };
+
+      const result = await repository.create(data);
+
+      assert.ok(result);
+      const call = pool.query.mock.calls[0];
+      const params = call.arguments[1] as unknown[];
+      assert.equal(params[2], 'Custom description');
+      assert.equal(params[3], 25);
+    });
+
+    it('should trim task name', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleTaskRow],
+        rowCount: 1,
+      }));
+
+      const data: CreateTaskDto = {
+        householdId: sampleTaskRow.household_id,
+        name: '  Untrimmed Name  ',
+        ruleType: 'daily',
+      };
+
+      await repository.create(data);
+
+      const call = pool.query.mock.calls[0];
+      const params = call.arguments[1] as unknown[];
+      assert.equal(params[1], 'Untrimmed Name');
+    });
+  });
+
+  describe('update', () => {
+    it('should update task with provided fields', async () => {
+      const updatedRow = { ...sampleTaskRow, name: 'Updated Name', points: 20 };
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [updatedRow],
+        rowCount: 1,
+      }));
+
+      const data: UpdateTaskDto = {
+        name: 'Updated Name',
+        points: 20,
+      };
+
+      const result = await repository.update(sampleTaskRow.id, sampleTaskRow.household_id, data);
+
+      assert.ok(result);
+      assert.equal(result.name, 'Updated Name');
+      assert.equal(result.points, 20);
+    });
+
+    it('should return null when task not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.update('non-existent', 'household-id', { name: 'New Name' });
+
+      assert.equal(result, null);
+    });
+
+    it('should return existing task when no fields to update', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleTaskRow],
+        rowCount: 1,
+      }));
+
+      const result = await repository.update(sampleTaskRow.id, sampleTaskRow.household_id, {});
+
+      assert.ok(result);
+      // Should call findByIdAndHousehold, not UPDATE
+      assert.equal(pool.query.mock.callCount(), 1);
+    });
+  });
+
+  describe('deactivate', () => {
+    it('should return true when task is deactivated', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ id: sampleTaskRow.id }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.deactivate(sampleTaskRow.id, sampleTaskRow.household_id);
+
+      assert.equal(result, true);
+      const call = pool.query.mock.calls[0];
+      assert.ok(call.arguments[0].includes('active = false'));
+    });
+
+    it('should return false when task not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.deactivate('non-existent', 'household-id');
+
+      assert.equal(result, false);
+    });
+  });
+
+  describe('list', () => {
+    it('should return paginated results', async () => {
+      // First call for count, second for data
+      let callCount = 0;
+      pool.query.mock.mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return { rows: [{ count: '10' }], rowCount: 1 };
+        }
+        return { rows: [sampleTaskRow], rowCount: 1 };
+      });
+
+      const result = await repository.list(sampleTaskRow.household_id, {
+        page: 1,
+        pageSize: 5,
+      });
+
+      assert.equal(result.total, 10);
+      assert.equal(result.tasks.length, 1);
+    });
+
+    it('should filter by active status', async () => {
+      let callCount = 0;
+      pool.query.mock.mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return { rows: [{ count: '5' }], rowCount: 1 };
+        }
+        return { rows: [sampleTaskRow], rowCount: 1 };
+      });
+
+      await repository.list(sampleTaskRow.household_id, { active: true });
+
+      const call = pool.query.mock.calls[0];
+      assert.ok(call.arguments[0].includes('active = $2'));
+    });
+
+    it('should apply sorting', async () => {
+      let callCount = 0;
+      pool.query.mock.mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return { rows: [{ count: '5' }], rowCount: 1 };
+        }
+        return { rows: [sampleTaskRow], rowCount: 1 };
+      });
+
+      await repository.list(sampleTaskRow.household_id, {
+        sortBy: 'name',
+        sortOrder: 'asc',
+      });
+
+      const dataCall = pool.query.mock.calls[1];
+      assert.ok(dataCall.arguments[0].includes('ORDER BY name ASC'));
+    });
+  });
+
+  describe('countChildrenInHousehold', () => {
+    it('should return count of children in household', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ count: '3' }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.countChildrenInHousehold(
+        ['child-1', 'child-2', 'child-3'],
+        sampleTaskRow.household_id,
+      );
+
+      assert.equal(result, 3);
+    });
+
+    it('should return 0 for empty child array', async () => {
+      const result = await repository.countChildrenInHousehold([], sampleTaskRow.household_id);
+
+      assert.equal(result, 0);
+      assert.equal(pool.query.mock.callCount(), 0);
+    });
+  });
+
+  describe('getHouseholdId', () => {
+    it('should return household ID for a task', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ household_id: sampleTaskRow.household_id }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.getHouseholdId(sampleTaskRow.id);
+
+      assert.equal(result, sampleTaskRow.household_id);
+    });
+
+    it('should return null when task not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.getHouseholdId('non-existent');
+
+      assert.equal(result, null);
+    });
+  });
+
+  describe('withClient', () => {
+    it('should create new repository with different executor', () => {
+      const mockClient = {
+        query: mock.fn(),
+        release: mock.fn(),
+      };
+
+      const clientRepo = repository.withClient(mockClient as never);
+
+      assert.ok(clientRepo instanceof TaskRepository);
+      assert.notEqual(clientRepo, repository);
+    });
+  });
+
+  describe('rule config parsing', () => {
+    it('should parse rule config from JSON string', async () => {
+      const rowWithJsonConfig = {
+        ...sampleTaskRow,
+        rule_type: 'weekly_rotation' as const,
+        rule_config: JSON.stringify({ rotation_type: 'odd_even_week' }),
+      };
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [rowWithJsonConfig],
+        rowCount: 1,
+      }));
+
+      const result = await repository.findById(sampleTaskRow.id);
+
+      assert.ok(result);
+      assert.ok(result.ruleConfig);
+      assert.equal(result.ruleConfig.rotation_type, 'odd_even_week');
+    });
+
+    it('should handle camelCase rule config', async () => {
+      const rowWithCamelCase = {
+        ...sampleTaskRow,
+        rule_type: 'repeating' as const,
+        rule_config: { repeatDays: [1, 3, 5] },
+      };
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [rowWithCamelCase],
+        rowCount: 1,
+      }));
+
+      const result = await repository.findById(sampleTaskRow.id);
+
+      assert.ok(result);
+      assert.ok(result.ruleConfig);
+      assert.deepEqual(result.ruleConfig.repeat_days, [1, 3, 5]);
+    });
+
+    it('should handle snake_case rule config', async () => {
+      const rowWithSnakeCase = {
+        ...sampleTaskRow,
+        rule_type: 'weekly_rotation' as const,
+        rule_config: { assigned_children: ['child-1', 'child-2'] },
+      };
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [rowWithSnakeCase],
+        rowCount: 1,
+      }));
+
+      const result = await repository.findById(sampleTaskRow.id);
+
+      assert.ok(result);
+      assert.ok(result.ruleConfig);
+      assert.deepEqual(result.ruleConfig.assigned_children, ['child-1', 'child-2']);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit tests for the new repository layer with mocked database connections. This enables fast, isolated testing without requiring a database.

### Changes

- **TaskRepository unit tests** (26 tests)
  - Tests all CRUD operations
  - Tests pagination and filtering
  - Tests rule config parsing (JSON string, camelCase, snake_case)
  
- **HouseholdRepository unit tests** (26 tests)
  - Tests household CRUD operations
  - Tests member management (add, remove, update role)
  - Tests household queries with counts

- **Updated package.json scripts**
  - `npm run test:unit` - Run unit tests only (no database required)
  - `npm run test:integration` - Run integration tests (requires database)

### Benefits

- Fast test execution (no database roundtrip)
- Better test isolation
- Easier to test edge cases and error conditions
- Foundation for expanding unit test coverage

### Testing

```bash
# Run unit tests (no database needed)
cd apps/backend && npm run test:unit
# 101 tests pass (52 repository + 49 utility)
```

## Test plan

- [x] All unit tests pass locally (`npm run test:unit`)
- [x] TypeScript compiles without errors
- [ ] CI passes

Part of #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)