### PR TITLE
fix(frontend): align navigation breakpoints for tablet support

### DIFF
--- a/apps/frontend/src/app/components/navigation/bottom-nav/bottom-nav.css
+++ b/apps/frontend/src/app/components/navigation/bottom-nav/bottom-nav.css
@@ -56,8 +56,8 @@
   line-height: 1.2;
 }
 
-/* Hide bottom nav on desktop (>= 1024px) */
-@media (min-width: 1024px) {
+/* Hide bottom nav on tablet and desktop (>= 768px) */
+@media (min-width: 768px) {
   .bottom-nav {
     display: none;
   }

--- a/apps/frontend/src/app/components/navigation/sidebar-nav/sidebar-nav.css
+++ b/apps/frontend/src/app/components/navigation/sidebar-nav/sidebar-nav.css
@@ -209,8 +209,8 @@
   right: 0;
 }
 
-/* Show sidebar on desktop (>= 1024px) */
-@media (min-width: 1024px) {
+/* Show sidebar on tablet and desktop (>= 768px) */
+@media (min-width: 768px) {
   .sidebar-nav {
     display: flex;
   }


### PR DESCRIPTION
## Summary
Closes #310

The navigation was broken between 768px and 1024px because:
- main-layout.css: switched from bottom nav to sidebar at 768px
- sidebar-nav.css: showed sidebar only at 1024px
- bottom-nav.css: hid bottom nav only at 1024px

This created a 768px-1024px gap where no navigation was visible.

## Changes
- sidebar-nav.css: Show sidebar at 768px instead of 1024px
- bottom-nav.css: Hide bottom nav at 768px instead of 1024px

## Result
All breakpoints are aligned at 768px:
- Mobile (<768px): Bottom navigation
- Tablet/Desktop (≥768px): Sidebar navigation

## Test plan
- [ ] Test at 375px width - bottom nav visible
- [ ] Test at 767px width - bottom nav visible
- [ ] Test at 768px width - sidebar visible, no bottom nav
- [ ] Test at 900px width - sidebar visible
- [ ] Test at 1024px width - sidebar visible
- [ ] Test at 1280px width - sidebar visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)