### PR TITLE
fix(frontend): pre-load children for quick-add modal

### DIFF
--- a/apps/frontend/src/app/layouts/main-layout/main-layout.ts
+++ b/apps/frontend/src/app/layouts/main-layout/main-layout.ts
@@ -96,6 +96,9 @@ export class MainLayout implements OnInit, OnDestroy {
         const household = households[0];
         this.householdId.set(household.id);
         this.householdName.set(household.name);
+
+        // Pre-load children for quick-add modal
+        await this.loadChildren();
       }
     } catch (err) {
       console.error('Failed to load household data:', err);
@@ -152,9 +155,10 @@ export class MainLayout implements OnInit, OnDestroy {
   /**
    * Open quick-add modal
    */
-  protected openQuickAdd(): void {
+  protected async openQuickAdd(): Promise<void> {
+    // Ensure children are loaded before opening modal
     if (this.children().length === 0) {
-      this.loadChildren();
+      await this.loadChildren();
     }
     this.quickAddOpen.set(true);
   }


### PR DESCRIPTION
## Summary
Closes #307

The quick-add modal was showing an empty "Assign to" dropdown because:
1. Children were only loaded when opening the modal
2. loadChildren() was called but not awaited
3. Modal opened before children finished loading

## Changes
- Pre-load children in loadHouseholdData() after getting household
- Make openQuickAdd() async and await loadChildren() if needed
- Ensures children are always available when modal opens

## Test plan
- [ ] Open quick-add modal (FAB button or sidebar button)
- [ ] Verify "Assign to" dropdown shows list of children
- [ ] Create task and verify it's assigned to selected child

🤖 Generated with [Claude Code](https://claude.com/claude-code)