### PR TITLE
fix(frontend): add mobile header with settings and household switcher

### DIFF
--- a/apps/frontend/src/app/layouts/main-layout/main-layout.css
+++ b/apps/frontend/src/app/layouts/main-layout/main-layout.css
@@ -24,6 +24,62 @@
   padding-bottom: 80px; /* Space for bottom nav on mobile */
 }
 
+/* Mobile header - shown on mobile only */
+.mobile-header {
+  position: sticky;
+  top: 0;
+  background: #ffffff;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  z-index: 50;
+  padding: 12px 16px;
+}
+
+.mobile-header-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 100%;
+}
+
+.mobile-logo {
+  font-family: var(--font-heading, 'Fredoka', sans-serif);
+  font-size: 24px;
+  font-weight: 700;
+  background: linear-gradient(135deg, #6366f1 0%, #ec4899 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.mobile-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.settings-btn {
+  width: 40px;
+  height: 40px;
+  border: none;
+  background: transparent;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  transition: background 0.2s ease;
+}
+
+.settings-btn:hover {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.settings-btn:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+}
+
 /* Bottom navigation container */
 .bottom-nav-container {
   position: fixed;
@@ -74,6 +130,10 @@
   .main-content {
     margin-left: 280px;
     padding-bottom: 0; /* No bottom nav on desktop */
+  }
+
+  .mobile-header {
+    display: none; /* Hide mobile header on desktop */
   }
 
   .bottom-nav-container {

--- a/apps/frontend/src/app/layouts/main-layout/main-layout.html
+++ b/apps/frontend/src/app/layouts/main-layout/main-layout.html
@@ -12,6 +12,24 @@
 
   <!-- Main Content Area -->
   <div class="main-content">
+    <!-- Mobile Header (Mobile only) -->
+    <header class="mobile-header">
+      <div class="mobile-header-content">
+        <div class="mobile-logo">Diddit!</div>
+        <div class="mobile-header-actions">
+          <app-household-switcher />
+          <button
+            type="button"
+            class="settings-btn"
+            (click)="onSettings()"
+            aria-label="Open settings"
+          >
+            ⚙️
+          </button>
+        </div>
+      </div>
+    </header>
+
     <!-- Router Outlet for Page Content -->
     <router-outlet />
 

--- a/apps/frontend/src/app/layouts/main-layout/main-layout.ts
+++ b/apps/frontend/src/app/layouts/main-layout/main-layout.ts
@@ -11,6 +11,7 @@ import { Router, RouterOutlet, NavigationEnd } from '@angular/router';
 import { filter, Subscription } from 'rxjs';
 import { BottomNav } from '../../components/navigation/bottom-nav/bottom-nav';
 import { SidebarNav } from '../../components/navigation/sidebar-nav/sidebar-nav';
+import { HouseholdSwitcherComponent } from '../../components/household-switcher/household-switcher';
 import {
   QuickAddModal,
   type QuickAddTaskData,
@@ -37,7 +38,7 @@ import type { Child } from '@st44/types';
  */
 @Component({
   selector: 'app-main-layout',
-  imports: [RouterOutlet, BottomNav, SidebarNav, QuickAddModal],
+  imports: [RouterOutlet, BottomNav, SidebarNav, HouseholdSwitcherComponent, QuickAddModal],
   templateUrl: './main-layout.html',
   styleUrl: './main-layout.css',
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
## Summary
Closes #311

Mobile users couldn't access settings or switch households because these features only existed in the sidebar (hidden on mobile).

## Changes
- Add mobile header component to main-layout
- Header includes app logo, household switcher, and settings button
- Header is visible on mobile only (hidden on tablet/desktop)
- Settings button navigates to /settings page
- Household switcher uses existing component for consistency

## Result
Mobile now has feature parity with desktop:
- Mobile (<768px): Mobile header + bottom navigation
- Tablet/Desktop (≥768px): Sidebar navigation with all features

## Test plan
- [ ] Test on mobile (375px width) - header visible with logo, switcher, settings
- [ ] Test on tablet (768px width) - header hidden, sidebar visible
- [ ] Click settings button - navigates to /settings
- [ ] Click household switcher - dropdown works, can switch households

🤖 Generated with [Claude Code](https://claude.com/claude-code)