### PR TITLE
feat(frontend): auto-activate household on login

### DIFF
--- a/apps/frontend/src/app/auth/login.spec.ts
+++ b/apps/frontend/src/app/auth/login.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { LoginComponent } from './login';
 import { AuthService } from '../services/auth.service';
+import { HouseholdService } from '../services/household.service';
 import { Router, ActivatedRoute, provideRouter } from '@angular/router';
 import { of, throwError } from 'rxjs';
 import { provideHttpClient } from '@angular/common/http';
@@ -11,6 +12,7 @@ describe('LoginComponent', () => {
   let component: LoginComponent;
   let fixture: ComponentFixture<LoginComponent>;
   let mockAuthService: { login: ReturnType<typeof vi.fn> };
+  let mockHouseholdService: { autoActivateHousehold: ReturnType<typeof vi.fn> };
   let router: Router;
   let mockActivatedRoute: {
     snapshot: {
@@ -28,6 +30,10 @@ describe('LoginComponent', () => {
       login: vi.fn(),
     };
 
+    mockHouseholdService = {
+      autoActivateHousehold: vi.fn().mockResolvedValue(undefined),
+    };
+
     mockActivatedRoute = {
       snapshot: {
         queryParams: {},
@@ -41,6 +47,7 @@ describe('LoginComponent', () => {
         provideHttpClientTesting(),
         provideRouter([]), // Provides a real Router for testing
         { provide: AuthService, useValue: mockAuthService },
+        { provide: HouseholdService, useValue: mockHouseholdService },
         { provide: ActivatedRoute, useValue: mockActivatedRoute },
       ],
     });

--- a/apps/frontend/src/app/auth/login.ts
+++ b/apps/frontend/src/app/auth/login.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormGroup, FormControl, Validators } from '@angular/forms';
 import { Router, RouterLink, ActivatedRoute } from '@angular/router';
 import { AuthService } from '../services/auth.service';
+import { HouseholdService } from '../services/household.service';
 import { lastValueFrom } from 'rxjs';
 import { environment } from '../../environments/environment.development';
 
@@ -19,6 +20,7 @@ interface GoogleSignInResponse {
 })
 export class LoginComponent implements OnInit {
   private readonly authService = inject(AuthService);
+  private readonly householdService = inject(HouseholdService);
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
 
@@ -60,6 +62,9 @@ export class LoginComponent implements OnInit {
     try {
       await lastValueFrom(this.authService.loginWithGoogle(response.credential));
 
+      // Auto-activate household after successful login
+      await this.householdService.autoActivateHousehold();
+
       // Success - navigate to return URL or home
       const returnUrl = this.route.snapshot.queryParams['returnUrl'] || '/home';
       this.router.navigateByUrl(returnUrl);
@@ -85,6 +90,9 @@ export class LoginComponent implements OnInit {
     try {
       const { email, password, rememberMe } = this.loginForm.value;
       await lastValueFrom(this.authService.login(email!, password!, rememberMe || false));
+
+      // Auto-activate household after successful login
+      await this.householdService.autoActivateHousehold();
 
       // Success - navigate to return URL or home
       const returnUrl = this.route.snapshot.queryParams['returnUrl'] || '/home';


### PR DESCRIPTION
## Summary
Closes #322

When a user logs in, automatically set an active household:
1. If a previously selected household is stored and still valid, keep it
2. If no stored household or it's invalid, select the first household
3. If user has no households, clear any stale selection

## Changes
- Add `autoActivateHousehold()` method to HouseholdService
- Call `autoActivateHousehold()` after successful login (email and Google)
- Update login tests to mock HouseholdService

## Logic
```
1. Get stored household ID from localStorage
2. Fetch user's households from API
3. If no households: clear stored ID, return
4. If stored ID is valid: keep it active
5. Otherwise: select first household as active
```

## Test plan
- [ ] Login with one household - auto-selects it
- [ ] Login with multiple households - auto-selects first (or last used if stored)
- [ ] Login after switching households - remembers last selection
- [ ] Login with no households - works without error
- [ ] All frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)