### PR TITLE
feat(frontend): add child selection to EditTaskModal for repeating and rotation tasks

### DIFF
--- a/apps/frontend/src/app/components/modals/edit-task-modal/edit-task-modal.css
+++ b/apps/frontend/src/app/components/modals/edit-task-modal/edit-task-modal.css
@@ -23,3 +23,64 @@
   margin-bottom: var(--space-lg);
   line-height: var(--line-height-relaxed);
 }
+
+/* Day and child selection fieldsets */
+.day-fieldset,
+.child-fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.day-selector,
+.children-selector {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  margin-top: var(--space-xs);
+}
+
+.day-checkbox,
+.child-checkbox {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-xs) var(--space-sm);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  transition:
+    background-color 0.2s,
+    border-color 0.2s;
+}
+
+.day-checkbox:hover,
+.child-checkbox:hover {
+  background: var(--color-surface-hover);
+}
+
+.day-checkbox:has(input:checked),
+.child-checkbox:has(input:checked) {
+  background: var(--color-primary-light);
+  border-color: var(--color-primary);
+}
+
+.day-checkbox input,
+.child-checkbox input {
+  width: auto;
+  margin: 0;
+}
+
+.help-text {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  font-weight: normal;
+}
+
+.no-children-message {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  font-style: italic;
+}

--- a/apps/frontend/src/app/components/modals/edit-task-modal/edit-task-modal.html
+++ b/apps/frontend/src/app/components/modals/edit-task-modal/edit-task-modal.html
@@ -70,6 +70,87 @@
         </select>
       </div>
 
+      <!-- Repeat Days (shown if repeating) -->
+      @if (ruleType === 'repeating') {
+        <div class="form-group">
+          <fieldset class="day-fieldset">
+            <legend class="form-label">Repeat On *</legend>
+            <div class="day-selector" role="group" aria-label="Select days">
+              @for (day of daysOfWeek; track day.value) {
+                <label class="day-checkbox">
+                  <input
+                    type="checkbox"
+                    [checked]="isDaySelected(day.value)"
+                    (change)="onDayChange(day.value, $any($event.target).checked)"
+                    [attr.aria-label]="'Repeat on ' + day.label"
+                  />
+                  {{ day.label }}
+                </label>
+              }
+            </div>
+            @if (form.controls.repeatDays.invalid && form.controls.repeatDays.touched) {
+              <div class="form-error" role="alert">Select at least one day</div>
+            }
+          </fieldset>
+        </div>
+      }
+
+      <!-- Rotation Type (shown if weekly_rotation) -->
+      @if (ruleType === 'weekly_rotation') {
+        <div class="form-group">
+          <label class="form-label" for="edit-rotation-type">Rotation Type *</label>
+          <select
+            id="edit-rotation-type"
+            class="form-select"
+            formControlName="rotationType"
+            [class.error]="form.controls.rotationType.invalid && form.controls.rotationType.touched"
+          >
+            @for (option of rotationOptions; track option.value) {
+              <option [value]="option.value">{{ option.label }}</option>
+            }
+          </select>
+        </div>
+      }
+
+      <!-- Assigned Children (shown for repeating and weekly_rotation) -->
+      @if (ruleType !== 'daily') {
+        <div class="form-group">
+          <fieldset class="child-fieldset">
+            <legend class="form-label">
+              Assign to Children *
+              @if (ruleType === 'weekly_rotation') {
+                <span class="help-text">(Select 2+ for rotation)</span>
+              }
+            </legend>
+            <div class="children-selector" role="group" aria-label="Assign children">
+              @for (child of children(); track child.id) {
+                <label class="child-checkbox">
+                  <input
+                    type="checkbox"
+                    [checked]="isChildSelected(child.id)"
+                    (change)="onChildChange(child.id, $any($event.target).checked)"
+                    [attr.aria-label]="'Assign to ' + child.name"
+                  />
+                  {{ child.name }}
+                </label>
+              }
+              @if (children().length === 0) {
+                <p class="no-children-message">No children in this household yet.</p>
+              }
+            </div>
+            @if (form.controls.assignedChildren.invalid && form.controls.assignedChildren.touched) {
+              <div class="form-error" role="alert">
+                @if (ruleType === 'weekly_rotation') {
+                  Select at least 2 children for rotation
+                } @else {
+                  Select at least 1 child
+                }
+              </div>
+            }
+          </fieldset>
+        </div>
+      }
+
       <div class="modal-actions-split" modal-actions>
         <button type="button" class="btn btn-danger" (click)="onDeleteClick()">Delete</button>
         <div class="modal-actions-right">

--- a/apps/frontend/src/app/components/modals/edit-task-modal/edit-task-modal.ts
+++ b/apps/frontend/src/app/components/modals/edit-task-modal/edit-task-modal.ts
@@ -7,9 +7,17 @@ import {
   effect,
   ChangeDetectionStrategy,
 } from '@angular/core';
-import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import {
+  FormBuilder,
+  ReactiveFormsModule,
+  Validators,
+  FormArray,
+  AbstractControl,
+} from '@angular/forms';
 import { Modal } from '../modal/modal';
-import type { Task, TaskRuleType } from '@st44/types';
+import type { Task, TaskRuleType, TaskRuleConfig, Child } from '@st44/types';
+import { ChildrenService } from '../../../services/children.service';
+import { HouseholdService } from '../../../services/household.service';
 
 /**
  * Data structure for edit task submission
@@ -18,6 +26,7 @@ export interface EditTaskData {
   name: string;
   points: number;
   ruleType: TaskRuleType;
+  ruleConfig?: TaskRuleConfig;
 }
 
 /**
@@ -69,12 +78,43 @@ export class EditTaskModal {
   private readonly fb = inject(FormBuilder);
 
   /**
+   * Children service
+   */
+  private readonly childrenService = inject(ChildrenService);
+
+  /**
+   * Household service
+   */
+  private readonly householdService = inject(HouseholdService);
+
+  /**
+   * Available children for assignment
+   */
+  protected readonly children = signal<Child[]>([]);
+
+  /**
+   * Days of week for repeating tasks
+   */
+  protected readonly daysOfWeek = [
+    { value: 0, label: 'Sun' },
+    { value: 1, label: 'Mon' },
+    { value: 2, label: 'Tue' },
+    { value: 3, label: 'Wed' },
+    { value: 4, label: 'Thu' },
+    { value: 5, label: 'Fri' },
+    { value: 6, label: 'Sat' },
+  ];
+
+  /**
    * Form group for edit task
    */
   protected readonly form = this.fb.group({
     name: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(255)]],
     points: [5, [Validators.required, Validators.min(1), Validators.max(1000)]],
     ruleType: ['daily' as TaskRuleType, [Validators.required]],
+    rotationType: ['alternating' as 'odd_even_week' | 'alternating'],
+    repeatDays: this.fb.array<number>([]),
+    assignedChildren: this.fb.array<string>([]),
   });
 
   /**
@@ -96,19 +136,181 @@ export class EditTaskModal {
     { value: 'weekly_rotation', label: 'Weekly Rotation' },
   ];
 
+  /**
+   * Rotation type options
+   */
+  protected readonly rotationOptions: { value: 'odd_even_week' | 'alternating'; label: string }[] =
+    [
+      { value: 'alternating', label: 'Alternating' },
+      { value: 'odd_even_week', label: 'Odd/Even Week' },
+    ];
+
   constructor() {
     // Update form when task changes
     effect(() => {
       const currentTask = this.task();
       if (currentTask) {
-        this.form.patchValue({
-          name: currentTask.name,
-          points: currentTask.points,
-          ruleType: currentTask.ruleType,
-        });
+        this.prefillForm(currentTask);
         this.showDeleteConfirm.set(false);
       }
     });
+
+    // Update validators when rule type changes
+    this.form.get('ruleType')?.valueChanges.subscribe((ruleType) => {
+      this.updateValidators(ruleType);
+    });
+
+    // Load children on init
+    this.loadChildren();
+  }
+
+  /**
+   * Load children from current household
+   */
+  private async loadChildren(): Promise<void> {
+    const householdId = this.householdService.getActiveHouseholdId();
+    if (householdId) {
+      try {
+        const childrenList = await this.childrenService.listChildren(householdId);
+        this.children.set(childrenList);
+      } catch (error) {
+        console.error('Failed to load children:', error);
+      }
+    }
+  }
+
+  /**
+   * Prefill form with task data
+   */
+  private prefillForm(task: Task): void {
+    // Clear arrays
+    (this.form.get('repeatDays') as FormArray).clear();
+    (this.form.get('assignedChildren') as FormArray).clear();
+
+    // Get rule config
+    const ruleConfig = task.ruleConfig || {};
+    const repeatDays = ruleConfig.repeatDays || [];
+    const assignedChildren = ruleConfig.assignedChildren || [];
+    const rotationType = ruleConfig.rotationType || 'alternating';
+
+    // Populate repeatDays FormArray
+    const repeatDaysArray = this.form.get('repeatDays') as FormArray;
+    repeatDays.forEach((day: number) => repeatDaysArray.push(this.fb.control(day)));
+
+    // Populate assignedChildren FormArray
+    const assignedChildrenArray = this.form.get('assignedChildren') as FormArray;
+    assignedChildren.forEach((childId: string) =>
+      assignedChildrenArray.push(this.fb.control(childId)),
+    );
+
+    // Set form values
+    this.form.patchValue({
+      name: task.name,
+      points: task.points,
+      ruleType: task.ruleType,
+      rotationType: rotationType,
+    });
+
+    // Update validators for current rule type
+    this.updateValidators(task.ruleType);
+  }
+
+  /**
+   * Update validators based on rule type
+   */
+  private updateValidators(ruleType: TaskRuleType | null): void {
+    const rotationType = this.form.get('rotationType');
+    const repeatDays = this.form.get('repeatDays');
+    const assignedChildren = this.form.get('assignedChildren');
+
+    // Clear all conditional validators
+    rotationType?.clearValidators();
+    repeatDays?.clearValidators();
+    assignedChildren?.clearValidators();
+
+    // Apply validators based on rule type
+    if (ruleType === 'weekly_rotation') {
+      rotationType?.setValidators(Validators.required);
+      assignedChildren?.setValidators([Validators.required, this.minArrayLengthValidator(2)]);
+    } else if (ruleType === 'repeating') {
+      repeatDays?.setValidators([Validators.required, this.minArrayLengthValidator(1)]);
+      assignedChildren?.setValidators([Validators.required, this.minArrayLengthValidator(1)]);
+    }
+
+    // Update validity
+    rotationType?.updateValueAndValidity();
+    repeatDays?.updateValueAndValidity();
+    assignedChildren?.updateValueAndValidity();
+  }
+
+  /**
+   * Validator for minimum array length
+   */
+  private minArrayLengthValidator(minLength: number) {
+    return (control: AbstractControl) => {
+      const arr = control.value as FormArray | unknown[];
+      const length = Array.isArray(arr) ? arr.length : 0;
+      return length >= minLength ? null : { minLength: { required: minLength, actual: length } };
+    };
+  }
+
+  /**
+   * Handle day selection change
+   */
+  onDayChange(dayValue: number, checked: boolean): void {
+    const repeatDays = this.form.get('repeatDays') as FormArray;
+
+    if (checked) {
+      repeatDays.push(this.fb.control(dayValue));
+    } else {
+      const index = repeatDays.controls.findIndex((ctrl) => ctrl.value === dayValue);
+      if (index >= 0) {
+        repeatDays.removeAt(index);
+      }
+    }
+
+    repeatDays.updateValueAndValidity();
+  }
+
+  /**
+   * Handle child selection change
+   */
+  onChildChange(childId: string, checked: boolean): void {
+    const assignedChildren = this.form.get('assignedChildren') as FormArray;
+
+    if (checked) {
+      assignedChildren.push(this.fb.control(childId));
+    } else {
+      const index = assignedChildren.controls.findIndex((ctrl) => ctrl.value === childId);
+      if (index >= 0) {
+        assignedChildren.removeAt(index);
+      }
+    }
+
+    assignedChildren.updateValueAndValidity();
+  }
+
+  /**
+   * Check if day is selected
+   */
+  isDaySelected(dayValue: number): boolean {
+    const repeatDays = this.form.get('repeatDays') as FormArray;
+    return repeatDays.controls.some((ctrl) => ctrl.value === dayValue);
+  }
+
+  /**
+   * Check if child is selected
+   */
+  isChildSelected(childId: string): boolean {
+    const assignedChildren = this.form.get('assignedChildren') as FormArray;
+    return assignedChildren.controls.some((ctrl) => ctrl.value === childId);
+  }
+
+  /**
+   * Get current rule type
+   */
+  protected get ruleType(): TaskRuleType | null {
+    return this.form.get('ruleType')?.value || null;
   }
 
   /**
@@ -120,13 +322,39 @@ export class EditTaskModal {
     }
 
     const formValue = this.form.value;
+    const ruleType = formValue.ruleType!;
+
+    // Build rule config based on rule type
+    const ruleConfig = this.buildRuleConfig(ruleType);
 
     // Emit updated task data
     this.taskUpdated.emit({
       name: formValue.name!.trim(),
       points: formValue.points!,
-      ruleType: formValue.ruleType!,
+      ruleType,
+      ruleConfig,
     });
+  }
+
+  /**
+   * Build rule config based on current form state
+   */
+  private buildRuleConfig(ruleType: TaskRuleType): TaskRuleConfig {
+    if (ruleType === 'repeating') {
+      return {
+        repeatDays: (this.form.get('repeatDays') as FormArray).value as number[],
+        assignedChildren: (this.form.get('assignedChildren') as FormArray).value as string[],
+      };
+    }
+
+    if (ruleType === 'weekly_rotation') {
+      return {
+        rotationType: this.form.get('rotationType')?.value as 'odd_even_week' | 'alternating',
+        assignedChildren: (this.form.get('assignedChildren') as FormArray).value as string[],
+      };
+    }
+
+    return null;
   }
 
   /**


### PR DESCRIPTION
## Summary

- Add child selection UI to EditTaskModal for repeating and weekly_rotation tasks
- Load children from current household using ChildrenService
- Add day selection UI for repeating tasks
- Add rotation type selection for weekly_rotation tasks
- Add validation (min 1 child for repeating, min 2 for rotation)
- Include ruleConfig in EditTaskData interface
- Pre-populate selections when editing existing tasks

This enables full task configuration when editing task templates, matching the functionality already present in TaskCreateComponent.

## Test plan

- [ ] Edit a task and change rule type to "Repeating"
  - [ ] Day selection checkboxes appear
  - [ ] At least one day must be selected
  - [ ] Child selection checkboxes appear
  - [ ] At least one child must be selected
  - [ ] Saving task includes repeatDays and assignedChildren in ruleConfig
- [ ] Edit a task and change rule type to "Weekly Rotation"
  - [ ] Rotation type dropdown appears (Alternating, Odd/Even Week)
  - [ ] Child selection checkboxes appear
  - [ ] At least two children must be selected
  - [ ] Saving task includes rotationType and assignedChildren in ruleConfig
- [ ] Edit an existing repeating task
  - [ ] Days are pre-selected correctly
  - [ ] Children are pre-selected correctly
- [ ] Edit a task and change rule type back to "Daily"
  - [ ] Day/child selection disappears
  - [ ] Saving works without ruleConfig

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)