### PR TITLE
feat(backend, frontend): add member stats to Family page

### DIFF
--- a/apps/frontend/src/app/pages/family/family.spec.ts
+++ b/apps/frontend/src/app/pages/family/family.spec.ts
@@ -28,6 +28,9 @@ describe('Family', () => {
       displayName: 'Test User',
       role: 'parent',
       joinedAt: new Date().toISOString(),
+      tasksCompleted: 0,
+      totalTasks: 0,
+      points: 0,
     },
     {
       userId: 'user-2',
@@ -35,6 +38,9 @@ describe('Family', () => {
       displayName: 'Test Child',
       role: 'child',
       joinedAt: new Date().toISOString(),
+      tasksCompleted: 3,
+      totalTasks: 5,
+      points: 150,
     },
   ];
 
@@ -137,7 +143,7 @@ describe('Family', () => {
     });
 
     it('should use email username when displayName is null', async () => {
-      const membersWithoutDisplayName = [
+      const membersWithoutDisplayName: HouseholdMember[] = [
         {
           ...mockMembers[0],
           displayName: null,
@@ -159,6 +165,20 @@ describe('Family', () => {
 
       const otherMember = component['members']().find((m) => m.id === 'user-2');
       expect(otherMember?.name).not.toContain('(You)');
+    });
+
+    it('should pass through task stats and points from backend', async () => {
+      await component.ngOnInit();
+
+      const childMember = component['members']().find((m) => m.id === 'user-2');
+      expect(childMember?.tasksCompleted).toBe(3);
+      expect(childMember?.totalTasks).toBe(5);
+      expect(childMember?.points).toBe(150);
+
+      const parentMember = component['members']().find((m) => m.id === 'user-1');
+      expect(parentMember?.tasksCompleted).toBe(0);
+      expect(parentMember?.totalTasks).toBe(0);
+      expect(parentMember?.points).toBe(0);
     });
   });
 

--- a/apps/frontend/src/app/pages/family/family.ts
+++ b/apps/frontend/src/app/pages/family/family.ts
@@ -91,11 +91,10 @@ export class Family implements OnInit {
       this.householdId.set(household.id);
       this.householdName.set(household.name);
 
-      // Load household members
+      // Load household members with stats
       const householdMembers = await this.householdService.getHouseholdMembers(household.id);
 
       // Transform HouseholdMember[] to MemberCardData[]
-      // TODO: Get actual task/points data from backend
       const memberCards: MemberCardData[] = householdMembers.map((member) => {
         const isCurrentUser = member.userId === user.id;
         const displayName = isCurrentUser
@@ -107,9 +106,10 @@ export class Family implements OnInit {
           name: displayName,
           email: member.email,
           role: member.role === 'child' ? 'child' : 'parent',
-          tasksCompleted: 0, // TODO: Get from backend
-          totalTasks: 0, // TODO: Get from backend
-          points: 0, // TODO: Get from backend
+          // Use real stats from backend
+          tasksCompleted: member.tasksCompleted,
+          totalTasks: member.totalTasks,
+          points: member.points,
         };
       });
 

--- a/apps/frontend/src/app/services/household.service.ts
+++ b/apps/frontend/src/app/services/household.service.ts
@@ -28,6 +28,10 @@ export interface HouseholdMember {
   displayName: string | null;
   role: 'admin' | 'parent' | 'child';
   joinedAt: string;
+  // Stats fields - added for Family page member cards
+  tasksCompleted: number; // Tasks completed today
+  totalTasks: number; // Total tasks assigned today
+  points: number; // Current points balance
 }
 
 /**


### PR DESCRIPTION
## Summary

- Enhanced `GET /api/households/:id/members` endpoint to include task stats and points
- Query children table to get tasksCompleted, totalTasks, and points for today
- Link stats to household members via user_id for authenticated children
- Parents get 0s for stats (they don't have task assignments)
- Updated HouseholdMember interface in frontend to include stats fields
- Family page now displays actual task completion and points data

## Test plan

- [ ] View Family page as a parent
  - [ ] Parent member cards show 0 for tasks and points
  - [ ] Child member cards show actual tasks completed/total and points balance
- [ ] Complete a task as a child
  - [ ] Refresh Family page
  - [ ] Child's tasksCompleted count increases
  - [ ] Points increase appropriately
- [ ] Test with household that has no children
  - [ ] Page still loads correctly
- [ ] Test with children who don't have user accounts (child-only profiles)
  - [ ] Stats for those children still appear correctly

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)