### PR TITLE
refactor(frontend): use AuthService instead of localStorage JWT decoding

### DIFF
--- a/apps/frontend/src/app/components/household-settings/household-settings.ts
+++ b/apps/frontend/src/app/components/household-settings/household-settings.ts
@@ -14,11 +14,10 @@ import {
   HouseholdListItem,
   HouseholdMember,
 } from '../../services/household.service';
+import { AuthService } from '../../services/auth.service';
 import { ChildrenManagementComponent } from '../children-management/children-management';
 import { InviteUserComponent } from '../invite-user/invite-user';
 import { InvitationsSentListComponent } from '../invitations-sent-list/invitations-sent-list';
-import { StorageService } from '../../services/storage.service';
-import { STORAGE_KEYS } from '../../services/storage-keys';
 
 @Component({
   selector: 'app-household-settings',
@@ -37,7 +36,7 @@ export class HouseholdSettingsComponent implements OnInit {
   private readonly fb = inject(FormBuilder);
   private readonly router = inject(Router);
   private readonly householdService = inject(HouseholdService);
-  private readonly storage = inject(StorageService);
+  private readonly authService = inject(AuthService);
 
   household = signal<HouseholdListItem | null>(null);
   members = signal<HouseholdMember[]>([]);
@@ -146,19 +145,7 @@ export class HouseholdSettingsComponent implements OnInit {
   }
 
   private getCurrentUserId(): string {
-    // TODO: Get from auth service when available
-    // For now, decode from JWT
-    const token =
-      this.storage.getString(STORAGE_KEYS.ACCESS_TOKEN) ||
-      sessionStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
-    if (!token) return '';
-
-    try {
-      const payload = JSON.parse(atob(token.split('.')[1]));
-      return payload.userId || '';
-    } catch {
-      return '';
-    }
+    return this.authService.getCurrentUserId() ?? '';
   }
 
   async onInvitationSent() {

--- a/apps/frontend/src/app/services/auth.service.ts
+++ b/apps/frontend/src/app/services/auth.service.ts
@@ -204,6 +204,14 @@ export class AuthService {
   }
 
   /**
+   * Get the current user's ID
+   * @returns The user ID or null if not authenticated
+   */
+  getCurrentUserId(): string | null {
+    return this.currentUser()?.id ?? null;
+  }
+
+  /**
    * Get the current user's role
    * @returns The role or undefined if not authenticated
    */


### PR DESCRIPTION
## Summary

- Added `getCurrentUserId()` method to AuthService for convenience
- Updated HouseholdSettingsComponent to use AuthService instead of manually decoding JWT from localStorage/sessionStorage
- Removed direct StorageService dependency from HouseholdSettingsComponent
- Improves encapsulation and follows existing patterns

## Test plan

- [ ] Load Household Settings page as logged-in user
  - [ ] Current user's role is correctly determined
  - [ ] Admin users can edit household name
  - [ ] Non-admin users cannot edit household name
- [ ] Logout and login again
  - [ ] User ID is correctly retrieved after re-authentication

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)