### PR TITLE
fix(frontend): replace 'gear' text with ⚙️ emoji in sidebar navigation

### DIFF
--- a/apps/frontend/src/app/components/navigation/sidebar-nav/sidebar-nav.html
+++ b/apps/frontend/src/app/components/navigation/sidebar-nav/sidebar-nav.html
@@ -34,6 +34,6 @@
       <h4>{{ user().name }}</h4>
       <app-household-switcher></app-household-switcher>
     </div>
-    <span class="settings-icon" aria-hidden="true">gear</span>
+    <span class="settings-icon" aria-hidden="true">⚙️</span>
   </button>
 </nav>


### PR DESCRIPTION
## Summary
- Fixed gear icon in sidebar navigation displaying as text "gear" instead of an actual icon
- Changed to use ⚙️ emoji to match the icon style used throughout the navigation components

## Changes
- `apps/frontend/src/app/components/navigation/sidebar-nav/sidebar-nav.html`: Line 37, replaced "gear" text with ⚙️ emoji

## Test plan
- [x] Frontend build succeeds
- [x] All 634 frontend tests pass
- [ ] Visual verification: settings icon displays correctly in sidebar

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)