### PR TITLE
feat(types, frontend): add HouseholdMemberResponse to shared types

### DIFF
--- a/apps/frontend/src/app/components/household-settings/household-settings.ts
+++ b/apps/frontend/src/app/components/household-settings/household-settings.ts
@@ -12,7 +12,7 @@ import { DatePipe } from '@angular/common';
 import {
   HouseholdService,
   HouseholdListItem,
-  HouseholdMember,
+  HouseholdMemberResponse,
 } from '../../services/household.service';
 import { AuthService } from '../../services/auth.service';
 import { ChildrenManagementComponent } from '../children-management/children-management';
@@ -39,7 +39,7 @@ export class HouseholdSettingsComponent implements OnInit {
   private readonly authService = inject(AuthService);
 
   household = signal<HouseholdListItem | null>(null);
-  members = signal<HouseholdMember[]>([]);
+  members = signal<HouseholdMemberResponse[]>([]);
   currentUserRole = signal<'admin' | 'parent' | 'child' | null>(null);
   isLoading = signal(false);
   isSaving = signal(false);

--- a/apps/frontend/src/app/pages/family/family.spec.ts
+++ b/apps/frontend/src/app/pages/family/family.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Family } from './family';
-import { HouseholdService, type HouseholdMember } from '../../services/household.service';
+import { HouseholdService, type HouseholdMemberResponse } from '../../services/household.service';
 import { AuthService } from '../../services/auth.service';
 import { InvitationService } from '../../services/invitation.service';
 import { ChildrenService } from '../../services/children.service';
@@ -21,7 +21,7 @@ describe('Family', () => {
 
   const mockUser = { id: 'user-1', email: 'test@example.com' };
   const mockHousehold = { id: 'household-1', name: 'Test Family' };
-  const mockMembers: HouseholdMember[] = [
+  const mockMembers: HouseholdMemberResponse[] = [
     {
       userId: 'user-1',
       email: 'test@example.com',
@@ -143,7 +143,7 @@ describe('Family', () => {
     });
 
     it('should use email username when displayName is null', async () => {
-      const membersWithoutDisplayName: HouseholdMember[] = [
+      const membersWithoutDisplayName: HouseholdMemberResponse[] = [
         {
           ...mockMembers[0],
           displayName: null,

--- a/apps/frontend/src/app/services/household.service.ts
+++ b/apps/frontend/src/app/services/household.service.ts
@@ -1,5 +1,10 @@
 import { Injectable, signal, computed, inject } from '@angular/core';
-import type { Household, CreateHouseholdRequest, UpdateHouseholdRequest } from '@st44/types';
+import type {
+  Household,
+  CreateHouseholdRequest,
+  UpdateHouseholdRequest,
+  HouseholdMemberResponse,
+} from '@st44/types';
 import { ApiService } from './api.service';
 import { StorageService } from './storage.service';
 import { STORAGE_KEYS } from './storage-keys';
@@ -19,20 +24,10 @@ export interface HouseholdListItem {
 }
 
 /**
- * Household member interface matching backend response
- * TODO: Migrate to @st44/types when HouseholdMember response schema added
+ * Re-export HouseholdMemberResponse from @st44/types for consumers
+ * This type matches the GET /households/:id/members response
  */
-export interface HouseholdMember {
-  userId: string;
-  email: string;
-  displayName: string | null;
-  role: 'admin' | 'parent' | 'child';
-  joinedAt: string;
-  // Stats fields - added for Family page member cards
-  tasksCompleted: number; // Tasks completed today
-  totalTasks: number; // Total tasks assigned today
-  points: number; // Current points balance
-}
+export type { HouseholdMemberResponse };
 
 /**
  * Service for managing households and household state
@@ -92,8 +87,8 @@ export class HouseholdService {
     } satisfies UpdateHouseholdRequest);
   }
 
-  async getHouseholdMembers(householdId: string): Promise<HouseholdMember[]> {
-    return this.apiService.get<HouseholdMember[]>(`/households/${householdId}/members`);
+  async getHouseholdMembers(householdId: string): Promise<HouseholdMemberResponse[]> {
+    return this.apiService.get<HouseholdMemberResponse[]>(`/households/${householdId}/members`);
   }
 
   /**

--- a/apps/frontend/src/app/testing/fixtures.ts
+++ b/apps/frontend/src/app/testing/fixtures.ts
@@ -22,7 +22,7 @@ import type {
   Child,
   User,
   Household,
-  HouseholdMember,
+  HouseholdMemberResponse,
   TaskRuleConfig,
   PaginationMeta,
 } from '@st44/types';
@@ -125,17 +125,20 @@ export function createMockHousehold(overrides: Partial<Household> = {}): Househo
 }
 
 /**
- * Create a mock HouseholdMember
+ * Create a mock HouseholdMemberResponse (API response with stats)
  */
 export function createMockHouseholdMember(
-  overrides: Partial<HouseholdMember> = {},
-): HouseholdMember {
+  overrides: Partial<HouseholdMemberResponse> = {},
+): HouseholdMemberResponse {
   return {
-    id: generateMockUuid(),
-    householdId: generateMockUuid(),
     userId: generateMockUuid(),
+    email: `test-${idCounter}@example.com`,
+    displayName: `Test User ${idCounter}`,
     role: 'parent',
     joinedAt: nowDatetime(),
+    tasksCompleted: 0,
+    totalTasks: 0,
+    points: 0,
     ...overrides,
   };
 }

--- a/packages/types/src/schemas/household.schema.ts
+++ b/packages/types/src/schemas/household.schema.ts
@@ -60,7 +60,7 @@ export type UpdateHouseholdRequest = z.infer<typeof UpdateHouseholdRequestSchema
 
 /**
  * Household Member Schema
- * Represents a user's membership in a household
+ * Represents a user's membership in a household (database entity)
  */
 export const HouseholdMemberSchema = z.object({
   id: z.string().uuid(),
@@ -71,6 +71,24 @@ export const HouseholdMemberSchema = z.object({
 });
 
 export type HouseholdMember = z.infer<typeof HouseholdMemberSchema>;
+
+/**
+ * Household Member Response Schema
+ * API response for GET /households/:id/members
+ * Includes user info and task stats
+ */
+export const HouseholdMemberResponseSchema = z.object({
+  userId: z.string().uuid(),
+  email: z.string().email(),
+  displayName: z.string().nullable(),
+  role: z.enum(['admin', 'parent', 'child']),
+  joinedAt: z.string().datetime(),
+  tasksCompleted: z.number().int().nonnegative(),
+  totalTasks: z.number().int().nonnegative(),
+  points: z.number().int().nonnegative(),
+});
+
+export type HouseholdMemberResponse = z.infer<typeof HouseholdMemberResponseSchema>;
 
 /**
  * Household with Members Response


### PR DESCRIPTION
## Summary
- Created `HouseholdMemberResponseSchema` in `@st44/types` for the GET `/households/:id/members` API response
- Updated frontend to use the shared type instead of local interface

## Changes
- `packages/types/src/schemas/household.schema.ts`: Added `HouseholdMemberResponseSchema` with fields for email, displayName, role, joinedAt, tasksCompleted, totalTasks, points
- `apps/frontend/src/app/services/household.service.ts`: Import and use `HouseholdMemberResponse` from `@st44/types`
- `apps/frontend/src/app/components/household-settings/household-settings.ts`: Updated to use `HouseholdMemberResponse`
- `apps/frontend/src/app/testing/fixtures.ts`: Updated `createMockHouseholdMember` to return `HouseholdMemberResponse`
- `apps/frontend/src/app/pages/family/family.spec.ts`: Updated test types

## Test plan
- [x] Types package builds successfully
- [x] Frontend builds successfully
- [x] All 634 frontend tests pass
- [x] Backend unaffected (no changes needed)

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)