### PR TITLE
fix(frontend): make household dropdown open downward on mobile (#339)

### DIFF
--- a/apps/frontend/src/app/components/household-switcher/household-switcher.css
+++ b/apps/frontend/src/app/components/household-switcher/household-switcher.css
@@ -201,8 +201,21 @@
     padding: 0.0625rem 0.375rem;
   }
 
+  /* On mobile, dropdown opens downward (below the toggle) since switcher is in header */
   .switcher-dropdown {
     min-width: 200px;
+    bottom: auto;
+    top: calc(100% + 0.5rem);
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+  }
+
+  /* Flip the chevron icon direction for mobile (points down when closed) */
+  .switcher-toggle__icon {
+    transform: rotate(0deg);
+  }
+
+  .switcher-toggle__icon--open {
+    transform: rotate(180deg);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes the household dropdown going outside the screen on mobile devices.

**Root cause**: The dropdown was configured to open upward (`bottom: calc(100% + 0.5rem)`) which works for desktop where the switcher is at the bottom of the sidebar. On mobile, the switcher is in the header at the top, so opening upward causes it to go off-screen.

**Fix**: Added a mobile media query that changes the dropdown to open downward instead.

## Changes

- Added mobile-specific CSS that changes dropdown position from `bottom` to `top`
- Updated box-shadow direction to match downward opening
- Flipped chevron icon animation to indicate correct direction

## Test Plan

- [ ] Open the app on mobile viewport (< 640px width)
- [ ] Click household switcher in the header
- [ ] Verify dropdown opens below the toggle button
- [ ] Verify dropdown stays within the visible viewport
- [ ] Verify chevron points down when closed, up when open
- [ ] Test on desktop - dropdown should still open upward in sidebar

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)