### PR TITLE
fix(frontend): clear nav active state on Settings page (#341)

### DIFF
--- a/apps/frontend/src/app/components/navigation/bottom-nav/bottom-nav.ts
+++ b/apps/frontend/src/app/components/navigation/bottom-nav/bottom-nav.ts
@@ -2,8 +2,9 @@ import { Component, ChangeDetectionStrategy, input, output } from '@angular/core
 
 /**
  * Screen identifier type for navigation
+ * 'none' is used when no main nav item should be active (e.g., Settings page)
  */
-export type NavScreen = 'home' | 'tasks' | 'family' | 'progress';
+export type NavScreen = 'home' | 'tasks' | 'family' | 'progress' | 'none';
 
 /**
  * Navigation item configuration

--- a/apps/frontend/src/app/layouts/main-layout/main-layout.ts
+++ b/apps/frontend/src/app/layouts/main-layout/main-layout.ts
@@ -133,6 +133,9 @@ export class MainLayout implements OnInit, OnDestroy {
       this.activeScreen.set('family');
     } else if (url.includes('/progress')) {
       this.activeScreen.set('progress');
+    } else {
+      // Settings, household-settings, or other pages - no main nav item active
+      this.activeScreen.set('none');
     }
   }
 
@@ -140,7 +143,10 @@ export class MainLayout implements OnInit, OnDestroy {
    * Handle navigation between screens
    */
   protected onNavigate(screen: NavScreen): void {
-    const routes: Record<NavScreen, string> = {
+    // 'none' is not a navigable screen, it just means no nav item is active
+    if (screen === 'none') return;
+
+    const routes: Record<Exclude<NavScreen, 'none'>, string> = {
       home: '/home',
       tasks: '/tasks',
       family: '/family',


### PR DESCRIPTION
## Summary

Fixes navigation items incorrectly showing active state when on the Settings page.

**Root cause**: The `updateActiveScreenFromUrl` function only handled known main routes (home, tasks, family, progress). When on the Settings page, none matched, so the active screen kept its previous value.

**Fix**: Added `'none'` to the `NavScreen` type and set it as the fallback when no main route matches.

## Changes

- Extended `NavScreen` type to include `'none'`
- Updated `updateActiveScreenFromUrl` to set `'none'` when URL doesn't match any main route
- Updated `onNavigate` to handle `'none'` case (early return)

## Test Plan

- [ ] Navigate to Settings page
- [ ] Verify no bottom nav items are highlighted
- [ ] Verify no sidebar nav items are highlighted
- [ ] Navigate back to Home - verify Home is highlighted
- [ ] Navigate to Tasks - verify Tasks is highlighted

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)