### PR TITLE
fix(frontend): align profile fields with backend firstName/lastName (#337)

### DIFF
--- a/apps/frontend/src/app/pages/settings/settings.html
+++ b/apps/frontend/src/app/pages/settings/settings.html
@@ -49,16 +49,29 @@
         <h2>Profile</h2>
 
         <form class="settings-form" (submit)="saveProfile(); $event.preventDefault()">
-          <!-- Name Field -->
+          <!-- First Name Field -->
           <div class="form-group">
-            <label for="name">Display Name</label>
+            <label for="firstName">First Name</label>
             <input
               type="text"
-              id="name"
-              name="name"
-              [(ngModel)]="name"
-              placeholder="Enter your name"
-              maxlength="255"
+              id="firstName"
+              name="firstName"
+              [(ngModel)]="firstName"
+              placeholder="Enter your first name"
+              maxlength="100"
+            />
+          </div>
+
+          <!-- Last Name Field -->
+          <div class="form-group">
+            <label for="lastName">Last Name</label>
+            <input
+              type="text"
+              id="lastName"
+              name="lastName"
+              [(ngModel)]="lastName"
+              placeholder="Enter your last name"
+              maxlength="100"
             />
             <small class="form-hint">This is how you'll appear to other family members</small>
           </div>

--- a/apps/frontend/src/app/pages/settings/settings.ts
+++ b/apps/frontend/src/app/pages/settings/settings.ts
@@ -38,7 +38,8 @@ export class Settings implements OnInit {
   protected readonly profile = signal<UserProfile | null>(null);
 
   // Form fields
-  protected name = '';
+  protected firstName = '';
+  protected lastName = '';
   protected email = '';
   protected currentPassword = '';
   protected newPassword = '';
@@ -63,7 +64,8 @@ export class Settings implements OnInit {
       this.profile.set(profile);
 
       // Initialize form fields
-      this.name = profile.name ?? '';
+      this.firstName = profile.firstName ?? '';
+      this.lastName = profile.lastName ?? '';
       this.email = profile.email;
     } catch (err) {
       console.error('Failed to load profile:', err);
@@ -86,10 +88,15 @@ export class Settings implements OnInit {
       this.successMessage.set(null);
 
       // Build update request with only changed fields
-      const updates: { name?: string; email?: string; password?: string } = {};
+      const updates: { firstName?: string; lastName?: string; email?: string; password?: string } =
+        {};
 
-      if (this.name !== (currentProfile.name ?? '')) {
-        updates.name = this.name;
+      if (this.firstName !== (currentProfile.firstName ?? '')) {
+        updates.firstName = this.firstName;
+      }
+
+      if (this.lastName !== (currentProfile.lastName ?? '')) {
+        updates.lastName = this.lastName;
       }
 
       if (this.email !== currentProfile.email) {
@@ -134,7 +141,8 @@ export class Settings implements OnInit {
 
       const updatedProfile = await this.userService.updateProfile(updates);
       this.profile.set(updatedProfile);
-      this.name = updatedProfile.name ?? '';
+      this.firstName = updatedProfile.firstName ?? '';
+      this.lastName = updatedProfile.lastName ?? '';
       this.email = updatedProfile.email;
 
       // Clear password fields

--- a/apps/frontend/src/app/services/user.service.ts
+++ b/apps/frontend/src/app/services/user.service.ts
@@ -6,13 +6,15 @@ import { environment } from '../../environments/environment.development';
 export interface UserProfile {
   id: string;
   email: string;
-  name: string | null;
+  firstName: string | null;
+  lastName: string | null;
   createdAt: string;
   updatedAt: string;
 }
 
 export interface UpdateProfileRequest {
-  name?: string;
+  firstName?: string;
+  lastName?: string;
   email?: string;
   password?: string;
 }


### PR DESCRIPTION
## Summary

Fixes the "cannot save profile" bug on the Settings page.

**Root cause**: The frontend was sending `{ name: string }` but the backend expected `{ firstName: string, lastName: string }`. The Zod schema validation was rejecting the request.

**Fix**: Updated frontend to use `firstName` and `lastName` fields to match the backend API contract.

## Changes

- **user.service.ts**: Updated `UserProfile` and `UpdateProfileRequest` interfaces
- **settings.ts**: Updated form fields and save logic to use firstName/lastName
- **settings.html**: Split single name input into First Name and Last Name fields

## Test Plan

- [ ] Navigate to Settings page
- [ ] Enter first name and last name
- [ ] Click Save Changes
- [ ] Verify success message appears
- [ ] Refresh page and verify changes persisted
- [ ] Try changing email and password as well

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)