### PR TITLE
test(backend): add unit tests for remaining repositories (#289)

### DIFF
--- a/apps/backend/src/repositories/assignment.repository.test.ts
+++ b/apps/backend/src/repositories/assignment.repository.test.ts
@@ -1,0 +1,749 @@
+/**
+ * AssignmentRepository Unit Tests
+ *
+ * Tests the AssignmentRepository using mocked database connections.
+ * No actual database is required to run these tests.
+ */
+
+import { describe, it, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  AssignmentRepository,
+  type CreateAssignmentDto,
+  type CreateCompletionDto,
+} from './assignment.repository.js';
+
+// Mock Pool implementation
+function createMockPool() {
+  const queryMock = mock.fn();
+  return {
+    query: queryMock,
+    connect: mock.fn(),
+    end: mock.fn(),
+  };
+}
+
+// Sample assignment row data
+const sampleAssignmentRow = {
+  id: '123e4567-e89b-12d3-a456-426614174000',
+  household_id: 'household-123',
+  task_id: 'task-123',
+  child_id: 'child-123',
+  date: '2024-01-15',
+  status: 'pending' as const,
+  created_at: new Date('2024-01-01T00:00:00Z'),
+};
+
+const sampleAssignmentWithDetailsRow = {
+  ...sampleAssignmentRow,
+  task_name: 'Clean Room',
+  task_description: 'Make your bed and tidy up',
+  task_points: 10,
+  child_name: 'Alice',
+  completed_at: null as Date | null,
+};
+
+const sampleCompletionRow = {
+  id: '123e4567-e89b-12d3-a456-426614174001',
+  household_id: 'household-123',
+  task_assignment_id: sampleAssignmentRow.id,
+  child_id: 'child-123',
+  completed_at: new Date('2024-01-15T10:30:00Z'),
+  points_earned: 10,
+};
+
+describe('AssignmentRepository', () => {
+  let pool: ReturnType<typeof createMockPool>;
+  let repository: AssignmentRepository;
+
+  beforeEach(() => {
+    pool = createMockPool();
+    repository = new AssignmentRepository(pool as never);
+  });
+
+  describe('findById', () => {
+    it('should return an assignment when found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleAssignmentRow],
+        rowCount: 1,
+      }));
+
+      const result = await repository.findById(sampleAssignmentRow.id);
+
+      assert.ok(result);
+      assert.equal(result.id, sampleAssignmentRow.id);
+      assert.equal(result.householdId, sampleAssignmentRow.household_id);
+      assert.equal(result.taskId, sampleAssignmentRow.task_id);
+      assert.equal(result.childId, sampleAssignmentRow.child_id);
+      assert.equal(result.date, sampleAssignmentRow.date);
+      assert.equal(result.status, sampleAssignmentRow.status);
+    });
+
+    it('should return null when assignment not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.findById('non-existent-id');
+
+      assert.equal(result, null);
+    });
+
+    it('should call query with correct parameters', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      await repository.findById('test-id');
+
+      assert.equal(pool.query.mock.callCount(), 1);
+      const [query, params] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes('SELECT'));
+      assert.ok(query.includes('WHERE id = $1'));
+      assert.deepEqual(params, ['test-id']);
+    });
+  });
+
+  describe('findByIdWithDetails', () => {
+    it('should return assignment with details when found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleAssignmentWithDetailsRow],
+        rowCount: 1,
+      }));
+
+      const result = await repository.findByIdWithDetails(sampleAssignmentRow.id);
+
+      assert.ok(result);
+      assert.equal(result.id, sampleAssignmentRow.id);
+      assert.equal(result.taskName, 'Clean Room');
+      assert.equal(result.taskDescription, 'Make your bed and tidy up');
+      assert.equal(result.taskPoints, 10);
+      assert.equal(result.childName, 'Alice');
+      assert.equal(result.completedAt, null);
+    });
+
+    it('should return completed assignment with completedAt', async () => {
+      const completedRow = {
+        ...sampleAssignmentWithDetailsRow,
+        status: 'completed' as const,
+        completed_at: new Date('2024-01-15T10:30:00Z'),
+      };
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [completedRow],
+        rowCount: 1,
+      }));
+
+      const result = await repository.findByIdWithDetails(sampleAssignmentRow.id);
+
+      assert.ok(result);
+      assert.equal(result.status, 'completed');
+      assert.ok(result.completedAt);
+    });
+
+    it('should return null when not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.findByIdWithDetails('non-existent');
+
+      assert.equal(result, null);
+    });
+  });
+
+  describe('findByChild', () => {
+    it('should return assignments for a child within date range', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleAssignmentWithDetailsRow],
+        rowCount: 1,
+      }));
+
+      const result = await repository.findByChild('child-123', '2024-01-01', '2024-01-31');
+
+      assert.equal(result.length, 1);
+      assert.equal(result[0].childId, 'child-123');
+      assert.equal(result[0].taskName, 'Clean Room');
+    });
+
+    it('should return empty array when no assignments found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.findByChild('child-123', '2024-01-01', '2024-01-31');
+
+      assert.equal(result.length, 0);
+    });
+
+    it('should call query with correct parameters', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      await repository.findByChild('child-123', '2024-01-01', '2024-01-31');
+
+      const [query, params] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes('WHERE ta.child_id = $1'));
+      assert.ok(query.includes('ta.date >= $2'));
+      assert.ok(query.includes('ta.date <= $3'));
+      assert.deepEqual(params, ['child-123', '2024-01-01', '2024-01-31']);
+    });
+  });
+
+  describe('findByHousehold', () => {
+    it('should return assignments for a household within date range', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleAssignmentWithDetailsRow],
+        rowCount: 1,
+      }));
+
+      const result = await repository.findByHousehold('household-123', '2024-01-01', '2024-01-31');
+
+      assert.equal(result.length, 1);
+      assert.equal(result[0].householdId, 'household-123');
+    });
+
+    it('should apply child filter', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      await repository.findByHousehold('household-123', '2024-01-01', '2024-01-31', {
+        childId: 'child-456',
+      });
+
+      const [query, params] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes('AND ta.child_id = $4'));
+      assert.deepEqual(params, ['household-123', '2024-01-01', '2024-01-31', 'child-456']);
+    });
+
+    it('should apply status filter', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      await repository.findByHousehold('household-123', '2024-01-01', '2024-01-31', {
+        status: 'completed',
+      });
+
+      const [query, params] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes('AND ta.status = $4'));
+      assert.deepEqual(params, ['household-123', '2024-01-01', '2024-01-31', 'completed']);
+    });
+
+    it('should apply task filter', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      await repository.findByHousehold('household-123', '2024-01-01', '2024-01-31', {
+        taskId: 'task-789',
+      });
+
+      const [query, params] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes('AND ta.task_id = $4'));
+      assert.deepEqual(params, ['household-123', '2024-01-01', '2024-01-31', 'task-789']);
+    });
+
+    it('should apply multiple filters', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      await repository.findByHousehold('household-123', '2024-01-01', '2024-01-31', {
+        childId: 'child-456',
+        status: 'pending',
+        taskId: 'task-789',
+      });
+
+      const [query, params] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes('AND ta.child_id = $4'));
+      assert.ok(query.includes('AND ta.status = $5'));
+      assert.ok(query.includes('AND ta.task_id = $6'));
+      assert.deepEqual(params, [
+        'household-123',
+        '2024-01-01',
+        '2024-01-31',
+        'child-456',
+        'pending',
+        'task-789',
+      ]);
+    });
+  });
+
+  describe('findPending', () => {
+    it('should return pending assignments for a child', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleAssignmentRow],
+        rowCount: 1,
+      }));
+
+      const result = await repository.findPending('child-123');
+
+      assert.equal(result.length, 1);
+      assert.equal(result[0].status, 'pending');
+    });
+
+    it('should call query with correct parameters', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      await repository.findPending('child-123');
+
+      const [query, params] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes("status = 'pending'"));
+      assert.ok(query.includes('WHERE child_id = $1'));
+      assert.deepEqual(params, ['child-123']);
+    });
+  });
+
+  describe('create', () => {
+    it('should create a new assignment', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleAssignmentRow],
+        rowCount: 1,
+      }));
+
+      const data: CreateAssignmentDto = {
+        householdId: 'household-123',
+        taskId: 'task-123',
+        childId: 'child-123',
+        date: '2024-01-15',
+      };
+
+      const result = await repository.create(data);
+
+      assert.ok(result);
+      assert.equal(result.householdId, 'household-123');
+      assert.equal(result.taskId, 'task-123');
+      assert.equal(result.childId, 'child-123');
+      assert.equal(result.date, '2024-01-15');
+    });
+
+    it('should use provided status', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ ...sampleAssignmentRow, status: 'completed' }],
+        rowCount: 1,
+      }));
+
+      await repository.create({
+        householdId: 'household-123',
+        taskId: 'task-123',
+        childId: 'child-123',
+        date: '2024-01-15',
+        status: 'completed',
+      });
+
+      const [, params] = pool.query.mock.calls[0].arguments;
+      assert.equal(params[4], 'completed');
+    });
+
+    it('should default to pending status', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleAssignmentRow],
+        rowCount: 1,
+      }));
+
+      await repository.create({
+        householdId: 'household-123',
+        taskId: 'task-123',
+        childId: null,
+        date: '2024-01-15',
+      });
+
+      const [, params] = pool.query.mock.calls[0].arguments;
+      assert.equal(params[4], 'pending');
+    });
+  });
+
+  describe('batchCreate', () => {
+    it('should create multiple assignments', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleAssignmentRow, { ...sampleAssignmentRow, id: 'assignment-2' }],
+        rowCount: 2,
+      }));
+
+      const assignments: CreateAssignmentDto[] = [
+        { householdId: 'household-123', taskId: 'task-1', childId: 'child-1', date: '2024-01-15' },
+        { householdId: 'household-123', taskId: 'task-2', childId: 'child-2', date: '2024-01-15' },
+      ];
+
+      const result = await repository.batchCreate(assignments);
+
+      assert.equal(result.length, 2);
+    });
+
+    it('should return empty array when no assignments provided', async () => {
+      const result = await repository.batchCreate([]);
+
+      assert.equal(result.length, 0);
+      assert.equal(pool.query.mock.callCount(), 0);
+    });
+
+    it('should use ON CONFLICT DO NOTHING for duplicates', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleAssignmentRow],
+        rowCount: 1,
+      }));
+
+      await repository.batchCreate([
+        { householdId: 'household-123', taskId: 'task-1', childId: 'child-1', date: '2024-01-15' },
+      ]);
+
+      const [query] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes('ON CONFLICT'));
+      assert.ok(query.includes('DO NOTHING'));
+    });
+  });
+
+  describe('updateStatus', () => {
+    it('should update assignment status and return true', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ id: sampleAssignmentRow.id }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.updateStatus(sampleAssignmentRow.id, 'completed');
+
+      assert.equal(result, true);
+    });
+
+    it('should return false when assignment not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.updateStatus('non-existent', 'completed');
+
+      assert.equal(result, false);
+    });
+
+    it('should call query with correct parameters', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      await repository.updateStatus('assignment-id', 'completed');
+
+      const [query, params] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes('UPDATE task_assignments SET status = $2'));
+      assert.ok(query.includes('WHERE id = $1'));
+      assert.deepEqual(params, ['assignment-id', 'completed']);
+    });
+  });
+
+  describe('completeIfPending', () => {
+    it('should complete pending assignment and return it', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ ...sampleAssignmentRow, status: 'completed' }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.completeIfPending(sampleAssignmentRow.id);
+
+      assert.ok(result);
+      assert.equal(result.status, 'completed');
+    });
+
+    it('should return null if not pending', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.completeIfPending('already-completed');
+
+      assert.equal(result, null);
+    });
+
+    it('should only update if status is pending', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      await repository.completeIfPending('assignment-id');
+
+      const [query] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes("AND status = 'pending'"));
+    });
+  });
+
+  describe('reassign', () => {
+    it('should reassign pending assignment to new child', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ ...sampleAssignmentRow, child_id: 'new-child' }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.reassign(sampleAssignmentRow.id, 'new-child');
+
+      assert.ok(result);
+      assert.equal(result.childId, 'new-child');
+    });
+
+    it('should return null if not pending', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.reassign('completed-assignment', 'new-child');
+
+      assert.equal(result, null);
+    });
+
+    it('should only reassign if pending', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      await repository.reassign('assignment-id', 'new-child');
+
+      const [query] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes("AND status = 'pending'"));
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete assignment and return true', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ id: sampleAssignmentRow.id }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.delete(sampleAssignmentRow.id);
+
+      assert.equal(result, true);
+    });
+
+    it('should return false when assignment not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.delete('non-existent');
+
+      assert.equal(result, false);
+    });
+  });
+
+  describe('getHouseholdId', () => {
+    it('should return household ID for assignment', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ household_id: 'household-123' }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.getHouseholdId(sampleAssignmentRow.id);
+
+      assert.equal(result, 'household-123');
+    });
+
+    it('should return null when assignment not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.getHouseholdId('non-existent');
+
+      assert.equal(result, null);
+    });
+  });
+
+  describe('exists', () => {
+    it('should return true when assignment exists with child', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ id: 1 }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.exists('task-123', 'child-123', '2024-01-15');
+
+      assert.equal(result, true);
+    });
+
+    it('should return true when assignment exists without child', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ id: 1 }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.exists('task-123', null, '2024-01-15');
+
+      assert.equal(result, true);
+    });
+
+    it('should return false when assignment does not exist', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.exists('task-123', 'child-123', '2024-01-15');
+
+      assert.equal(result, false);
+    });
+
+    it('should use IS NULL for null childId', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      await repository.exists('task-123', null, '2024-01-15');
+
+      const [query, params] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes('child_id IS NULL'));
+      assert.deepEqual(params, ['task-123', '2024-01-15']);
+    });
+
+    it('should use = $2 for non-null childId', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      await repository.exists('task-123', 'child-123', '2024-01-15');
+
+      const [query, params] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes('child_id = $2'));
+      assert.deepEqual(params, ['task-123', 'child-123', '2024-01-15']);
+    });
+  });
+
+  // Task Completions Tests
+
+  describe('createCompletion', () => {
+    it('should create a task completion record', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleCompletionRow],
+        rowCount: 1,
+      }));
+
+      const data: CreateCompletionDto = {
+        householdId: 'household-123',
+        taskAssignmentId: sampleAssignmentRow.id,
+        childId: 'child-123',
+        completedAt: new Date('2024-01-15T10:30:00Z'),
+        pointsEarned: 10,
+      };
+
+      const result = await repository.createCompletion(data);
+
+      assert.ok(result);
+      assert.equal(result.householdId, 'household-123');
+      assert.equal(result.taskAssignmentId, sampleAssignmentRow.id);
+      assert.equal(result.childId, 'child-123');
+      assert.equal(result.pointsEarned, 10);
+    });
+
+    it('should call query with correct parameters', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleCompletionRow],
+        rowCount: 1,
+      }));
+
+      const completedAt = new Date('2024-01-15T10:30:00Z');
+      await repository.createCompletion({
+        householdId: 'household-123',
+        taskAssignmentId: 'assignment-123',
+        childId: 'child-123',
+        completedAt,
+        pointsEarned: 10,
+      });
+
+      const [query, params] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes('INSERT INTO task_completions'));
+      assert.deepEqual(params, ['household-123', 'assignment-123', 'child-123', completedAt, 10]);
+    });
+  });
+
+  describe('findCompletionByAssignment', () => {
+    it('should return completion when found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleCompletionRow],
+        rowCount: 1,
+      }));
+
+      const result = await repository.findCompletionByAssignment(sampleAssignmentRow.id);
+
+      assert.ok(result);
+      assert.equal(result.taskAssignmentId, sampleAssignmentRow.id);
+      assert.equal(result.pointsEarned, 10);
+    });
+
+    it('should return null when not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.findCompletionByAssignment('non-existent');
+
+      assert.equal(result, null);
+    });
+  });
+
+  describe('getAssignmentWithPoints', () => {
+    it('should return assignment with task points', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [
+          {
+            id: sampleAssignmentRow.id,
+            household_id: 'household-123',
+            child_id: 'child-123',
+            task_id: 'task-123',
+            status: 'pending',
+            points: 10,
+          },
+        ],
+        rowCount: 1,
+      }));
+
+      const result = await repository.getAssignmentWithPoints(sampleAssignmentRow.id);
+
+      assert.ok(result);
+      assert.equal(result.id, sampleAssignmentRow.id);
+      assert.equal(result.points, 10);
+      assert.equal(result.status, 'pending');
+    });
+
+    it('should return null when not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.getAssignmentWithPoints('non-existent');
+
+      assert.equal(result, null);
+    });
+  });
+
+  describe('withClient', () => {
+    it('should create a new repository instance with client', () => {
+      const mockClient = { query: mock.fn() };
+      const newRepo = repository.withClient(mockClient as never);
+
+      assert.ok(newRepo instanceof AssignmentRepository);
+      assert.notEqual(newRepo, repository);
+    });
+  });
+});

--- a/apps/backend/src/repositories/child.repository.test.ts
+++ b/apps/backend/src/repositories/child.repository.test.ts
@@ -1,0 +1,573 @@
+/**
+ * ChildRepository Unit Tests
+ *
+ * Tests the ChildRepository using mocked database connections.
+ * No actual database is required to run these tests.
+ */
+
+import { describe, it, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { ChildRepository, type CreateChildDto, type UpdateChildDto } from './child.repository.js';
+
+// Mock Pool implementation
+function createMockPool() {
+  const queryMock = mock.fn();
+  return {
+    query: queryMock,
+    connect: mock.fn(),
+    end: mock.fn(),
+  };
+}
+
+// Sample child row data
+const sampleChildRow = {
+  id: '123e4567-e89b-12d3-a456-426614174000',
+  household_id: '123e4567-e89b-12d3-a456-426614174001',
+  user_id: null,
+  name: 'Test Child',
+  birth_year: 2015,
+  created_at: new Date('2024-01-01T00:00:00Z'),
+  updated_at: new Date('2024-01-01T00:00:00Z'),
+};
+
+const sampleChildRowWithUser = {
+  ...sampleChildRow,
+  user_id: '123e4567-e89b-12d3-a456-426614174002',
+};
+
+describe('ChildRepository', () => {
+  let pool: ReturnType<typeof createMockPool>;
+  let repository: ChildRepository;
+
+  beforeEach(() => {
+    pool = createMockPool();
+    repository = new ChildRepository(pool as never);
+  });
+
+  describe('findById', () => {
+    it('should return a child when found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleChildRow],
+        rowCount: 1,
+      }));
+
+      const result = await repository.findById(sampleChildRow.id);
+
+      assert.ok(result);
+      assert.equal(result.id, sampleChildRow.id);
+      assert.equal(result.householdId, sampleChildRow.household_id);
+      assert.equal(result.name, sampleChildRow.name);
+      assert.equal(result.birthYear, sampleChildRow.birth_year);
+      assert.equal(result.userId, null);
+    });
+
+    it('should return null when child not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.findById('non-existent-id');
+
+      assert.equal(result, null);
+    });
+
+    it('should call query with correct parameters', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      await repository.findById('test-id');
+
+      assert.equal(pool.query.mock.callCount(), 1);
+      const [query, params] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes('SELECT'));
+      assert.ok(query.includes('WHERE id = $1'));
+      assert.deepEqual(params, ['test-id']);
+    });
+  });
+
+  describe('findByIdAndHousehold', () => {
+    it('should return a child when found in household', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleChildRow],
+        rowCount: 1,
+      }));
+
+      const result = await repository.findByIdAndHousehold(
+        sampleChildRow.id,
+        sampleChildRow.household_id,
+      );
+
+      assert.ok(result);
+      assert.equal(result.id, sampleChildRow.id);
+      assert.equal(result.householdId, sampleChildRow.household_id);
+    });
+
+    it('should return null when child not in household', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.findByIdAndHousehold('child-id', 'other-household-id');
+
+      assert.equal(result, null);
+    });
+
+    it('should call query with correct parameters', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      await repository.findByIdAndHousehold('child-id', 'household-id');
+
+      assert.equal(pool.query.mock.callCount(), 1);
+      const [query, params] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes('WHERE id = $1 AND household_id = $2'));
+      assert.deepEqual(params, ['child-id', 'household-id']);
+    });
+  });
+
+  describe('findByHousehold', () => {
+    it('should return all children for a household', async () => {
+      const secondChild = { ...sampleChildRow, id: 'child-2', name: 'Second Child' };
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleChildRow, secondChild],
+        rowCount: 2,
+      }));
+
+      const result = await repository.findByHousehold(sampleChildRow.household_id);
+
+      assert.equal(result.length, 2);
+      assert.equal(result[0].name, 'Test Child');
+      assert.equal(result[1].name, 'Second Child');
+    });
+
+    it('should return empty array when no children', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.findByHousehold('household-id');
+
+      assert.deepEqual(result, []);
+    });
+
+    it('should call query with correct parameters', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      await repository.findByHousehold('household-id');
+
+      assert.equal(pool.query.mock.callCount(), 1);
+      const [query, params] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes('WHERE household_id = $1'));
+      assert.ok(query.includes('ORDER BY name ASC'));
+      assert.deepEqual(params, ['household-id']);
+    });
+  });
+
+  describe('findByHouseholdWithPoints', () => {
+    it('should return children with points balance', async () => {
+      const childWithPoints = {
+        ...sampleChildRow,
+        points_earned: '100',
+        points_spent: '30',
+        points_balance: '70',
+      };
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [childWithPoints],
+        rowCount: 1,
+      }));
+
+      const result = await repository.findByHouseholdWithPoints(sampleChildRow.household_id);
+
+      assert.equal(result.length, 1);
+      assert.equal(result[0].name, 'Test Child');
+      assert.equal(result[0].pointsEarned, 100);
+      assert.equal(result[0].pointsSpent, 30);
+      assert.equal(result[0].pointsBalance, 70);
+    });
+  });
+
+  describe('findByUserId', () => {
+    it('should return a child when found by user ID', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleChildRowWithUser],
+        rowCount: 1,
+      }));
+
+      const result = await repository.findByUserId(sampleChildRowWithUser.user_id!);
+
+      assert.ok(result);
+      assert.equal(result.userId, sampleChildRowWithUser.user_id);
+    });
+
+    it('should return null when no child linked to user', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.findByUserId('user-id');
+
+      assert.equal(result, null);
+    });
+  });
+
+  describe('findByUserIdAndHousehold', () => {
+    it('should return a child when found by user ID and household', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleChildRowWithUser],
+        rowCount: 1,
+      }));
+
+      const result = await repository.findByUserIdAndHousehold(
+        sampleChildRowWithUser.user_id!,
+        sampleChildRowWithUser.household_id,
+      );
+
+      assert.ok(result);
+      assert.equal(result.userId, sampleChildRowWithUser.user_id);
+      assert.equal(result.householdId, sampleChildRowWithUser.household_id);
+    });
+
+    it('should return null when child not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.findByUserIdAndHousehold('user-id', 'household-id');
+
+      assert.equal(result, null);
+    });
+  });
+
+  describe('create', () => {
+    it('should create a new child', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleChildRow],
+        rowCount: 1,
+      }));
+
+      const data: CreateChildDto = {
+        householdId: sampleChildRow.household_id,
+        name: 'Test Child',
+        birthYear: 2015,
+      };
+
+      const result = await repository.create(data);
+
+      assert.ok(result);
+      assert.equal(result.name, 'Test Child');
+      assert.equal(result.birthYear, 2015);
+    });
+
+    it('should call query with correct INSERT statement', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleChildRow],
+        rowCount: 1,
+      }));
+
+      const data: CreateChildDto = {
+        householdId: 'household-id',
+        name: '  Test Child  ', // With whitespace
+        birthYear: 2015,
+      };
+
+      await repository.create(data);
+
+      assert.equal(pool.query.mock.callCount(), 1);
+      const [query, params] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes('INSERT INTO children'));
+      assert.ok(query.includes('RETURNING'));
+      // Name should be trimmed
+      assert.equal(params[2], 'Test Child');
+    });
+
+    it('should handle optional fields', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ ...sampleChildRow, birth_year: null, user_id: null }],
+        rowCount: 1,
+      }));
+
+      const data: CreateChildDto = {
+        householdId: 'household-id',
+        name: 'Test Child',
+        // No birthYear or userId
+      };
+
+      const result = await repository.create(data);
+
+      assert.ok(result);
+      assert.equal(result.birthYear, null);
+      assert.equal(result.userId, null);
+    });
+  });
+
+  describe('update', () => {
+    it('should update child name', async () => {
+      const updatedRow = { ...sampleChildRow, name: 'Updated Name' };
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [updatedRow],
+        rowCount: 1,
+      }));
+
+      const data: UpdateChildDto = { name: 'Updated Name' };
+      const result = await repository.update(sampleChildRow.id, sampleChildRow.household_id, data);
+
+      assert.ok(result);
+      assert.equal(result.name, 'Updated Name');
+    });
+
+    it('should update birth year', async () => {
+      const updatedRow = { ...sampleChildRow, birth_year: 2016 };
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [updatedRow],
+        rowCount: 1,
+      }));
+
+      const data: UpdateChildDto = { birthYear: 2016 };
+      const result = await repository.update(sampleChildRow.id, sampleChildRow.household_id, data);
+
+      assert.ok(result);
+      assert.equal(result.birthYear, 2016);
+    });
+
+    it('should return null when child not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const data: UpdateChildDto = { name: 'Updated Name' };
+      const result = await repository.update('non-existent', 'household-id', data);
+
+      assert.equal(result, null);
+    });
+
+    it('should return current child when no updates provided', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleChildRow],
+        rowCount: 1,
+      }));
+
+      const data: UpdateChildDto = {};
+      const result = await repository.update(sampleChildRow.id, sampleChildRow.household_id, data);
+
+      assert.ok(result);
+      // Should call findByIdAndHousehold instead of UPDATE
+      const [query] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes('SELECT'));
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete a child and return true', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ id: sampleChildRow.id }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.delete(sampleChildRow.id, sampleChildRow.household_id);
+
+      assert.equal(result, true);
+    });
+
+    it('should return false when child not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.delete('non-existent', 'household-id');
+
+      assert.equal(result, false);
+    });
+
+    it('should call query with correct DELETE statement', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      await repository.delete('child-id', 'household-id');
+
+      assert.equal(pool.query.mock.callCount(), 1);
+      const [query, params] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes('DELETE FROM children'));
+      assert.ok(query.includes('WHERE id = $1 AND household_id = $2'));
+      assert.deepEqual(params, ['child-id', 'household-id']);
+    });
+  });
+
+  describe('linkToUser', () => {
+    it('should link child to user and return true', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ id: sampleChildRow.id }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.linkToUser(sampleChildRow.id, 'user-id');
+
+      assert.equal(result, true);
+    });
+
+    it('should return false when child not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.linkToUser('non-existent', 'user-id');
+
+      assert.equal(result, false);
+    });
+  });
+
+  describe('unlinkFromUser', () => {
+    it('should unlink child from user and return true', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ id: sampleChildRow.id }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.unlinkFromUser(sampleChildRow.id);
+
+      assert.equal(result, true);
+    });
+
+    it('should return false when child not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.unlinkFromUser('non-existent');
+
+      assert.equal(result, false);
+    });
+  });
+
+  describe('getHouseholdId', () => {
+    it('should return household ID for child', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ household_id: sampleChildRow.household_id }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.getHouseholdId(sampleChildRow.id);
+
+      assert.equal(result, sampleChildRow.household_id);
+    });
+
+    it('should return null when child not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.getHouseholdId('non-existent');
+
+      assert.equal(result, null);
+    });
+  });
+
+  describe('belongsToHousehold', () => {
+    it('should return true when child belongs to household', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ id: 1 }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.belongsToHousehold(
+        sampleChildRow.id,
+        sampleChildRow.household_id,
+      );
+
+      assert.equal(result, true);
+    });
+
+    it('should return false when child does not belong to household', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.belongsToHousehold('child-id', 'other-household');
+
+      assert.equal(result, false);
+    });
+  });
+
+  describe('countByHousehold', () => {
+    it('should return count of children', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ count: '5' }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.countByHousehold('household-id');
+
+      assert.equal(result, 5);
+    });
+
+    it('should return 0 when no children', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ count: '0' }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.countByHousehold('household-id');
+
+      assert.equal(result, 0);
+    });
+  });
+
+  describe('getPointsBalance', () => {
+    it('should return points balance for child', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ points_earned: '100', points_spent: '30', points_balance: '70' }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.getPointsBalance(sampleChildRow.id);
+
+      assert.ok(result);
+      assert.equal(result.pointsEarned, 100);
+      assert.equal(result.pointsSpent, 30);
+      assert.equal(result.pointsBalance, 70);
+    });
+
+    it('should return zeros when no points data exists', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.getPointsBalance(sampleChildRow.id);
+
+      assert.ok(result);
+      assert.equal(result.pointsEarned, 0);
+      assert.equal(result.pointsSpent, 0);
+      assert.equal(result.pointsBalance, 0);
+    });
+  });
+
+  describe('withClient', () => {
+    it('should create a new repository instance with client', () => {
+      const mockClient = { query: mock.fn() };
+      const newRepo = repository.withClient(mockClient as never);
+
+      assert.ok(newRepo instanceof ChildRepository);
+      assert.notEqual(newRepo, repository);
+    });
+  });
+});

--- a/apps/backend/src/repositories/user.repository.test.ts
+++ b/apps/backend/src/repositories/user.repository.test.ts
@@ -1,0 +1,539 @@
+/**
+ * UserRepository Unit Tests
+ *
+ * Tests the UserRepository using mocked database connections.
+ * No actual database is required to run these tests.
+ */
+
+import { describe, it, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { UserRepository, type CreateUserDto, type UpdateUserDto } from './user.repository.js';
+
+// Mock Pool implementation
+function createMockPool() {
+  const queryMock = mock.fn();
+  return {
+    query: queryMock,
+    connect: mock.fn(),
+    end: mock.fn(),
+  };
+}
+
+// Sample user row data
+const sampleUserRow = {
+  id: '123e4567-e89b-12d3-a456-426614174000',
+  email: 'test@example.com',
+  name: 'Test User',
+  password_hash: 'hashed_password',
+  oauth_provider: null,
+  oauth_provider_id: null,
+  created_at: new Date('2024-01-01T00:00:00Z'),
+  updated_at: new Date('2024-01-01T00:00:00Z'),
+};
+
+const sampleOAuthUserRow = {
+  ...sampleUserRow,
+  id: '123e4567-e89b-12d3-a456-426614174001',
+  email: 'oauth@example.com',
+  password_hash: null,
+  oauth_provider: 'google',
+  oauth_provider_id: 'google-123',
+};
+
+const samplePasswordResetTokenRow = {
+  id: '123e4567-e89b-12d3-a456-426614174002',
+  user_id: sampleUserRow.id,
+  token: 'reset-token-123',
+  expires_at: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 hours from now
+  used: false,
+  created_at: new Date('2024-01-01T00:00:00Z'),
+};
+
+describe('UserRepository', () => {
+  let pool: ReturnType<typeof createMockPool>;
+  let repository: UserRepository;
+
+  beforeEach(() => {
+    pool = createMockPool();
+    repository = new UserRepository(pool as never);
+  });
+
+  describe('findById', () => {
+    it('should return a user when found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleUserRow],
+        rowCount: 1,
+      }));
+
+      const result = await repository.findById(sampleUserRow.id);
+
+      assert.ok(result);
+      assert.equal(result.id, sampleUserRow.id);
+      assert.equal(result.email, sampleUserRow.email);
+      assert.equal(result.name, sampleUserRow.name);
+      assert.equal(result.passwordHash, sampleUserRow.password_hash);
+    });
+
+    it('should return null when user not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.findById('non-existent-id');
+
+      assert.equal(result, null);
+    });
+
+    it('should call query with correct parameters', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      await repository.findById('test-id');
+
+      assert.equal(pool.query.mock.callCount(), 1);
+      const [query, params] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes('SELECT'));
+      assert.ok(query.includes('WHERE id = $1'));
+      assert.deepEqual(params, ['test-id']);
+    });
+  });
+
+  describe('findByEmail', () => {
+    it('should return a user when found by email', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleUserRow],
+        rowCount: 1,
+      }));
+
+      const result = await repository.findByEmail('test@example.com');
+
+      assert.ok(result);
+      assert.equal(result.email, sampleUserRow.email);
+    });
+
+    it('should lowercase email before querying', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      await repository.findByEmail('TEST@EXAMPLE.COM');
+
+      const [, params] = pool.query.mock.calls[0].arguments;
+      assert.deepEqual(params, ['test@example.com']);
+    });
+
+    it('should return null when user not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.findByEmail('notfound@example.com');
+
+      assert.equal(result, null);
+    });
+  });
+
+  describe('findByOAuth', () => {
+    it('should return a user when found by OAuth provider', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleOAuthUserRow],
+        rowCount: 1,
+      }));
+
+      const result = await repository.findByOAuth('google', 'google-123');
+
+      assert.ok(result);
+      assert.equal(result.oauthProvider, 'google');
+      assert.equal(result.oauthProviderId, 'google-123');
+    });
+
+    it('should return null when OAuth user not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.findByOAuth('google', 'non-existent');
+
+      assert.equal(result, null);
+    });
+
+    it('should call query with correct parameters', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      await repository.findByOAuth('google', 'provider-id');
+
+      const [query, params] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes('oauth_provider = $1'));
+      assert.ok(query.includes('oauth_provider_id = $2'));
+      assert.deepEqual(params, ['google', 'provider-id']);
+    });
+  });
+
+  describe('create', () => {
+    it('should create a new user with password', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleUserRow],
+        rowCount: 1,
+      }));
+
+      const data: CreateUserDto = {
+        email: 'new@example.com',
+        name: 'New User',
+        passwordHash: 'hashed_password',
+      };
+
+      const result = await repository.create(data);
+
+      assert.ok(result);
+      assert.equal(result.email, sampleUserRow.email);
+    });
+
+    it('should create a new OAuth user', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleOAuthUserRow],
+        rowCount: 1,
+      }));
+
+      const data: CreateUserDto = {
+        email: 'oauth@example.com',
+        oauthProvider: 'google',
+        oauthProviderId: 'google-123',
+      };
+
+      const result = await repository.create(data);
+
+      assert.ok(result);
+      assert.equal(result.oauthProvider, 'google');
+    });
+
+    it('should lowercase email before inserting', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleUserRow],
+        rowCount: 1,
+      }));
+
+      await repository.create({ email: 'NEW@EXAMPLE.COM' });
+
+      const [, params] = pool.query.mock.calls[0].arguments;
+      assert.equal(params[0], 'new@example.com');
+    });
+
+    it('should handle optional fields as null', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleUserRow],
+        rowCount: 1,
+      }));
+
+      await repository.create({ email: 'test@example.com' });
+
+      const [, params] = pool.query.mock.calls[0].arguments;
+      assert.equal(params[1], null); // name
+      assert.equal(params[2], null); // passwordHash
+      assert.equal(params[3], null); // oauthProvider
+      assert.equal(params[4], null); // oauthProviderId
+    });
+  });
+
+  describe('update', () => {
+    it('should update user email', async () => {
+      const updatedRow = { ...sampleUserRow, email: 'updated@example.com' };
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [updatedRow],
+        rowCount: 1,
+      }));
+
+      const result = await repository.update(sampleUserRow.id, { email: 'UPDATED@EXAMPLE.COM' });
+
+      assert.ok(result);
+      const [, params] = pool.query.mock.calls[0].arguments;
+      assert.equal(params[0], 'updated@example.com'); // lowercased
+    });
+
+    it('should update user name', async () => {
+      const updatedRow = { ...sampleUserRow, name: 'Updated Name' };
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [updatedRow],
+        rowCount: 1,
+      }));
+
+      const result = await repository.update(sampleUserRow.id, { name: 'Updated Name' });
+
+      assert.ok(result);
+      assert.equal(result.name, 'Updated Name');
+    });
+
+    it('should return null when user not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.update('non-existent', { name: 'New Name' });
+
+      assert.equal(result, null);
+    });
+
+    it('should return current user when no updates provided', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [sampleUserRow],
+        rowCount: 1,
+      }));
+
+      const result = await repository.update(sampleUserRow.id, {});
+
+      assert.ok(result);
+      // Should call findById instead of UPDATE
+      const [query] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes('SELECT'));
+    });
+  });
+
+  describe('updatePassword', () => {
+    it('should update password and return true', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ id: sampleUserRow.id }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.updatePassword(sampleUserRow.id, 'new_hash');
+
+      assert.equal(result, true);
+    });
+
+    it('should return false when user not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.updatePassword('non-existent', 'new_hash');
+
+      assert.equal(result, false);
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete user and return true', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ id: sampleUserRow.id }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.delete(sampleUserRow.id);
+
+      assert.equal(result, true);
+    });
+
+    it('should return false when user not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.delete('non-existent');
+
+      assert.equal(result, false);
+    });
+  });
+
+  describe('emailExists', () => {
+    it('should return true when email exists', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ id: 1 }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.emailExists('test@example.com');
+
+      assert.equal(result, true);
+    });
+
+    it('should return false when email does not exist', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.emailExists('notfound@example.com');
+
+      assert.equal(result, false);
+    });
+
+    it('should lowercase email before checking', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      await repository.emailExists('TEST@EXAMPLE.COM');
+
+      const [, params] = pool.query.mock.calls[0].arguments;
+      assert.deepEqual(params, ['test@example.com']);
+    });
+  });
+
+  // Password Reset Token Tests
+
+  describe('createPasswordResetToken', () => {
+    it('should create a password reset token', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [samplePasswordResetTokenRow],
+        rowCount: 1,
+      }));
+
+      const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+      const result = await repository.createPasswordResetToken(
+        sampleUserRow.id,
+        'token-123',
+        expiresAt,
+      );
+
+      assert.ok(result);
+      assert.equal(result.userId, sampleUserRow.id);
+      assert.equal(result.token, samplePasswordResetTokenRow.token);
+      assert.equal(result.used, false);
+    });
+  });
+
+  describe('findValidPasswordResetToken', () => {
+    it('should return token when valid and not expired', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [samplePasswordResetTokenRow],
+        rowCount: 1,
+      }));
+
+      const result = await repository.findValidPasswordResetToken('reset-token-123');
+
+      assert.ok(result);
+      assert.equal(result.token, samplePasswordResetTokenRow.token);
+    });
+
+    it('should return null when token not found or expired', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.findValidPasswordResetToken('invalid-token');
+
+      assert.equal(result, null);
+    });
+
+    it('should query with correct conditions', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      await repository.findValidPasswordResetToken('token');
+
+      const [query] = pool.query.mock.calls[0].arguments;
+      assert.ok(query.includes('used = false'));
+      assert.ok(query.includes('expires_at > NOW()'));
+    });
+  });
+
+  describe('markPasswordResetTokenUsed', () => {
+    it('should mark token as used and return true', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ id: samplePasswordResetTokenRow.id }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.markPasswordResetTokenUsed(samplePasswordResetTokenRow.id);
+
+      assert.equal(result, true);
+    });
+
+    it('should return false when token not found', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.markPasswordResetTokenUsed('non-existent');
+
+      assert.equal(result, false);
+    });
+  });
+
+  describe('deleteExpiredPasswordResetTokens', () => {
+    it('should delete expired tokens and return count', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ id: '1' }, { id: '2' }],
+        rowCount: 2,
+      }));
+
+      const result = await repository.deleteExpiredPasswordResetTokens(sampleUserRow.id);
+
+      assert.equal(result, 2);
+    });
+
+    it('should return 0 when no tokens to delete', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.deleteExpiredPasswordResetTokens(sampleUserRow.id);
+
+      assert.equal(result, 0);
+    });
+  });
+
+  describe('deleteAllPasswordResetTokens', () => {
+    it('should delete all tokens for user and return count', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ id: '1' }, { id: '2' }, { id: '3' }],
+        rowCount: 3,
+      }));
+
+      const result = await repository.deleteAllPasswordResetTokens(sampleUserRow.id);
+
+      assert.equal(result, 3);
+    });
+  });
+
+  describe('getUserIdByPasswordResetToken', () => {
+    it('should return user ID for valid token', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [{ user_id: sampleUserRow.id }],
+        rowCount: 1,
+      }));
+
+      const result = await repository.getUserIdByPasswordResetToken('valid-token');
+
+      assert.equal(result, sampleUserRow.id);
+    });
+
+    it('should return null for invalid token', async () => {
+      pool.query.mock.mockImplementation(async () => ({
+        rows: [],
+        rowCount: 0,
+      }));
+
+      const result = await repository.getUserIdByPasswordResetToken('invalid-token');
+
+      assert.equal(result, null);
+    });
+  });
+
+  describe('withClient', () => {
+    it('should create a new repository instance with client', () => {
+      const mockClient = { query: mock.fn() };
+      const newRepo = repository.withClient(mockClient as never);
+
+      assert.ok(newRepo instanceof UserRepository);
+      assert.notEqual(newRepo, repository);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for ChildRepository (37 tests)
- Add comprehensive unit tests for UserRepository (36 tests)
- Add comprehensive unit tests for AssignmentRepository (47 tests)
- All tests use mocked database connections (no database required)
- Total: 120 new repository unit tests

This completes the repository unit tests for issue #289. Combined with the existing TaskRepository (26 tests) and HouseholdRepository (26 tests), we now have 172 repository unit tests total.

## Test plan
- [x] All 172 repository unit tests pass locally
- [ ] CI passes

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)