### PR TITLE
feat(frontend): add Rewards page to main navigation (#348)

### DIFF
--- a/apps/frontend/src/app/components/navigation/bottom-nav/bottom-nav.spec.ts
+++ b/apps/frontend/src/app/components/navigation/bottom-nav/bottom-nav.spec.ts
@@ -21,12 +21,12 @@ describe('BottomNav', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should display all 4 navigation items', () => {
+  it('should display all 5 navigation items', () => {
     componentRef.setInput('activeScreen', 'home');
     fixture.detectChanges();
 
     const navButtons = fixture.nativeElement.querySelectorAll('.nav-btn');
-    expect(navButtons.length).toBe(4);
+    expect(navButtons.length).toBe(5);
   });
 
   it('should display correct icons and labels', () => {
@@ -41,8 +41,8 @@ describe('BottomNav', () => {
       (btn as HTMLElement).querySelector('.nav-label')?.textContent?.trim(),
     );
 
-    expect(icons).toEqual(['🏠', '✓', '👥', '🏆']);
-    expect(labels).toEqual(['Home', 'Tasks', 'Family', 'Progress']);
+    expect(icons).toEqual(['🏠', '✓', '👥', '🏆', '🎁']);
+    expect(labels).toEqual(['Home', 'Tasks', 'Family', 'Progress', 'Rewards']);
   });
 
   it('should apply active class to current screen', () => {
@@ -138,7 +138,7 @@ describe('BottomNav', () => {
       (btn as HTMLElement).getAttribute('aria-label'),
     );
 
-    expect(labels).toEqual(['Home', 'Tasks', 'Family', 'Progress']);
+    expect(labels).toEqual(['Home', 'Tasks', 'Family', 'Progress', 'Rewards']);
   });
 
   it('should update active state when activeScreen changes', () => {

--- a/apps/frontend/src/app/components/navigation/bottom-nav/bottom-nav.ts
+++ b/apps/frontend/src/app/components/navigation/bottom-nav/bottom-nav.ts
@@ -4,7 +4,7 @@ import { Component, ChangeDetectionStrategy, input, output } from '@angular/core
  * Screen identifier type for navigation
  * 'none' is used when no main nav item should be active (e.g., Settings page)
  */
-export type NavScreen = 'home' | 'tasks' | 'family' | 'progress' | 'none';
+export type NavScreen = 'home' | 'tasks' | 'family' | 'progress' | 'rewards' | 'none';
 
 /**
  * Navigation item configuration
@@ -41,6 +41,7 @@ export class BottomNav {
     { id: 'tasks', icon: '✓', label: 'Tasks' },
     { id: 'family', icon: '👥', label: 'Family' },
     { id: 'progress', icon: '🏆', label: 'Progress' },
+    { id: 'rewards', icon: '🎁', label: 'Rewards' },
   ];
 
   /**

--- a/apps/frontend/src/app/components/navigation/sidebar-nav/sidebar-nav.spec.ts
+++ b/apps/frontend/src/app/components/navigation/sidebar-nav/sidebar-nav.spec.ts
@@ -46,13 +46,13 @@ describe('SidebarNav', () => {
     expect(logo?.textContent).toContain('Diddit!');
   });
 
-  it('should display all 4 navigation items', () => {
+  it('should display all 5 navigation items', () => {
     componentRef.setInput('activeScreen', 'home');
     componentRef.setInput('user', mockUser);
     fixture.detectChanges();
 
     const navButtons = fixture.nativeElement.querySelectorAll('.sidebar-btn');
-    expect(navButtons.length).toBe(4);
+    expect(navButtons.length).toBe(5);
   });
 
   it('should display correct icons and labels', () => {
@@ -68,8 +68,8 @@ describe('SidebarNav', () => {
       (btn as HTMLElement).textContent?.replace(/[^\w\s]/g, '').trim(),
     );
 
-    expect(icons).toEqual(['🏠', '✓', '👥', '🏆']);
-    expect(labels).toEqual(['Home', 'Tasks', 'Family', 'Progress']);
+    expect(icons).toEqual(['🏠', '✓', '👥', '🏆', '🎁']);
+    expect(labels).toEqual(['Home', 'Tasks', 'Family', 'Progress', 'Rewards']);
   });
 
   it('should apply active class to current screen', () => {

--- a/apps/frontend/src/app/components/navigation/sidebar-nav/sidebar-nav.ts
+++ b/apps/frontend/src/app/components/navigation/sidebar-nav/sidebar-nav.ts
@@ -52,6 +52,7 @@ export class SidebarNav {
     { id: 'tasks', icon: '✓', label: 'Tasks' },
     { id: 'family', icon: '👥', label: 'Family' },
     { id: 'progress', icon: '🏆', label: 'Progress' },
+    { id: 'rewards', icon: '🎁', label: 'Rewards' },
   ];
 
   /**

--- a/apps/frontend/src/app/layouts/main-layout/main-layout.ts
+++ b/apps/frontend/src/app/layouts/main-layout/main-layout.ts
@@ -133,6 +133,8 @@ export class MainLayout implements OnInit, OnDestroy {
       this.activeScreen.set('family');
     } else if (url.includes('/progress')) {
       this.activeScreen.set('progress');
+    } else if (url.includes('/rewards')) {
+      this.activeScreen.set('rewards');
     } else {
       // Settings, household-settings, or other pages - no main nav item active
       this.activeScreen.set('none');
@@ -151,6 +153,7 @@ export class MainLayout implements OnInit, OnDestroy {
       tasks: '/tasks',
       family: '/family',
       progress: '/progress',
+      rewards: '/rewards',
     };
 
     const route = routes[screen];


### PR DESCRIPTION
## Summary
- Add Rewards to sidebar navigation (desktop)
- Add Rewards to bottom navigation (mobile)
- Handle rewards route detection in MainLayout
- Update tests for 5 nav items

The Rewards Management page was fully functional but had no navigation link - users could only access it by typing the URL directly.

## Test plan
- [x] All 634 frontend tests pass
- [x] Build succeeds
- [ ] CI passes

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)