### PR TITLE
feat(frontend): create navigation UI for child layout (#349)

### DIFF
--- a/apps/frontend/src/app/components/navigation/child-nav/child-nav.css
+++ b/apps/frontend/src/app/components/navigation/child-nav/child-nav.css
@@ -1,0 +1,87 @@
+.child-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--color-surface, #ffffff);
+  padding: var(--space-md, 16px) var(--space-lg, 24px);
+  box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.1);
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-md, 16px);
+  z-index: 1000;
+}
+
+.child-nav-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs, 4px);
+  padding: var(--space-md, 16px) var(--space-sm, 8px);
+  background: var(--color-background, #f9fafb);
+  border: 2px solid transparent;
+  border-radius: var(--radius-lg, 16px);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  color: var(--color-text-secondary, #6b7280);
+  font-family: var(--font-body, 'Outfit', sans-serif);
+  min-height: 80px;
+}
+
+.child-nav-btn:hover {
+  background: var(--color-background-hover, #f3f4f6);
+  transform: scale(1.02);
+}
+
+.child-nav-btn.active {
+  background: linear-gradient(
+    135deg,
+    var(--color-primary, #6366f1) 0%,
+    var(--color-secondary, #ec4899) 100%
+  );
+  color: white;
+  border-color: transparent;
+  transform: scale(1.02);
+}
+
+.child-nav-btn:focus-visible {
+  outline: 3px solid var(--color-primary, #6366f1);
+  outline-offset: 2px;
+}
+
+.child-nav-icon {
+  font-size: 32px;
+  line-height: 1;
+}
+
+.child-nav-label {
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.2;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* Tablet and desktop - larger buttons */
+@media (min-width: 768px) {
+  .child-nav {
+    max-width: 400px;
+    left: 50%;
+    transform: translateX(-50%);
+    border-radius: var(--radius-lg, 16px) var(--radius-lg, 16px) 0 0;
+  }
+
+  .child-nav-btn {
+    min-height: 100px;
+    padding: var(--space-lg, 24px);
+  }
+
+  .child-nav-icon {
+    font-size: 40px;
+  }
+
+  .child-nav-label {
+    font-size: 16px;
+  }
+}

--- a/apps/frontend/src/app/components/navigation/child-nav/child-nav.html
+++ b/apps/frontend/src/app/components/navigation/child-nav/child-nav.html
@@ -1,0 +1,15 @@
+<nav class="child-nav" role="navigation" aria-label="Child navigation">
+  @for (item of navItems; track item.id) {
+    <button
+      type="button"
+      class="child-nav-btn"
+      [class.active]="isActive(item.id)"
+      (click)="handleNavClick(item.id)"
+      [attr.aria-label]="item.label"
+      [attr.aria-current]="isActive(item.id) ? 'page' : null"
+    >
+      <div class="child-nav-icon">{{ item.icon }}</div>
+      <div class="child-nav-label">{{ item.label }}</div>
+    </button>
+  }
+</nav>

--- a/apps/frontend/src/app/components/navigation/child-nav/child-nav.spec.ts
+++ b/apps/frontend/src/app/components/navigation/child-nav/child-nav.spec.ts
@@ -1,0 +1,158 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ChildNav } from './child-nav';
+import { ComponentRef } from '@angular/core';
+
+describe('ChildNav', () => {
+  let component: ChildNav;
+  let componentRef: ComponentRef<ChildNav>;
+  let fixture: ComponentFixture<ChildNav>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ChildNav],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChildNav);
+    component = fixture.componentInstance;
+    componentRef = fixture.componentRef;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display 2 navigation items', () => {
+    componentRef.setInput('activeScreen', 'tasks');
+    fixture.detectChanges();
+
+    const navButtons = fixture.nativeElement.querySelectorAll('.child-nav-btn');
+    expect(navButtons.length).toBe(2);
+  });
+
+  it('should display correct icons and labels', () => {
+    componentRef.setInput('activeScreen', 'tasks');
+    fixture.detectChanges();
+
+    const navButtons = fixture.nativeElement.querySelectorAll('.child-nav-btn');
+    const icons = Array.from(navButtons).map((btn) =>
+      (btn as HTMLElement).querySelector('.child-nav-icon')?.textContent?.trim(),
+    );
+    const labels = Array.from(navButtons).map((btn) =>
+      (btn as HTMLElement).querySelector('.child-nav-label')?.textContent?.trim(),
+    );
+
+    expect(icons).toEqual(['📋', '🎁']);
+    expect(labels).toEqual(['My Tasks', 'My Rewards']);
+  });
+
+  it('should apply active class to current screen', () => {
+    componentRef.setInput('activeScreen', 'tasks');
+    fixture.detectChanges();
+
+    const navButtons = fixture.nativeElement.querySelectorAll('.child-nav-btn');
+    const tasksButton = navButtons[0];
+    const rewardsButton = navButtons[1];
+
+    expect(tasksButton.classList.contains('active')).toBe(true);
+    expect(rewardsButton.classList.contains('active')).toBe(false);
+  });
+
+  it('should apply active class to rewards when active', () => {
+    componentRef.setInput('activeScreen', 'rewards');
+    fixture.detectChanges();
+
+    const navButtons = fixture.nativeElement.querySelectorAll('.child-nav-btn');
+    const tasksButton = navButtons[0];
+    const rewardsButton = navButtons[1];
+
+    expect(tasksButton.classList.contains('active')).toBe(false);
+    expect(rewardsButton.classList.contains('active')).toBe(true);
+  });
+
+  it('should emit navigate event when nav item clicked', () => {
+    const navigateSpy = vi.fn();
+    component.navigate.subscribe(navigateSpy);
+
+    componentRef.setInput('activeScreen', 'tasks');
+    fixture.detectChanges();
+
+    const navButtons = fixture.nativeElement.querySelectorAll('.child-nav-btn');
+    const rewardsButton = navButtons[1];
+    rewardsButton.click();
+
+    expect(navigateSpy).toHaveBeenCalledWith('rewards');
+  });
+
+  it('should emit correct screen for each navigation item', () => {
+    const navigateSpy = vi.fn();
+    component.navigate.subscribe(navigateSpy);
+
+    componentRef.setInput('activeScreen', 'tasks');
+    fixture.detectChanges();
+
+    const navButtons = fixture.nativeElement.querySelectorAll('.child-nav-btn');
+
+    (navButtons[0] as HTMLButtonElement).click();
+    expect(navigateSpy).toHaveBeenCalledWith('tasks');
+
+    (navButtons[1] as HTMLButtonElement).click();
+    expect(navigateSpy).toHaveBeenCalledWith('rewards');
+  });
+
+  it('should have correct accessibility attributes', () => {
+    componentRef.setInput('activeScreen', 'tasks');
+    fixture.detectChanges();
+
+    const nav = fixture.nativeElement.querySelector('.child-nav');
+    expect(nav.getAttribute('role')).toBe('navigation');
+    expect(nav.getAttribute('aria-label')).toBe('Child navigation');
+  });
+
+  it('should set aria-current on active item', () => {
+    componentRef.setInput('activeScreen', 'rewards');
+    fixture.detectChanges();
+
+    const navButtons = fixture.nativeElement.querySelectorAll('.child-nav-btn');
+    const rewardsButton = navButtons[1];
+
+    expect(rewardsButton.getAttribute('aria-current')).toBe('page');
+  });
+
+  it('should not set aria-current on non-active items', () => {
+    componentRef.setInput('activeScreen', 'tasks');
+    fixture.detectChanges();
+
+    const navButtons = fixture.nativeElement.querySelectorAll('.child-nav-btn');
+    const rewardsButton = navButtons[1];
+
+    expect(rewardsButton.getAttribute('aria-current')).toBeNull();
+  });
+
+  it('should have aria-label for each navigation item', () => {
+    componentRef.setInput('activeScreen', 'tasks');
+    fixture.detectChanges();
+
+    const navButtons = fixture.nativeElement.querySelectorAll('.child-nav-btn');
+    const labels = Array.from(navButtons).map((btn) =>
+      (btn as HTMLElement).getAttribute('aria-label'),
+    );
+
+    expect(labels).toEqual(['My Tasks', 'My Rewards']);
+  });
+
+  it('should update active state when activeScreen changes', () => {
+    componentRef.setInput('activeScreen', 'tasks');
+    fixture.detectChanges();
+
+    let navButtons = fixture.nativeElement.querySelectorAll('.child-nav-btn');
+    expect(navButtons[0].classList.contains('active')).toBe(true);
+    expect(navButtons[1].classList.contains('active')).toBe(false);
+
+    componentRef.setInput('activeScreen', 'rewards');
+    fixture.detectChanges();
+
+    navButtons = fixture.nativeElement.querySelectorAll('.child-nav-btn');
+    expect(navButtons[0].classList.contains('active')).toBe(false);
+    expect(navButtons[1].classList.contains('active')).toBe(true);
+  });
+});

--- a/apps/frontend/src/app/components/navigation/child-nav/child-nav.ts
+++ b/apps/frontend/src/app/components/navigation/child-nav/child-nav.ts
@@ -1,0 +1,65 @@
+import { Component, ChangeDetectionStrategy, input, output } from '@angular/core';
+
+/**
+ * Child navigation screen type
+ */
+export type ChildNavScreen = 'tasks' | 'rewards';
+
+/**
+ * Child navigation item configuration
+ */
+export interface ChildNavItem {
+  id: ChildNavScreen;
+  icon: string;
+  label: string;
+}
+
+/**
+ * Child Navigation Component
+ *
+ * Simple bottom navigation for child users with two options:
+ * - My Tasks
+ * - My Rewards
+ *
+ * Designed to be playful and easy for children to use.
+ */
+@Component({
+  selector: 'app-child-nav',
+  imports: [],
+  templateUrl: './child-nav.html',
+  styleUrl: './child-nav.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ChildNav {
+  /**
+   * Currently active screen
+   */
+  activeScreen = input.required<ChildNavScreen>();
+
+  /**
+   * Emitted when user navigates to a different screen
+   */
+  navigate = output<ChildNavScreen>();
+
+  /**
+   * Navigation items configuration
+   */
+  readonly navItems: ChildNavItem[] = [
+    { id: 'tasks', icon: '📋', label: 'My Tasks' },
+    { id: 'rewards', icon: '🎁', label: 'My Rewards' },
+  ];
+
+  /**
+   * Handle navigation item click
+   */
+  handleNavClick(screen: ChildNavScreen) {
+    this.navigate.emit(screen);
+  }
+
+  /**
+   * Check if a screen is active
+   */
+  isActive(screen: ChildNavScreen): boolean {
+    return this.activeScreen() === screen;
+  }
+}

--- a/apps/frontend/src/app/layouts/child-layout/child-layout.css
+++ b/apps/frontend/src/app/layouts/child-layout/child-layout.css
@@ -1,4 +1,106 @@
 .child-layout {
   min-height: 100vh;
   background: linear-gradient(180deg, #f0f9ff 0%, #e0f2fe 100%);
+  display: flex;
+  flex-direction: column;
+}
+
+/* Header */
+.child-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: linear-gradient(
+    135deg,
+    var(--color-primary, #6366f1) 0%,
+    var(--color-secondary, #ec4899) 100%
+  );
+  padding: var(--space-md, 16px);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+}
+
+.child-header-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.child-logo {
+  font-family: var(--font-display, 'Outfit', sans-serif);
+  font-size: 28px;
+  font-weight: 800;
+  color: white;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.logout-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs, 4px);
+  padding: var(--space-sm, 8px) var(--space-md, 16px);
+  background: rgba(255, 255, 255, 0.2);
+  border: 2px solid rgba(255, 255, 255, 0.4);
+  border-radius: var(--radius-full, 9999px);
+  color: white;
+  font-family: var(--font-body, 'Outfit', sans-serif);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.logout-btn:hover {
+  background: rgba(255, 255, 255, 0.3);
+  transform: scale(1.05);
+}
+
+.logout-btn:focus-visible {
+  outline: 3px solid white;
+  outline-offset: 2px;
+}
+
+.logout-icon {
+  font-size: 18px;
+}
+
+.logout-text {
+  display: none;
+}
+
+@media (min-width: 400px) {
+  .logout-text {
+    display: inline;
+  }
+}
+
+/* Main Content */
+.child-content {
+  flex: 1;
+  padding-bottom: 120px; /* Space for bottom nav */
+}
+
+/* Tablet and desktop adjustments */
+@media (min-width: 768px) {
+  .child-header {
+    padding: var(--space-lg, 24px);
+  }
+
+  .child-logo {
+    font-size: 32px;
+  }
+
+  .logout-btn {
+    padding: var(--space-md, 16px) var(--space-lg, 24px);
+    font-size: 16px;
+  }
+
+  .logout-icon {
+    font-size: 20px;
+  }
+
+  .child-content {
+    padding-bottom: 140px;
+  }
 }

--- a/apps/frontend/src/app/layouts/child-layout/child-layout.html
+++ b/apps/frontend/src/app/layouts/child-layout/child-layout.html
@@ -1,3 +1,20 @@
 <div class="child-layout">
-  <router-outlet />
+  <!-- Header -->
+  <header class="child-header">
+    <div class="child-header-content">
+      <div class="child-logo">Diddit!</div>
+      <button type="button" class="logout-btn" (click)="onLogout()" aria-label="Log out">
+        <span class="logout-icon">👋</span>
+        <span class="logout-text">Bye!</span>
+      </button>
+    </div>
+  </header>
+
+  <!-- Main Content -->
+  <main class="child-content">
+    <router-outlet />
+  </main>
+
+  <!-- Bottom Navigation -->
+  <app-child-nav [activeScreen]="activeScreen()" (navigate)="onNavigate($event)" />
 </div>

--- a/apps/frontend/src/app/layouts/child-layout/child-layout.ts
+++ b/apps/frontend/src/app/layouts/child-layout/child-layout.ts
@@ -1,18 +1,85 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import {
+  Component,
+  ChangeDetectionStrategy,
+  signal,
+  inject,
+  OnInit,
+  OnDestroy,
+} from '@angular/core';
+import { Router, RouterOutlet, NavigationEnd } from '@angular/router';
+import { filter, Subscription } from 'rxjs';
+import { ChildNav, type ChildNavScreen } from '../../components/navigation/child-nav/child-nav';
+import { AuthService } from '../../services/auth.service';
 
 /**
  * Child Layout Component
  *
- * Simple layout wrapper for child user pages.
- * Child pages have minimal chrome and a child-friendly interface.
- * No sidebar/bottom nav - child pages handle their own navigation.
+ * Layout wrapper for child user pages with:
+ * - Header with greeting and logout
+ * - Bottom navigation (Tasks / Rewards)
+ * - Child-friendly interface
  */
 @Component({
   selector: 'app-child-layout',
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, ChildNav],
   templateUrl: './child-layout.html',
   styleUrl: './child-layout.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ChildLayout {}
+export class ChildLayout implements OnInit, OnDestroy {
+  private readonly router = inject(Router);
+  private readonly authService = inject(AuthService);
+  private routerSubscription: Subscription | null = null;
+
+  // State
+  protected readonly activeScreen = signal<ChildNavScreen>('tasks');
+
+  ngOnInit(): void {
+    this.updateActiveScreenFromUrl(this.router.url);
+
+    // Listen for route changes
+    this.routerSubscription = this.router.events
+      .pipe(filter((event): event is NavigationEnd => event instanceof NavigationEnd))
+      .subscribe((event) => {
+        this.updateActiveScreenFromUrl(event.urlAfterRedirects);
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.routerSubscription?.unsubscribe();
+  }
+
+  /**
+   * Update active screen based on URL
+   */
+  private updateActiveScreenFromUrl(url: string): void {
+    if (url.includes('/my-rewards')) {
+      this.activeScreen.set('rewards');
+    } else {
+      this.activeScreen.set('tasks');
+    }
+  }
+
+  /**
+   * Handle navigation
+   */
+  protected onNavigate(screen: ChildNavScreen): void {
+    const routes: Record<ChildNavScreen, string> = {
+      tasks: '/my-tasks',
+      rewards: '/my-rewards',
+    };
+
+    const route = routes[screen];
+    if (route) {
+      void this.router.navigate([route]);
+    }
+  }
+
+  /**
+   * Handle logout
+   */
+  protected onLogout(): void {
+    this.authService.logout();
+    void this.router.navigate(['/child-login']);
+  }
+}


### PR DESCRIPTION
## Summary
- Add ChildNav component with 2-button bottom navigation (Tasks/Rewards)
- Add header with logo and logout button to ChildLayout
- Playful, child-friendly design with large touch targets
- 12 new unit tests for ChildNav component

Previously, children who logged in were stuck on `/my-tasks` with no way to navigate to `/my-rewards` or log out.

## Changes

### New Files
- `child-nav.ts` - Navigation component with Tasks/Rewards buttons
- `child-nav.html` - Accessible navigation template
- `child-nav.css` - Child-friendly styling with large buttons
- `child-nav.spec.ts` - 12 comprehensive tests

### Modified Files
- `child-layout.ts` - Added navigation state and logout handling
- `child-layout.html` - Added header and navigation
- `child-layout.css` - Added header and layout styling

## Test plan
- [x] All 646 frontend tests pass
- [x] Build succeeds
- [ ] CI passes

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)