### PR TITLE
feat(frontend): add household settings access to Settings page

### DIFF
--- a/apps/frontend/src/app/pages/settings/settings.css
+++ b/apps/frontend/src/app/pages/settings/settings.css
@@ -315,6 +315,71 @@
   box-shadow: var(--shadow-md);
 }
 
+/* ===== HOUSEHOLD SECTION ===== */
+
+.household-info {
+  margin-bottom: var(--space-md);
+}
+
+.household-links {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.settings-link {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  background: var(--color-background);
+  border-radius: var(--radius-sm);
+  text-decoration: none;
+  color: var(--color-text-primary);
+  transition:
+    background 0.2s,
+    transform 0.2s;
+}
+
+.settings-link:hover {
+  background: var(--color-surface-hover, #f3f4f6);
+  transform: translateX(4px);
+}
+
+.settings-link:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.link-icon {
+  font-size: var(--font-size-lg);
+  flex-shrink: 0;
+}
+
+.link-text {
+  flex: 1;
+  font-weight: var(--font-weight-medium);
+}
+
+.link-arrow {
+  color: var(--color-text-muted, #9ca3af);
+  font-size: var(--font-size-lg);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 var(--space-xs);
+  background: var(--color-primary);
+  color: white;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  border-radius: var(--radius-full);
+}
+
 /* ===== ACCOUNT INFO ===== */
 
 .account-info {

--- a/apps/frontend/src/app/pages/settings/settings.html
+++ b/apps/frontend/src/app/pages/settings/settings.html
@@ -136,6 +136,37 @@
         </form>
       </section>
 
+      <!-- Household Section -->
+      @if (activeHousehold()) {
+        <section class="settings-section">
+          <h2>Household</h2>
+
+          <div class="household-info">
+            <div class="info-row">
+              <span class="info-label">Current Household</span>
+              <span class="info-value">{{ activeHousehold()?.name }}</span>
+            </div>
+          </div>
+
+          <div class="household-links">
+            <a routerLink="/household/settings" class="settings-link">
+              <span class="link-icon">⚙️</span>
+              <span class="link-text">Household Settings</span>
+              <span class="link-arrow">→</span>
+            </a>
+
+            <a routerLink="/invitations" class="settings-link">
+              <span class="link-icon">✉️</span>
+              <span class="link-text">Invitations</span>
+              @if (pendingInvitationsCount() > 0) {
+                <span class="badge">{{ pendingInvitationsCount() }}</span>
+              }
+              <span class="link-arrow">→</span>
+            </a>
+          </div>
+        </section>
+      }
+
       <!-- Account Section -->
       <section class="settings-section">
         <h2>Account</h2>


### PR DESCRIPTION
## Summary
- Add Household section to Settings page showing current household name
- Add navigation link to /household/settings for household configuration
- Add navigation link to /invitations with pending invitation count badge

This provides users easy access to household management features directly from the Settings page, completing the navigation gaps identified in the UX audit.

## Changes
- **settings.ts**: Added HouseholdService and InvitationService integration, loads household data and pending invitations count
- **settings.html**: Added Household section with styled navigation links
- **settings.css**: Added styles for household links and invitation badge

## Test plan
- [x] Build succeeds
- [x] All 646 frontend tests pass
- [ ] Verify Household section appears when user has active household
- [ ] Verify pending invitations badge shows correct count
- [ ] Verify links navigate to correct pages

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)