### PR TITLE
feat(frontend): wire up child login credentials UI on Family page

### DIFF
--- a/apps/frontend/src/app/components/modals/child-details-modal/child-details-modal.css
+++ b/apps/frontend/src/app/components/modals/child-details-modal/child-details-modal.css
@@ -1,0 +1,202 @@
+/* Child Details Modal Styles */
+
+.child-details {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+/* Info Section */
+.info-section {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-md);
+  background: var(--color-background);
+  border-radius: var(--radius-md);
+}
+
+.child-avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: var(--radius-full);
+  background: var(--gradient-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.avatar-emoji {
+  font-size: 32px;
+}
+
+.child-info {
+  flex: 1;
+}
+
+.child-name {
+  font-family: var(--font-heading);
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-primary);
+  margin: 0 0 var(--space-xs) 0;
+}
+
+.child-age {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+/* Section Title */
+.section-title {
+  font-family: var(--font-heading);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  margin: 0 0 var(--space-sm) 0;
+  padding-bottom: var(--space-xs);
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+}
+
+/* Account Section */
+.account-section {
+  padding: var(--space-md);
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border, #e5e7eb);
+}
+
+.account-status {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-sm);
+  padding: var(--space-sm);
+  border-radius: var(--radius-sm);
+  margin-bottom: var(--space-md);
+}
+
+.account-status.has-account {
+  background: var(--color-success-light, #dcfce7);
+}
+
+.account-status.no-account {
+  background: var(--color-warning-light, #fef3c7);
+}
+
+.status-icon {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  flex-shrink: 0;
+}
+
+.has-account .status-icon {
+  color: var(--color-success, #22c55e);
+}
+
+.no-account .status-icon {
+  color: var(--color-warning, #f59e0b);
+}
+
+.status-info {
+  flex: 1;
+}
+
+.status-label {
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  margin: 0 0 var(--space-xs) 0;
+}
+
+.status-detail {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.create-btn {
+  width: 100%;
+}
+
+/* QR Section */
+.qr-section {
+  padding: var(--space-md);
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border, #e5e7eb);
+  opacity: 0.7;
+}
+
+.qr-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-lg);
+  background: var(--color-background);
+  border-radius: var(--radius-sm);
+  border: 2px dashed var(--color-border, #d1d5db);
+}
+
+.qr-icon {
+  font-size: 48px;
+  margin-bottom: var(--space-sm);
+}
+
+.qr-label {
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  margin: 0 0 var(--space-xs) 0;
+}
+
+.qr-description {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  margin: 0;
+  text-align: center;
+}
+
+/* Modal Actions */
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-sm);
+  padding-top: var(--space-md);
+  margin-top: var(--space-md);
+  border-top: 1px solid var(--color-border, #e5e7eb);
+}
+
+/* Button styles */
+.btn {
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+  transition:
+    transform 0.2s,
+    box-shadow 0.2s;
+  border: none;
+}
+
+.btn-primary {
+  background: var(--gradient-primary);
+  color: white;
+}
+
+.btn-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+.btn-secondary {
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border, #d1d5db);
+}
+
+.btn-secondary:hover {
+  background: var(--color-background);
+}

--- a/apps/frontend/src/app/components/modals/child-details-modal/child-details-modal.html
+++ b/apps/frontend/src/app/components/modals/child-details-modal/child-details-modal.html
@@ -1,0 +1,87 @@
+<app-modal [open]="open()" (closeModal)="onClose()" title="Child Details">
+  @if (child(); as child) {
+    <div class="child-details">
+      <!-- Child Info Section -->
+      <div class="info-section">
+        <div class="child-avatar">
+          <span class="avatar-emoji">
+            @if (child.avatarUrl) {
+              {{ child.avatarUrl }}
+            } @else {
+              👤
+            }
+          </span>
+        </div>
+
+        <div class="child-info">
+          <h3 class="child-name">{{ child.name }}</h3>
+          @if (childAge()) {
+            <p class="child-age">{{ childAge() }} years old</p>
+          }
+        </div>
+      </div>
+
+      <!-- Account Status Section -->
+      <div class="account-section">
+        <h4 class="section-title">Login Account</h4>
+
+        @if (hasAccount()) {
+          <!-- Child has account -->
+          <div class="account-status has-account">
+            <span class="status-icon">✓</span>
+            <div class="status-info">
+              <p class="status-label">Account Active</p>
+              @if (childEmail()) {
+                <p class="status-detail">{{ childEmail() }}</p>
+              }
+            </div>
+          </div>
+        } @else {
+          <!-- Child does not have account -->
+          @if (!showCreateAccount()) {
+            <div class="account-status no-account">
+              <span class="status-icon">✗</span>
+              <div class="status-info">
+                <p class="status-label">No Account</p>
+                <p class="status-detail">Create login credentials so this child can sign in</p>
+              </div>
+            </div>
+
+            <button
+              type="button"
+              class="btn btn-primary create-btn"
+              (click)="toggleCreateAccount()"
+            >
+              Create Login
+            </button>
+          } @else {
+            <!-- Create Account Form -->
+            <app-create-child-account
+              [child]="child"
+              [householdId]="householdId()"
+              (accountCreated)="onAccountCreated()"
+              (cancelled)="onCreateAccountCancelled()"
+            />
+          }
+        }
+      </div>
+
+      <!-- QR Code Section (Future Feature) -->
+      <div class="qr-section">
+        <h4 class="section-title">QR Code Login</h4>
+        <div class="qr-placeholder">
+          <div class="qr-icon">📱</div>
+          <p class="qr-label">Coming Soon</p>
+          <p class="qr-description">Quick login with QR code scan</p>
+        </div>
+      </div>
+    </div>
+  }
+
+  <!-- Modal Actions -->
+  @if (!showCreateAccount()) {
+    <div class="modal-actions" modal-actions>
+      <button type="button" class="btn btn-secondary" (click)="onClose()">Close</button>
+    </div>
+  }
+</app-modal>

--- a/apps/frontend/src/app/components/modals/child-details-modal/child-details-modal.ts
+++ b/apps/frontend/src/app/components/modals/child-details-modal/child-details-modal.ts
@@ -1,0 +1,106 @@
+import { Component, input, output, signal, computed, ChangeDetectionStrategy } from '@angular/core';
+import type { Child } from '@st44/types';
+import { Modal } from '../modal/modal';
+import { CreateChildAccountComponent } from '../../create-child-account/create-child-account';
+
+/**
+ * Child Details Modal
+ *
+ * Shows child information and allows parents to:
+ * - View child details (name, age)
+ * - Create login credentials for children without accounts
+ * - View account status for children with accounts
+ *
+ * Design reserves space for future QR code login feature (#238).
+ */
+@Component({
+  selector: 'app-child-details-modal',
+  imports: [Modal, CreateChildAccountComponent],
+  templateUrl: './child-details-modal.html',
+  styleUrl: './child-details-modal.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ChildDetailsModal {
+  /**
+   * Whether the modal is open
+   */
+  open = input<boolean>(false);
+
+  /**
+   * The child to display details for
+   */
+  child = input<Child | null>(null);
+
+  /**
+   * The child's email if they have an account (from household members)
+   */
+  childEmail = input<string | null>(null);
+
+  /**
+   * The household ID for API calls
+   */
+  householdId = input.required<string>();
+
+  /**
+   * Event emitted when modal should close
+   */
+  closeRequested = output<void>();
+
+  /**
+   * Event emitted when account is created successfully
+   */
+  accountCreated = output<void>();
+
+  /**
+   * Whether to show the create account form
+   */
+  protected readonly showCreateAccount = signal(false);
+
+  /**
+   * Whether the child has an account (userId is set)
+   */
+  protected readonly hasAccount = computed(() => {
+    const child = this.child();
+    return child?.userId != null;
+  });
+
+  /**
+   * Calculate child's age from birth year
+   */
+  protected readonly childAge = computed(() => {
+    const child = this.child();
+    if (!child?.birthYear) return null;
+    return new Date().getFullYear() - child.birthYear;
+  });
+
+  /**
+   * Handle modal close
+   */
+  onClose(): void {
+    this.showCreateAccount.set(false);
+    this.closeRequested.emit();
+  }
+
+  /**
+   * Toggle create account form
+   */
+  toggleCreateAccount(): void {
+    this.showCreateAccount.update((v) => !v);
+  }
+
+  /**
+   * Handle account created event from CreateChildAccountComponent
+   */
+  onAccountCreated(): void {
+    this.showCreateAccount.set(false);
+    this.accountCreated.emit();
+    this.closeRequested.emit();
+  }
+
+  /**
+   * Handle cancel from CreateChildAccountComponent
+   */
+  onCreateAccountCancelled(): void {
+    this.showCreateAccount.set(false);
+  }
+}

--- a/apps/frontend/src/app/pages/family/family.html
+++ b/apps/frontend/src/app/pages/family/family.html
@@ -51,7 +51,12 @@
         @if (members().length > 0) {
           <div class="member-list">
             @for (member of members(); track member.id) {
-              <app-member-card [member]="member" [showStats]="true" [clickable]="false" />
+              <app-member-card
+                [member]="member"
+                [showStats]="true"
+                [clickable]="isChildMember(member)"
+                (cardClick)="onMemberClick($event)"
+              />
             }
           </div>
         } @else {
@@ -76,5 +81,16 @@
       (closeRequested)="closeAddChildModal()"
       (childAdded)="onChildAdded($event)"
     />
+
+    @if (householdId()) {
+      <app-child-details-modal
+        [open]="childDetailsModalOpen()"
+        [child]="selectedChild()"
+        [childEmail]="selectedChildEmail()"
+        [householdId]="householdId()!"
+        (closeRequested)="closeChildDetailsModal()"
+        (accountCreated)="onChildAccountCreated()"
+      />
+    }
   </div>
 }

--- a/apps/frontend/src/app/pages/family/family.spec.ts
+++ b/apps/frontend/src/app/pages/family/family.spec.ts
@@ -17,7 +17,10 @@ describe('Family', () => {
   };
   let mockAuthService: { currentUser: ReturnType<typeof vi.fn> };
   let mockInvitationService: { sendInvitation: ReturnType<typeof vi.fn> };
-  let mockChildrenService: { createChild: ReturnType<typeof vi.fn> };
+  let mockChildrenService: {
+    createChild: ReturnType<typeof vi.fn>;
+    listChildren: ReturnType<typeof vi.fn>;
+  };
 
   const mockUser = { id: 'user-1', email: 'test@example.com' };
   const mockHousehold = { id: 'household-1', name: 'Test Family' };
@@ -58,6 +61,18 @@ describe('Family', () => {
     };
     mockChildrenService = {
       createChild: vi.fn().mockResolvedValue({ id: 'child-1', name: 'New Child' }),
+      listChildren: vi.fn().mockResolvedValue([
+        {
+          id: 'child-1',
+          householdId: 'household-1',
+          userId: 'user-2',
+          name: 'Test Child',
+          birthYear: 2014,
+          avatarUrl: null,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ]),
     };
 
     // Default mock returns


### PR DESCRIPTION
## Summary
- Create ChildDetailsModal component to display child info and manage login credentials
- Make children clickable in the Family page member list
- Integrate existing CreateChildAccountComponent for account creation
- Reserve space in modal for future QR code login feature (#238)

This allows parents to set up login credentials for their children directly from the Family page, completing the connection between the existing backend API and frontend component.

## Changes
- **child-details-modal.ts/html/css**: New modal component showing child details, account status, and account creation form
- **family.ts**: Load children data, handle child click, open/close child details modal
- **family.html**: Make child members clickable, add child details modal
- **family.spec.ts**: Add listChildren mock to fix tests

## Test plan
- [x] Build succeeds
- [x] All 646 frontend tests pass
- [ ] Verify clicking on a child opens the details modal
- [ ] Verify "Create Login" button appears for children without accounts
- [ ] Verify account creation flow works end-to-end
- [ ] Verify children with accounts show "Account Active" status
- [ ] Verify QR code placeholder is visible for future feature

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)