### PR TITLE
fix: replace text placeholders with emoji icons in empty states

### DIFF
--- a/apps/frontend/src/app/pages/family/family.html
+++ b/apps/frontend/src/app/pages/family/family.html
@@ -61,7 +61,7 @@
           </div>
         } @else {
           <div class="empty-state" role="status">
-            <div class="empty-icon" aria-hidden="true">people</div>
+            <div class="empty-icon" aria-hidden="true">👨‍👩‍👧‍👦</div>
             <h3>No members yet</h3>
             <p>Start inviting family members to your household.</p>
           </div>

--- a/apps/frontend/src/app/pages/tasks/tasks.html
+++ b/apps/frontend/src/app/pages/tasks/tasks.html
@@ -61,7 +61,7 @@
       @if (filteredTasks().length === 0) {
         <!-- Empty State -->
         <div class="empty-state" role="status">
-          <div class="empty-icon" aria-hidden="true">clipboard</div>
+          <div class="empty-icon" aria-hidden="true">📋</div>
           <p class="empty-text">{{ emptyMessage() }}</p>
         </div>
       } @else {


### PR DESCRIPTION
## Summary

- Replaced text "clipboard" with 📋 emoji on Tasks page empty state
- Replaced text "people" with 👨‍👩‍👧‍👦 emoji on Family page empty state

The empty state icons were displaying literal text instead of visual icons. This matches the pattern used in other pages (home, child-dashboard).

## Test plan

- [x] Navigate to Tasks page with no tasks → verify 📋 icon displays
- [x] Navigate to Family page with no members → verify 👨‍👩‍👧‍👦 icon displays
- [x] All frontend tests pass
- [x] Build succeeds

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)