### PR TITLE
fix(frontend): use consistent child:childId format for all children

### DIFF
--- a/apps/frontend/src/app/pages/family/family.spec.ts
+++ b/apps/frontend/src/app/pages/family/family.spec.ts
@@ -149,8 +149,9 @@ describe('Family', () => {
         email: 'test@example.com',
         role: 'parent',
       });
+      // Children with accounts use child:childId format
       expect(members[1]).toMatchObject({
-        id: 'user-2',
+        id: 'child:child-1',
         name: 'Test Child',
         email: 'child@example.com',
         role: 'child',
@@ -178,14 +179,16 @@ describe('Family', () => {
       const currentUserMember = component['members']().find((m) => m.id === 'user-1');
       expect(currentUserMember?.name).toContain('(You)');
 
-      const otherMember = component['members']().find((m) => m.id === 'user-2');
+      // Children with accounts use child:childId format
+      const otherMember = component['members']().find((m) => m.id === 'child:child-1');
       expect(otherMember?.name).not.toContain('(You)');
     });
 
     it('should pass through task stats and points from backend', async () => {
       await component.ngOnInit();
 
-      const childMember = component['members']().find((m) => m.id === 'user-2');
+      // Children with accounts use child:childId format
+      const childMember = component['members']().find((m) => m.id === 'child:child-1');
       expect(childMember?.tasksCompleted).toBe(3);
       expect(childMember?.totalTasks).toBe(5);
       expect(childMember?.points).toBe(150);


### PR DESCRIPTION
## Summary

Follow-up fix to PR #358. Some children were still not clickable because children with accounts used `userId` as their ID, which could fail lookup if the child record wasn't properly linked.

**Root cause:** Children with accounts used `userId` as member ID, but the click handler looked up by `userId` in `childrenByUserId` map. If a child had an account but wasn't in that map, clicking did nothing.

## Changes

- All children now use `child:childId` format (with or without accounts)
- Build `userIdToChildId` map to find childId from household member's userId
- Simplified click handler - all children use same lookup path via `childrenById`
- Updated tests to expect new ID format

## Test plan

- [x] Frontend tests pass (646 tests)
- [x] Build succeeds
- [ ] Manual: All children clickable on Family page
- [ ] Manual: Child details modal opens for all children
- [ ] Manual: Can create account for children without one

🤖 Generated with [Claude Code](https://claude.com/claude-code)