### PR TITLE
fix(frontend): remove duplicate children on Family page

### DIFF
--- a/apps/frontend/src/app/pages/family/family.ts
+++ b/apps/frontend/src/app/pages/family/family.ts
@@ -133,20 +133,21 @@ export class Family implements OnInit {
       }
 
       // Track which children already have accounts (appear in householdMembers)
+      // Use userIdToChildId lookup instead of role string to handle case mismatches
       const childrenWithAccounts = new Set<string>();
       for (const member of householdMembers) {
-        if (member.role === 'child') {
-          const childId = userIdToChildId.get(member.userId);
-          if (childId) {
-            childrenWithAccounts.add(childId);
-          }
+        const childId = userIdToChildId.get(member.userId);
+        if (childId) {
+          childrenWithAccounts.add(childId);
         }
       }
 
       // Transform HouseholdMember[] to MemberCardData[]
       const memberCards: MemberCardData[] = householdMembers.map((member) => {
         const isCurrentUser = member.userId === user.id;
-        const isChild = member.role === 'child';
+        // Determine if member is a child by checking if they have a child record
+        // This is more reliable than checking member.role which may have case mismatches
+        const isChild = childByUserIdMap.has(member.userId);
         // Handle null email for unlinked children
         const emailUsername = member.email ? member.email.split('@')[0] : null;
         const displayName = isCurrentUser


### PR DESCRIPTION
## Summary

Fixes children appearing twice on the Family page where:
- First list: Not clickable
- Second list: Works correctly

## Root Cause

The code was using case-sensitive string comparison (`member.role === 'child'`) to:
1. Track which children already have accounts (to avoid duplicates)
2. Determine if a member should be displayed as a child (clickable)

If the backend returned a different case (e.g., 'Child' vs 'child'), children with accounts would be added twice and the first occurrence wouldn't be clickable.

## Fix

Use `childByUserIdMap.has(member.userId)` to determine if a member is a child, which checks if they have a child record linked to their user account. This is more reliable than depending on the role string from the backend.

## Changes

- `apps/frontend/src/app/pages/family/family.ts`
  - Line 138-143: Removed `if (member.role === 'child')` check when building `childrenWithAccounts`
  - Line 150: Changed `isChild` from `member.role === 'child'` to `childByUserIdMap.has(member.userId)`

## Test plan

- [x] All 19 family tests pass
- [x] Frontend builds successfully
- [ ] Manual test: Navigate to /family and verify children appear only once
- [ ] Manual test: Verify all child cards are clickable

Fixes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)