### PR TITLE
feat(frontend): add version info to Settings page

### DIFF
--- a/apps/frontend/src/app/pages/settings/settings.html
+++ b/apps/frontend/src/app/pages/settings/settings.html
@@ -182,6 +182,22 @@
           <button type="button" class="btn btn-danger" (click)="logout()">Log Out</button>
         </div>
       </section>
+
+      <!-- About Section -->
+      <section class="settings-section">
+        <h2>About</h2>
+
+        <div class="account-info">
+          <div class="info-row">
+            <span class="info-label">Version</span>
+            <span class="info-value">{{ appVersion }}</span>
+          </div>
+          <div class="info-row">
+            <span class="info-label">Build</span>
+            <span class="info-value">{{ buildTime | date: 'medium' }}</span>
+          </div>
+        </div>
+      </section>
     </div>
   </div>
 }

--- a/apps/frontend/src/app/pages/settings/settings.ts
+++ b/apps/frontend/src/app/pages/settings/settings.ts
@@ -6,6 +6,7 @@ import { UserService, type UserProfile } from '../../services/user.service';
 import { AuthService } from '../../services/auth.service';
 import { HouseholdService, type HouseholdListItem } from '../../services/household.service';
 import { InvitationService } from '../../services/invitation.service';
+import { environment } from '../../../environments/environment';
 
 /**
  * Settings Screen
@@ -55,6 +56,10 @@ export class Settings implements OnInit {
 
   // Password section toggle
   protected readonly showPasswordSection = signal(false);
+
+  // App version info
+  protected readonly appVersion = environment.version;
+  protected readonly buildTime = environment.buildTime;
 
   async ngOnInit(): Promise<void> {
     await Promise.all([this.loadProfile(), this.loadHouseholdData()]);

--- a/apps/frontend/src/environments/environment.development.ts
+++ b/apps/frontend/src/environments/environment.development.ts
@@ -2,4 +2,6 @@ export const environment = {
   production: false,
   apiUrl: '',
   googleClientId: '', // Add your Google OAuth Client ID here for development
+  version: '1.0.0-dev',
+  buildTime: new Date().toISOString(),
 };

--- a/apps/frontend/src/environments/environment.ts
+++ b/apps/frontend/src/environments/environment.ts
@@ -2,4 +2,6 @@ export const environment = {
   production: true,
   apiUrl: '',
   googleClientId: '', // Add your Google OAuth Client ID here for production
+  version: '1.0.0',
+  buildTime: new Date().toISOString(),
 };


### PR DESCRIPTION
## Summary

Adds version and build time display to the Settings page to help verify which build is deployed.

## Changes

- Added `version` and `buildTime` to environment files
- Added "About" section to Settings page showing:
  - **Version**: e.g., "1.0.0"
  - **Build**: timestamp of when the build was created

## Screenshot location

Settings page > scroll to bottom > "About" section

## Test plan

- [x] Frontend builds successfully
- [ ] Navigate to Settings page
- [ ] Verify "About" section shows version and build time

🤖 Generated with [Claude Code](https://claude.com/claude-code)