### PR TITLE
fix(backend): add /api/children/me/tasks endpoint for child dashboard

### DIFF
--- a/apps/backend/src/routes/children.ts
+++ b/apps/backend/src/routes/children.ts
@@ -574,10 +574,29 @@ export default async function childrenRoutes(server: FastifyInstance) {
   });
 
   // Get my tasks (for logged-in children)
-  server.get('/api/children/my-tasks', {
+  // Primary endpoint: /api/children/me/tasks (used by frontend)
+  server.get('/api/children/me/tasks', {
     schema: stripResponseValidation({
       summary: 'Get tasks for logged-in child',
       description: 'Returns tasks assigned to the authenticated child user',
+      tags: ['children'],
+      security: [{ bearerAuth: [] }],
+      querystring: zodToOpenAPI(TaskQuerySchema),
+      response: {
+        200: zodToOpenAPI(MyTasksResponseSchema),
+        ...CommonErrors.Unauthorized,
+        ...CommonErrors.InternalServerError,
+      },
+    }),
+    preHandler: [authenticateUser],
+    handler: getMyTasks,
+  });
+
+  // Legacy alias: /api/children/my-tasks (for backward compatibility)
+  server.get('/api/children/my-tasks', {
+    schema: stripResponseValidation({
+      summary: 'Get tasks for logged-in child (legacy)',
+      description: 'Legacy endpoint - use /api/children/me/tasks instead',
       tags: ['children'],
       security: [{ bearerAuth: [] }],
       querystring: zodToOpenAPI(TaskQuerySchema),


### PR DESCRIPTION
## Summary

- Fixed 400 validation error when children log in and view their dashboard
- The frontend was calling `/api/children/me/tasks` but backend only had `/api/children/my-tasks`
- Added `/api/children/me/tasks` as primary endpoint (matches frontend)
- Kept `/api/children/my-tasks` as legacy alias for backward compatibility

## Test plan

- [ ] Login as a child user
- [ ] Navigate to child dashboard
- [ ] Verify tasks load correctly without "We couldn't load your tasks" error
- [ ] Verify backend tests pass in CI

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)