### PR TITLE
fix(frontend): quick-add now creates task assignment for child

### DIFF
--- a/apps/frontend/src/app/services/task.service.ts
+++ b/apps/frontend/src/app/services/task.service.ts
@@ -385,4 +385,35 @@ export class TaskService {
     this.errorSignal.set(null);
     this.assignmentsErrorSignal.set(null);
   }
+
+  /**
+   * Create a manual task assignment for a specific task, child, and date
+   *
+   * @param taskId - ID of the task template
+   * @param childId - ID of the child to assign to (optional)
+   * @param date - Date for the assignment (ISO format YYYY-MM-DD)
+   * @returns Observable of the created assignment
+   */
+  createManualAssignment(
+    taskId: string,
+    childId: string | null,
+    date: string,
+  ): Observable<{ assignment: Assignment }> {
+    return from(
+      this.apiService.post<{ assignment: Assignment }>(`/assignments/manual`, {
+        taskId,
+        childId,
+        date,
+      }),
+    ).pipe(
+      tap((response) => {
+        // Add to state
+        this.assignmentsSignal.update((assignments) => [...assignments, response.assignment]);
+      }),
+      catchError((err) => {
+        this.assignmentsErrorSignal.set('Failed to create assignment');
+        return throwError(() => err);
+      }),
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- Fix quick-add modal not assigning tasks to children
- Pass `assignedChildren` in `ruleConfig` when creating task
- Create manual task assignment for today after task creation
- Add `createManualAssignment` method to TaskService

## Problem
When a parent used quick-add to create a daily task and assigned it to a child, the task did not appear on the child's task list because:
1. The `assignedChildId` was collected but never passed to the API
2. No `task_assignment` record was created for today

## Solution
The quick-add flow now:
1. Creates the task with `ruleConfig.assignedChildren: [childId]`
2. Immediately creates a manual assignment for today via `/api/assignments/manual`

This ensures the task appears on the child's dashboard immediately.

## Test plan
- [x] Frontend builds successfully
- [x] Frontend tests pass (647 passed)
- [ ] Manual test: Create task via quick-add, verify it appears on child's task list

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)