### PR TITLE
fix(frontend): show assigned children in edit task modal for all rule types

### DIFF
--- a/apps/frontend/src/app/components/task-edit/task-edit.html
+++ b/apps/frontend/src/app/components/task-edit/task-edit.html
@@ -168,43 +168,45 @@
         }
 
         <!-- Assigned Children -->
-        @if (ruleType !== 'daily') {
-          <div class="form-group">
-            <fieldset>
-              <legend>
-                Assign to Children <span class="required">*</span>
-                @if (ruleType === 'weekly_rotation') {
-                  <span class="help">(Select 2+ for rotation)</span>
-                }
-              </legend>
-              <div class="children-selector" role="group" aria-label="Assign children">
-                @for (child of children(); track child.id) {
-                  <label class="child-checkbox">
-                    <input
-                      type="checkbox"
-                      [checked]="isChildSelected(child.id)"
-                      (change)="onChildChange(child.id, $any($event.target).checked)"
-                      [attr.aria-label]="'Assign to ' + child.name"
-                    />
-                    {{ child.name }}
-                  </label>
-                }
-              </div>
-              @if (
-                taskForm.get('assignedChildren')?.invalid &&
-                taskForm.get('assignedChildren')?.touched
-              ) {
-                <p class="error" role="alert">
-                  @if (ruleType === 'weekly_rotation') {
-                    Select at least 2 children for rotation
-                  } @else {
-                    Select at least 1 child
-                  }
-                </p>
+        <div class="form-group">
+          <fieldset>
+            <legend>
+              Assign to Children
+              @if (ruleType !== 'daily') {
+                <span class="required">*</span>
               }
-            </fieldset>
-          </div>
-        }
+              @if (ruleType === 'weekly_rotation') {
+                <span class="help">(Select 2+ for rotation)</span>
+              } @else if (ruleType === 'daily') {
+                <span class="help">(Optional)</span>
+              }
+            </legend>
+            <div class="children-selector" role="group" aria-label="Assign children">
+              @for (child of children(); track child.id) {
+                <label class="child-checkbox">
+                  <input
+                    type="checkbox"
+                    [checked]="isChildSelected(child.id)"
+                    (change)="onChildChange(child.id, $any($event.target).checked)"
+                    [attr.aria-label]="'Assign to ' + child.name"
+                  />
+                  {{ child.name }}
+                </label>
+              }
+            </div>
+            @if (
+              taskForm.get('assignedChildren')?.invalid && taskForm.get('assignedChildren')?.touched
+            ) {
+              <p class="error" role="alert">
+                @if (ruleType === 'weekly_rotation') {
+                  Select at least 2 children for rotation
+                } @else {
+                  Select at least 1 child
+                }
+              </p>
+            }
+          </fieldset>
+        </div>
 
         <!-- Active Status -->
         <div class="form-group">


### PR DESCRIPTION
## Summary
- Show "Assign to Children" section for all task rule types, not just repeating/rotation
- Mark assignment as optional for daily tasks, required for others
- Display appropriate help text per rule type

## Problem
When editing a task, the edit modal did not display which child the task was currently assigned to for daily tasks. Additionally, there was no way to change the assigned child from the edit modal for daily tasks because the children selector was hidden.

## Solution
The children selector is now visible for all rule types:
- **Daily**: Optional assignment, shows "(Optional)" help text
- **Repeating**: Required, shows validation error if no child selected
- **Weekly Rotation**: Required (2+ children), shows "(Select 2+ for rotation)" help text

## Test plan
- [x] Frontend builds successfully
- [x] Frontend tests pass (647 passed)
- [ ] Manual test: Open edit modal for a daily task with assigned child, verify child is shown
- [ ] Manual test: Change assigned child for daily task, verify it saves correctly

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)