### PR TITLE
fix(frontend): load children using task's householdId in edit modal

### DIFF
--- a/apps/frontend/src/app/components/task-edit/task-edit.css
+++ b/apps/frontend/src/app/components/task-edit/task-edit.css
@@ -267,6 +267,17 @@ fieldset {
   color: #dc2626;
 }
 
+.empty-state {
+  margin: 0;
+  padding: 1rem;
+  font-size: 0.875rem;
+  color: #6b7280;
+  background-color: #f9fafb;
+  border: 1px dashed #d1d5db;
+  border-radius: 0.375rem;
+  text-align: center;
+}
+
 .error-message {
   padding: 1rem;
   margin-bottom: 1rem;

--- a/apps/frontend/src/app/components/task-edit/task-edit.html
+++ b/apps/frontend/src/app/components/task-edit/task-edit.html
@@ -192,6 +192,10 @@
                   />
                   {{ child.name }}
                 </label>
+              } @empty {
+                <p class="empty-state">
+                  No children in this household. Add children from the Family page to assign tasks.
+                </p>
               }
             </div>
             @if (

--- a/apps/frontend/src/app/components/task-edit/task-edit.spec.ts
+++ b/apps/frontend/src/app/components/task-edit/task-edit.spec.ts
@@ -3,7 +3,6 @@ import { TaskEditComponent } from './task-edit';
 import type { Task } from '@st44/types';
 import { TaskService } from '../../services/task.service';
 import { ChildrenService } from '../../services/children.service';
-import { HouseholdService } from '../../services/household.service';
 import { of, throwError } from 'rxjs';
 import { signal } from '@angular/core';
 import { FormArray } from '@angular/forms';
@@ -24,9 +23,6 @@ describe('TaskEditComponent', () => {
   };
   let mockChildrenService: {
     listChildren: ReturnType<typeof vi.fn>;
-  };
-  let mockHouseholdService: {
-    getActiveHouseholdId: ReturnType<typeof vi.fn>;
   };
 
   const mockChildren = [
@@ -61,16 +57,11 @@ describe('TaskEditComponent', () => {
       listChildren: vi.fn().mockResolvedValue(mockChildren),
     };
 
-    mockHouseholdService = {
-      getActiveHouseholdId: vi.fn().mockReturnValue('household-1'),
-    };
-
     TestBed.configureTestingModule({
       imports: [TaskEditComponent],
       providers: [
         { provide: TaskService, useValue: mockTaskService },
         { provide: ChildrenService, useValue: mockChildrenService },
-        { provide: HouseholdService, useValue: mockHouseholdService },
       ],
     });
 
@@ -259,12 +250,6 @@ describe('TaskEditComponent', () => {
   describe('Save', () => {
     it('should not save if form is invalid', () => {
       component.taskForm.get('name')?.setValue('');
-      component.onSave();
-      expect(mockTaskService.updateTask).not.toHaveBeenCalled();
-    });
-
-    it('should not save if no household ID', () => {
-      mockHouseholdService.getActiveHouseholdId.mockReturnValue(null);
       component.onSave();
       expect(mockTaskService.updateTask).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary
- Fix task edit modal not showing children checkboxes
- Load children using task's `householdId` directly instead of `householdService.getActiveHouseholdId()`
- Add empty state message when household has no children

## Problem
The task edit modal showed no children to assign because it was trying to load them using `householdService.getActiveHouseholdId()`, which could return null if the active household wasn't set in localStorage.

## Solution
Use the task's `householdId` directly as the source of truth:
- Load children in the effect that handles task input changes
- Use `task.householdId` for both loading children and saving updates
- Remove dependency on `HouseholdService`

## Test plan
- [x] Frontend builds successfully
- [x] All tests pass (646 passed)
- [ ] Manual test: Open edit modal for any task, verify children checkboxes are shown
- [ ] Manual test: Verify assigned children are pre-selected

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)