### PR TITLE
fix(frontend): show children selector for all rule types in edit task modal

### DIFF
--- a/apps/frontend/src/app/components/modals/edit-task-modal/edit-task-modal.html
+++ b/apps/frontend/src/app/components/modals/edit-task-modal/edit-task-modal.html
@@ -112,44 +112,47 @@
         </div>
       }
 
-      <!-- Assigned Children (shown for repeating and weekly_rotation) -->
-      @if (ruleType !== 'daily') {
-        <div class="form-group">
-          <fieldset class="child-fieldset">
-            <legend class="form-label">
-              Assign to Children *
+      <!-- Assigned Children (shown for all rule types) -->
+      <div class="form-group">
+        <fieldset class="child-fieldset">
+          <legend class="form-label">
+            Assign to Children
+            @if (ruleType !== 'daily') {
+              <span class="required">*</span>
+            }
+            @if (ruleType === 'weekly_rotation') {
+              <span class="help-text">(Select 2+ for rotation)</span>
+            } @else if (ruleType === 'daily') {
+              <span class="help-text">(Optional)</span>
+            }
+          </legend>
+          <div class="children-selector" role="group" aria-label="Assign children">
+            @for (child of children(); track child.id) {
+              <label class="child-checkbox">
+                <input
+                  type="checkbox"
+                  [checked]="isChildSelected(child.id)"
+                  (change)="onChildChange(child.id, $any($event.target).checked)"
+                  [attr.aria-label]="'Assign to ' + child.name"
+                />
+                {{ child.name }}
+              </label>
+            }
+            @if (children().length === 0) {
+              <p class="no-children-message">No children in this household yet.</p>
+            }
+          </div>
+          @if (form.controls.assignedChildren.invalid && form.controls.assignedChildren.touched) {
+            <div class="form-error" role="alert">
               @if (ruleType === 'weekly_rotation') {
-                <span class="help-text">(Select 2+ for rotation)</span>
-              }
-            </legend>
-            <div class="children-selector" role="group" aria-label="Assign children">
-              @for (child of children(); track child.id) {
-                <label class="child-checkbox">
-                  <input
-                    type="checkbox"
-                    [checked]="isChildSelected(child.id)"
-                    (change)="onChildChange(child.id, $any($event.target).checked)"
-                    [attr.aria-label]="'Assign to ' + child.name"
-                  />
-                  {{ child.name }}
-                </label>
-              }
-              @if (children().length === 0) {
-                <p class="no-children-message">No children in this household yet.</p>
+                Select at least 2 children for rotation
+              } @else {
+                Select at least 1 child
               }
             </div>
-            @if (form.controls.assignedChildren.invalid && form.controls.assignedChildren.touched) {
-              <div class="form-error" role="alert">
-                @if (ruleType === 'weekly_rotation') {
-                  Select at least 2 children for rotation
-                } @else {
-                  Select at least 1 child
-                }
-              </div>
-            }
-          </fieldset>
-        </div>
-      }
+          }
+        </fieldset>
+      </div>
 
       <div class="modal-actions-split" modal-actions>
         <button type="button" class="btn btn-danger" (click)="onDeleteClick()">Delete</button>


### PR DESCRIPTION
## Summary
- Show "Assign to Children" selector for all task types (daily, repeating, weekly_rotation)
- For daily tasks, children assignment is optional (displayed as "(Optional)")
- For repeating/weekly_rotation tasks, children assignment remains required
- Load children using task's householdId directly instead of householdService
- Include assignedChildren in ruleConfig for daily tasks when children are selected

## Root Cause
The `EditTaskModal` component (used by the Tasks page) had two issues:
1. Children selector was hidden for daily tasks (`@if (ruleType !== 'daily')`)
2. Used `householdService.getActiveHouseholdId()` which could return null

Note: There was also a separate `TaskEditComponent` that was fixed in PR #395, but it was never integrated into the app - the actual component being used is `EditTaskModal`.

## Test plan
- [ ] Open Tasks page
- [ ] Click edit on a daily task - verify "Assign to Children" selector is visible
- [ ] Select a child and save - verify task is updated
- [ ] Edit a repeating task - verify children selector works
- [ ] Edit a weekly_rotation task - verify children selector works

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)