### PR TITLE
fix(backend): remove updated_at from task_assignments updates

### DIFF
--- a/apps/backend/src/routes/tasks.ts
+++ b/apps/backend/src/routes/tasks.ts
@@ -526,7 +526,7 @@ async function updateTask(request: FastifyRequest<UpdateTaskRequest>, reply: Fas
         // Single child assignment - update or create today's pending assignment
         const updateResult = await db.query(
           `UPDATE task_assignments
-           SET child_id = $1, updated_at = NOW()
+           SET child_id = $1
            WHERE task_id = $2
              AND date = $3
              AND status = 'pending'
@@ -547,7 +547,7 @@ async function updateTask(request: FastifyRequest<UpdateTaskRequest>, reply: Fas
         // No children assigned - set child_id to null for today's pending assignment
         await db.query(
           `UPDATE task_assignments
-           SET child_id = NULL, updated_at = NOW()
+           SET child_id = NULL
            WHERE task_id = $1
              AND date = $2
              AND status = 'pending'`,


### PR DESCRIPTION
## Summary
Fixed 500 error when updating tasks with assignedChildren.

## Root Cause
The `task_assignments` table does **NOT** have an `updated_at` column:

```sql
CREATE TABLE IF NOT EXISTS task_assignments (
  id UUID PRIMARY KEY,
  household_id UUID NOT NULL,
  task_id UUID NOT NULL,
  child_id UUID,
  date DATE NOT NULL,
  status VARCHAR(50) DEFAULT 'pending',
  created_at TIMESTAMP WITH TIME ZONE  -- NO updated_at!
);
```

But the code was trying to set it:
```sql
SET child_id = $1, updated_at = NOW()  -- ERROR!
```

## Fix
Removed `updated_at = NOW()` from both UPDATE statements in the task assignment update logic (lines 529 and 550).

## Test plan
- [ ] Edit a repeating task and assign a child
- [ ] Save should succeed (not return 500 error)
- [ ] Verify task_assignments table is updated with new child_id

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)