### PR TITLE
fix(frontend): add single task type to edit modal and clarify quick-add scope

### DIFF
--- a/apps/frontend/src/app/components/modals/edit-task-modal/edit-task-modal.css
+++ b/apps/frontend/src/app/components/modals/edit-task-modal/edit-task-modal.css
@@ -84,3 +84,13 @@
   color: var(--color-text-secondary);
   font-style: italic;
 }
+
+.info-message {
+  padding: var(--space-sm) var(--space-md);
+  background: var(--color-info-bg, #e7f3ff);
+  border: 1px solid var(--color-info-border, #b3d7ff);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  color: var(--color-info-text, #0056b3);
+  line-height: var(--line-height-relaxed);
+}

--- a/apps/frontend/src/app/components/modals/edit-task-modal/edit-task-modal.html
+++ b/apps/frontend/src/app/components/modals/edit-task-modal/edit-task-modal.html
@@ -112,47 +112,59 @@
         </div>
       }
 
-      <!-- Assigned Children (shown for all rule types) -->
-      <div class="form-group">
-        <fieldset class="child-fieldset">
-          <legend class="form-label">
-            Assign to Children
-            @if (ruleType !== 'daily') {
-              <span class="required">*</span>
-            }
-            @if (ruleType === 'weekly_rotation') {
-              <span class="help-text">(Select 2+ for rotation)</span>
-            } @else if (ruleType === 'daily') {
-              <span class="help-text">(Optional)</span>
-            }
-          </legend>
-          <div class="children-selector" role="group" aria-label="Assign children">
-            @for (child of children(); track child.id) {
-              <label class="child-checkbox">
-                <input
-                  type="checkbox"
-                  [checked]="isChildSelected(child.id)"
-                  (change)="onChildChange(child.id, $any($event.target).checked)"
-                  [attr.aria-label]="'Assign to ' + child.name"
-                />
-                {{ child.name }}
-              </label>
-            }
-            @if (children().length === 0) {
-              <p class="no-children-message">No children in this household yet.</p>
-            }
-          </div>
-          @if (form.controls.assignedChildren.invalid && form.controls.assignedChildren.touched) {
-            <div class="form-error" role="alert">
+      <!-- Assigned Children (shown for all rule types except single) -->
+      @if (ruleType !== 'single') {
+        <div class="form-group">
+          <fieldset class="child-fieldset">
+            <legend class="form-label">
+              Assign to Children
+              @if (ruleType !== 'daily') {
+                <span class="required">*</span>
+              }
               @if (ruleType === 'weekly_rotation') {
-                Select at least 2 children for rotation
-              } @else {
-                Select at least 1 child
+                <span class="help-text">(Select 2+ for rotation)</span>
+              } @else if (ruleType === 'daily') {
+                <span class="help-text">(Optional)</span>
+              }
+            </legend>
+            <div class="children-selector" role="group" aria-label="Assign children">
+              @for (child of children(); track child.id) {
+                <label class="child-checkbox">
+                  <input
+                    type="checkbox"
+                    [checked]="isChildSelected(child.id)"
+                    (change)="onChildChange(child.id, $any($event.target).checked)"
+                    [attr.aria-label]="'Assign to ' + child.name"
+                  />
+                  {{ child.name }}
+                </label>
+              }
+              @if (children().length === 0) {
+                <p class="no-children-message">No children in this household yet.</p>
               }
             </div>
-          }
-        </fieldset>
-      </div>
+            @if (form.controls.assignedChildren.invalid && form.controls.assignedChildren.touched) {
+              <div class="form-error" role="alert">
+                @if (ruleType === 'weekly_rotation') {
+                  Select at least 2 children for rotation
+                } @else {
+                  Select at least 1 child
+                }
+              </div>
+            }
+          </fieldset>
+        </div>
+      }
+
+      <!-- Single task info message -->
+      @if (ruleType === 'single') {
+        <div class="form-group">
+          <div class="info-message">
+            Single tasks are available for any child to claim. They appear in the "Available Tasks"
+            section.
+          </div>
+        </div>
+      }
 
       <div class="modal-actions-split" modal-actions>
         <button type="button" class="btn btn-danger" (click)="onDeleteClick()">Delete</button>

--- a/apps/frontend/src/app/components/modals/edit-task-modal/edit-task-modal.ts
+++ b/apps/frontend/src/app/components/modals/edit-task-modal/edit-task-modal.ts
@@ -128,6 +128,7 @@ export class EditTaskModal {
     { value: 'daily', label: 'Daily' },
     { value: 'repeating', label: 'Repeating (Custom Days)' },
     { value: 'weekly_rotation', label: 'Weekly Rotation' },
+    { value: 'single', label: 'Single (One-time)' },
   ];
 
   /**

--- a/apps/frontend/src/app/components/modals/quick-add-modal/quick-add-modal.html
+++ b/apps/frontend/src/app/components/modals/quick-add-modal/quick-add-modal.html
@@ -1,4 +1,4 @@
-<app-modal [open]="open()" (closeModal)="onClose()" title="Quick Add Task">
+<app-modal [open]="open()" (closeModal)="onClose()" title="Quick Add Daily Task">
   <form [formGroup]="form" (ngSubmit)="onSubmit()">
     <div class="form-group">
       <label class="form-label" for="task-name">Task Name *</label>


### PR DESCRIPTION
## Summary

- Add "Single (One-time)" option to edit task modal's recurrence dropdown
- Hide children selector for single tasks (children claim them instead)  
- Add info message explaining single task behavior
- Rename quick-add modal to "Quick Add Daily Task" to clarify its scope

## Changes

**Edit Task Modal (`edit-task-modal.ts`):**
- Added `{ value: 'single', label: 'Single (One-time)' }` to recurrence options

**Edit Task Modal Template (`edit-task-modal.html`):**
- Wrapped children selector with `@if (ruleType !== 'single')` to hide for single tasks
- Added info message when single type is selected explaining that single tasks are available for any child to claim

**Edit Task Modal Styles (`edit-task-modal.css`):**
- Added `.info-message` class for the single task explanation

**Quick-Add Modal (`quick-add-modal.html`):**
- Changed title from "Quick Add Task" to "Quick Add Daily Task" to clarify its purpose

## Test Plan

- [x] Frontend builds successfully
- [x] Frontend tests pass (646 passed)
- [x] Edit modal shows all 4 task types (daily, repeating, weekly_rotation, single)
- [x] When "Single" is selected, children selector is hidden
- [x] Info message appears for single tasks
- [x] Quick-add modal title is now "Quick Add Daily Task"

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)