### PR TITLE
fix(frontend): inject build timestamp at build time instead of runtime

### DIFF
--- a/apps/frontend/src/environments/environment.development.ts
+++ b/apps/frontend/src/environments/environment.development.ts
@@ -3,5 +3,5 @@ export const environment = {
   apiUrl: '',
   googleClientId: '', // Add your Google OAuth Client ID here for development
   version: '1.0.0-dev',
-  buildTime: new Date().toISOString(),
+  buildTime: 'development',
 };

--- a/apps/frontend/src/environments/environment.ts
+++ b/apps/frontend/src/environments/environment.ts
@@ -1,7 +1,11 @@
+// BUILD_TIME_PLACEHOLDER is replaced during the Docker build process
+// If not replaced, falls back to 'development' to indicate local dev
+const BUILD_TIME = 'BUILD_TIME_PLACEHOLDER';
+
 export const environment = {
   production: true,
   apiUrl: '',
   googleClientId: '', // Add your Google OAuth Client ID here for production
   version: '1.0.0',
-  buildTime: new Date().toISOString(),
+  buildTime: BUILD_TIME.startsWith('BUILD_TIME') ? 'development' : BUILD_TIME,
 };

--- a/infra/nginx/Dockerfile.frontend
+++ b/infra/nginx/Dockerfile.frontend
@@ -30,6 +30,10 @@ COPY apps/frontend/tsconfig*.json ./apps/frontend/
 COPY apps/frontend/.postcssrc.json ./apps/frontend/.postcssrc.json
 COPY apps/frontend/eslint.config.js ./apps/frontend/eslint.config.js
 
+# Inject build timestamp into environment.ts
+RUN BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ") && \
+    sed -i "s/BUILD_TIME_PLACEHOLDER/$BUILD_TIME/g" apps/frontend/src/environments/environment.ts
+
 # Build frontend
 RUN npm run build --workspace=apps/frontend --omit=dev
 


### PR DESCRIPTION
## Summary

Fixes the build timestamp shown in Settings to be set at build time rather than runtime, so it shows the actual deployment time instead of the current page load time.

## Problem

The build timestamp in the Settings page was updating on every page refresh because it used `new Date().toISOString()` at runtime.

## Solution

1. **Environment file** (`environment.ts`):
   - Replace dynamic `new Date()` with a `BUILD_TIME_PLACEHOLDER` constant
   - If placeholder is not replaced (local dev), show 'development'

2. **Dockerfile** (`Dockerfile.frontend`):
   - Add sed command to inject actual ISO timestamp during Docker build
   - Timestamp is captured at build time and embedded in the bundle

3. **Development mode** (`environment.development.ts`):
   - Show 'development' string instead of dynamic time
   - Makes it clear we're in dev mode

## Test Plan

- [x] Frontend builds successfully
- [ ] Docker build injects timestamp correctly
- [ ] Timestamp remains constant on page refresh in production
- [ ] Dev mode shows 'development'

Closes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)