### PR TITLE
fix(frontend): subscribe to loadAvailableTasks Observable in undoDecline

### DIFF
--- a/apps/frontend/src/app/services/single-task.service.ts
+++ b/apps/frontend/src/app/services/single-task.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, signal, computed, inject } from '@angular/core';
-import { Observable, tap, catchError, throwError } from 'rxjs';
+import { Observable, tap, catchError, throwError, switchMap, map } from 'rxjs';
 import { ApiService } from './api.service';
 import { ErrorHandlerService } from './error-handler.service';
 
@@ -175,10 +175,9 @@ export class SingleTaskService {
         success: boolean;
       }>(`/households/${householdId}/tasks/${taskId}/responses/${childId}`)
       .pipe(
-        tap(() => {
-          // Reload available tasks to show the task again
-          this.loadAvailableTasks();
-        }),
+        // Chain with loadAvailableTasks using switchMap to ensure the HTTP request fires
+        // and propagate completion/errors properly to callers
+        switchMap(() => this.loadAvailableTasks().pipe(map(() => ({ success: true })))),
         catchError((error) => {
           this.errorHandler.handle(error, { context: 'SingleTaskService.undoDecline' });
           return throwError(() => error);


### PR DESCRIPTION
## Summary
- Fix bug where undoDecline failed to reload available tasks
- Changed from unsubscribed Observable call to proper switchMap chain

## Problem
When a child undoes a task decline, the available tasks list doesn't refresh because `loadAvailableTasks()` was called without subscribing to the returned Observable. RxJS Observables are lazy - they don't execute until subscribed.

```typescript
// Before (broken - Observable never executes)
tap(() => {
  this.loadAvailableTasks();  // HTTP request never fires!
}),

// After (works - properly chained)
switchMap(() => this.loadAvailableTasks().pipe(map(() => ({ success: true })))),
```

## Benefits of switchMap approach
- Chains operations properly
- Returns the reload observable to callers
- Allows caller to handle completion/errors from both operations
- Ensures HTTP request actually fires

## Test plan
- [x] All 775 frontend tests pass
- [x] Build succeeds
- [ ] CI passes

Closes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)