### PR TITLE
docs(backend): document authorization rationale for child endpoints

### DIFF
--- a/apps/backend/src/routes/children.ts
+++ b/apps/backend/src/routes/children.ts
@@ -685,6 +685,10 @@ export default async function childrenRoutes(server: FastifyInstance) {
   });
 
   // Update child (parent/admin access)
+  // Authorization Rationale: Parents can edit child profiles because:
+  // - Fixing typos in name/birthYear is a low-risk, reversible operation
+  // - Common operation in family apps (parent manages their children's profiles)
+  // - No destructive side effects (unlike deletion which cascades to tasks/rewards)
   server.put('/api/households/:householdId/children/:childId', {
     schema: stripResponseValidation({
       summary: 'Update child details',
@@ -740,6 +744,12 @@ export default async function childrenRoutes(server: FastifyInstance) {
   });
 
   // Delete child (admin only)
+  // Authorization Rationale: Only admins can delete children because:
+  // - Deletion is permanent and irreversible
+  // - Cascades to related data: task assignments, task completions, rewards, etc.
+  // - High-risk operation that could lose historical data
+  // - Protects against accidental deletions by non-admin parents
+  // Note: Parents can edit children (see updateChild) but not delete them
   server.delete('/api/households/:householdId/children/:childId', {
     schema: stripResponseValidation({
       summary: 'Delete child',


### PR DESCRIPTION
## Summary
- Document the intentional authorization split between child update and delete endpoints
- Add code comments explaining the rationale for different permission requirements

## Background
The child management endpoints have different authorization requirements:
- `PUT /children/:childId` requires **parent** role
- `DELETE /children/:childId` requires **admin** role

This inconsistency was flagged but is actually intentional and follows a common pattern in family/household apps.

## Rationale Documented

### Update (parent access)
- Low-risk, reversible operation
- Allows parents to fix typos in name/birthYear
- Common operation in family apps

### Delete (admin access)
- Permanent, irreversible operation  
- Cascades to task assignments, completions, rewards
- High-risk operation protected from accidental deletion
- Only household admin should have this power

## Test plan
- [x] Type checking passes
- [x] No functional changes (comments only)
- [ ] CI passes

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)