### PR TITLE
feat(frontend): add gradient headers to Tasks and Progress pages

### DIFF
--- a/apps/frontend/src/app/pages/progress/progress.css
+++ b/apps/frontend/src/app/pages/progress/progress.css
@@ -1,58 +1,5 @@
 /* Progress Screen Styles */
 
-/* Layout */
-:host {
-  display: flex;
-  min-height: 100vh;
-  background: var(--color-background);
-  animation: fadeIn 0.2s ease-out;
-}
-
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-.desktop-nav {
-  display: none;
-}
-
-.main-content {
-  flex: 1;
-  padding: var(--space-lg) var(--space-md);
-  padding-bottom: calc(var(--space-xl) + 80px); /* Space for bottom nav */
-  max-width: 1200px;
-  margin: 0 auto;
-  width: 100%;
-}
-
-/* Tablet Layout */
-@media (min-width: 768px) {
-  .main-content {
-    padding: var(--space-xl);
-    padding-bottom: calc(var(--space-xl) + 80px); /* Keep space for bottom nav on tablet */
-  }
-}
-
-/* Desktop Layout - Hide bottom nav, show sidebar */
-@media (min-width: 1024px) {
-  .desktop-nav {
-    display: block;
-  }
-
-  .mobile-nav {
-    display: none;
-  }
-
-  .main-content {
-    padding-bottom: var(--space-xl);
-  }
-}
-
 /* Loading State */
 .loading-container {
   display: flex;
@@ -364,11 +311,6 @@
 
 /* Responsive Adjustments */
 @media (max-width: 768px) {
-  .main-content {
-    padding: var(--space-md);
-    padding-bottom: calc(var(--space-xl) + 80px);
-  }
-
   .section-header h2 {
     font-size: 20px;
   }

--- a/apps/frontend/src/app/pages/progress/progress.html
+++ b/apps/frontend/src/app/pages/progress/progress.html
@@ -1,22 +1,22 @@
-<div class="progress-page">
-  <!-- Loading State -->
-  @if (loading()) {
-    <div class="loading-container" role="status" aria-live="polite">
-      <div class="loading-spinner" aria-hidden="true"></div>
-      <p>Loading progress...</p>
-    </div>
-  }
+<!-- Loading State -->
+@if (loading()) {
+  <div class="loading-container" role="status" aria-live="polite">
+    <div class="loading-spinner" aria-hidden="true"></div>
+    <p>Loading progress...</p>
+  </div>
+}
 
-  <!-- Error State -->
-  @if (error()) {
-    <div class="error-container" role="alert" aria-live="assertive">
-      <p class="error-message">{{ error() }}</p>
-      <button class="retry-button" (click)="loadData()">Try Again</button>
-    </div>
-  }
+<!-- Error State -->
+@if (error()) {
+  <div class="error-container" role="alert" aria-live="assertive">
+    <p class="error-message">{{ error() }}</p>
+    <button class="retry-button" (click)="loadData()">Try Again</button>
+  </div>
+}
 
-  <!-- Main Content -->
-  @if (!loading() && !error()) {
+<!-- Main Content -->
+@if (!loading() && !error()) {
+  <app-page title="Progress" maxWidth="wide">
     <!-- Household Stats Section -->
     <section class="stats-section" aria-labelledby="stats-heading">
       <h2 id="stats-heading" class="visually-hidden">Household Statistics</h2>
@@ -134,5 +134,5 @@
         </div>
       }
     </section>
-  }
-</div>
+  </app-page>
+}

--- a/apps/frontend/src/app/pages/progress/progress.ts
+++ b/apps/frontend/src/app/pages/progress/progress.ts
@@ -9,6 +9,7 @@ import {
 import { AuthService } from '../../services/auth.service';
 import { HouseholdService } from '../../services/household.service';
 import { AnalyticsService } from '../../services/analytics.service';
+import { PageComponent } from '../../components/page/page';
 import type { HouseholdAnalytics, ChildStreak } from '@st44/types';
 
 /**
@@ -61,7 +62,7 @@ interface HouseholdStats {
  */
 @Component({
   selector: 'app-progress',
-  imports: [],
+  imports: [PageComponent],
   templateUrl: './progress.html',
   styleUrl: './progress.css',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/apps/frontend/src/app/pages/tasks/tasks.html
+++ b/apps/frontend/src/app/pages/tasks/tasks.html
@@ -1,4 +1,4 @@
-<app-page title="All Tasks" [showGradient]="false" maxWidth="medium">
+<app-page title="All Tasks" maxWidth="medium">
   <!-- Filter Tabs -->
   <div class="filter-tabs">
     @for (tab of filterTabs(); track tab.id) {


### PR DESCRIPTION
## Summary

- **Tasks page**: Removed `[showGradient]="false"` to enable gradient header (consistent with other pages)
- **Progress page**: Migrated to use PageComponent with gradient header
- Cleaned up ~55 lines of redundant CSS layout styles from Progress page (now handled by PageComponent)

This provides consistent header styling across all main pages (Rewards, Family, Tasks, Progress).

## Changes

| File | Change |
|------|--------|
| `tasks.html` | Removed `[showGradient]="false"` attribute |
| `progress.ts` | Added PageComponent import |
| `progress.html` | Wrapped content with `<app-page>` |
| `progress.css` | Removed layout styles handled by PageComponent |

## Test plan

- [x] Build passes
- [x] All 792 frontend tests pass
- [ ] Verify Tasks page shows gradient header
- [ ] Verify Progress page shows gradient header
- [ ] Verify responsive behavior on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)