### PR TITLE
fix(backend): handle single tasks with multiple assigned children

### DIFF
--- a/packages/types/src/schemas/task.schema.ts
+++ b/packages/types/src/schemas/task.schema.ts
@@ -19,12 +19,15 @@ export const TaskRuleConfigSchema = z
   .object({
     // For weekly_rotation: odd_even_week or alternating
     rotationType: z.enum(['odd_even_week', 'alternating']).optional(),
-    
+
     // For repeating: days of week (0=Sunday, 6=Saturday)
     repeatDays: z.array(z.number().int().min(0).max(6)).optional(),
-    
-    // For weekly_rotation: children assigned to the task
+
+    // For weekly_rotation and single: children assigned to the task
     assignedChildren: z.array(z.string().uuid()).optional(),
+
+    // For single tasks: optional deadline
+    deadline: z.string().datetime().optional(),
   })
   .nullable();
 


### PR DESCRIPTION
## Summary
- Add deadline field to TaskRuleConfigSchema for single task deadlines
- Extract deadline from ruleConfig and store in tasks.deadline column
- Insert candidates into task_candidates table when creating single tasks
- Add validation requiring at least one child for single tasks
- Include deadline in mapTaskRowToTask response

## Problem
Creating a single task with multiple assigned children returned a 500 Internal Server Error because:
1. The deadline was being passed inside ruleConfig but was never extracted to the tasks.deadline column
2. Candidates were never being inserted into the task_candidates table

## Solution
- Extended TaskRuleConfigSchema to accept a deadline field
- Modified createTask to extract deadline from ruleConfig and store it in the tasks table
- Added logic to insert task candidates after task creation
- Added validation to require at least one candidate for single tasks

## Test Plan
- [ ] Create a single task with one child - should succeed
- [ ] Create a single task with multiple children - should succeed and create candidates
- [ ] Create a single task with deadline - should store deadline in tasks.deadline
- [ ] Create a single task without candidates - should return 400 error

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)