### PR TITLE
fix(frontend): ensure settings icon is visible above household dropdown

### DIFF
--- a/apps/frontend/src/app/layouts/main-layout/main-layout.css
+++ b/apps/frontend/src/app/layouts/main-layout/main-layout.css
@@ -58,6 +58,8 @@
 }
 
 .settings-btn {
+  position: relative;
+  z-index: 51; /* Above household-switcher dropdown (z-index: 50) */
   width: 40px;
   height: 40px;
   border: none;


### PR DESCRIPTION
## Summary
Add z-index: 51 to settings button to ensure it stays above the
household-switcher dropdown (z-index: 50).

## Problem
The settings gear icon could be obscured when the household-switcher
dropdown was opened because the dropdown has z-index: 50 and the
settings button had no z-index.

## Solution
Add `position: relative` and `z-index: 51` to the settings button so
it stays above the dropdown.

## Test Plan
- [ ] Open the app on mobile
- [ ] Open the household-switcher dropdown
- [ ] Verify the settings icon remains visible and clickable

Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)