### PR TITLE
fix(frontend): show child and reward names instead of UUIDs in redemptions

### DIFF
--- a/apps/frontend/src/app/pages/rewards-management/rewards-management.html
+++ b/apps/frontend/src/app/pages/rewards-management/rewards-management.html
@@ -148,8 +148,8 @@
                 <h3>Redemption Request</h3>
                 <span class="status-badge">{{ redemption.status }}</span>
               </div>
-              <p class="child-name">Child ID: {{ redemption.childId }}</p>
-              <p class="reward-id">Reward ID: {{ redemption.rewardId }}</p>
+              <p class="child-name">Child: {{ redemption.childName || redemption.childId }}</p>
+              <p class="reward-name">Reward: {{ redemption.rewardName || redemption.rewardId }}</p>
               <p class="points">Points Spent: {{ redemption.pointsSpent }}</p>
               <p class="date">Redeemed: {{ redemption.redeemedAt | date: 'short' }}</p>
               @if (redemption.fulfilledAt) {

--- a/packages/types/src/schemas/reward.schema.ts
+++ b/packages/types/src/schemas/reward.schema.ts
@@ -47,6 +47,9 @@ export const RewardRedemptionSchema = z.object({
   status: RewardRedemptionStatusSchema,
   redeemedAt: z.string().datetime(),
   fulfilledAt: z.string().datetime().nullable(),
+  // Added by list endpoint for display purposes
+  rewardName: z.string().optional(),
+  childName: z.string().optional(),
 });
 
 export type RewardRedemption = z.infer<typeof RewardRedemptionSchema>;


### PR DESCRIPTION
## Summary
- Add rewardName and childName optional fields to RewardRedemptionSchema
- Update redemptions list view to display names instead of UUIDs
- Falls back to UUIDs if names are not available

## Problem
The redemptions list view showed raw UUIDs for child and reward, making it
impossible for parents to understand which child redeemed which reward.

## Solution
The backend already returns `childName` and `rewardName` fields in the
redemptions list response. This change:
1. Adds these optional fields to the TypeScript schema
2. Updates the template to show the names instead of UUIDs
3. Falls back to UUIDs if names are missing (for backwards compatibility)

## Test Plan
- [ ] View the redemptions tab in Rewards Management
- [ ] Verify child names are shown instead of UUIDs
- [ ] Verify reward names are shown instead of UUIDs

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)