### PR TITLE
fix(frontend): hide Complete Task button for parent users

### DIFF
--- a/apps/frontend/src/app/pages/tasks/tasks.html
+++ b/apps/frontend/src/app/pages/tasks/tasks.html
@@ -64,7 +64,7 @@
         @for (task of filteredTasks(); track task.id) {
           <app-task-card
             [task]="task"
-            [showCompleteButton]="true"
+            [showCompleteButton]="!isParent()"
             [clickable]="true"
             [showReassignButton]="activeFilter() !== 'all'"
             (complete)="onTaskComplete($event)"


### PR DESCRIPTION
## Summary
Hide the "Complete Task" button for parent users on the tasks page.

## Problem
The "Complete Task" button was visible for parents on the tasks page, but parents cannot complete tasks - only children can. This was confusing and served no purpose.

## Solution
Changed `[showCompleteButton]="true"` to `[showCompleteButton]="!isParent()"` so the button is only shown for non-parent users (i.e., children).

## Test Plan
- [ ] Log in as a parent user
- [ ] Navigate to `/tasks?filter=all`
- [ ] Verify the "Complete Task" button is NOT visible
- [ ] Log in as a child user
- [ ] Navigate to tasks
- [ ] Verify the "Complete Task" button IS visible

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)