### PR TITLE
fix(backend): fix DELETE children endpoint returning 500 error

### DIFF
--- a/apps/backend/src/routes/children.test.ts
+++ b/apps/backend/src/routes/children.test.ts
@@ -326,9 +326,8 @@ describe('Children API', () => {
         headers: { Authorization: `Bearer ${adminToken}` },
       });
 
-      assert.strictEqual(response.statusCode, 200);
-      const body = JSON.parse(response.body);
-      assert.strictEqual(body.message, 'Child removed successfully');
+      assert.strictEqual(response.statusCode, 204);
+      assert.strictEqual(response.body, ''); // No content
     });
 
     test('should return 404 for non-existent child', async () => {


### PR DESCRIPTION
## Summary
- Fix DELETE /api/households/:householdId/children/:childId returning 500 Internal Server Error

## Root Cause
The 404 error response was missing the required `statusCode` field, and the successful response was returning a JSON body instead of 204 No Content as declared in the schema.

## Changes
- Added `statusCode: 404` to the not found error response in deleteChild
- Changed successful deleteChild response from JSON body to 204 No Content
- Fixed updateChild 404 response to include statusCode for consistency

## Test plan
- [ ] Delete an existing child - should return 204 No Content
- [ ] Delete a non-existent child - should return 404 with proper error format
- [ ] Update a non-existent child - should return 404 with proper error format

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)