### PR TITLE
feat(frontend): add leave and delete household methods

### DIFF
--- a/apps/frontend/src/app/stores/household.store.ts
+++ b/apps/frontend/src/app/stores/household.store.ts
@@ -460,6 +460,15 @@ export class HouseholdStore {
   }
 
   /**
+   * Remove a household from the store (after leave/delete)
+   */
+  removeHousehold(householdId: string): void {
+    this.updateState({
+      households: this.state().households.filter((h) => h.id !== householdId),
+    });
+  }
+
+  /**
    * Invalidate all caches (force refresh on next load)
    */
   invalidateAll(): void {


### PR DESCRIPTION
## Summary
- Add `leaveHousehold()` and `deleteHousehold()` methods to HouseholdService
- Add `removeHousehold()` method to HouseholdStore
- Update `HouseholdListItem` interface with `adminCount` field

## Changes

### HouseholdService
- `leaveHousehold(householdId)`: Calls DELETE /households/:id/members/me, removes from store, auto-switches if needed
- `deleteHousehold(householdId)`: Calls DELETE /households/:id, removes from store, auto-switches if needed

### HouseholdStore
- `removeHousehold(householdId)`: Removes household from local store

### HouseholdListItem Interface
- Added `'admin'` to role union type
- Added `adminCount?: number` field

## Test plan
- [ ] Call leaveHousehold() - verify API call and store update
- [ ] Call deleteHousehold() - verify API call and store update
- [ ] Verify auto-switch to another household works when leaving/deleting active household

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)