### PR TITLE
feat(frontend): create Manage Households page

### DIFF
--- a/apps/frontend/src/app/app.routes.ts
+++ b/apps/frontend/src/app/app.routes.ts
@@ -92,6 +92,12 @@ export const routes: Routes = [
         title: 'Settings - Diddit!',
         loadComponent: () => import('./pages/settings/settings').then((m) => m.Settings),
       },
+      {
+        path: 'households',
+        title: 'Manage Households - Diddit!',
+        loadComponent: () =>
+          import('./pages/manage-households/manage-households').then((m) => m.ManageHouseholds),
+      },
       // Default redirect for authenticated parent/admin users
       {
         path: '',

--- a/apps/frontend/src/app/pages/manage-households/manage-households.css
+++ b/apps/frontend/src/app/pages/manage-households/manage-households.css
@@ -1,0 +1,403 @@
+/* Loading State */
+.loading-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  text-align: center;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.spinner {
+  width: 48px;
+  height: 48px;
+  border: 4px solid rgba(99, 102, 241, 0.2);
+  border-top-color: var(--color-primary, #6366f1);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: var(--space-md, 16px);
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Error State */
+.error-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  text-align: center;
+  padding: var(--space-xl, 24px);
+}
+
+.error-icon {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: var(--color-error, #ef4444);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 32px;
+  font-weight: 700;
+  margin-bottom: var(--space-lg, 20px);
+}
+
+.error-container h2 {
+  font-size: 24px;
+  color: var(--color-text-primary, #1f2937);
+  margin: 0 0 var(--space-sm, 8px) 0;
+}
+
+.error-container p {
+  color: var(--color-text-secondary, #6b7280);
+  margin: 0 0 var(--space-lg, 20px) 0;
+}
+
+.btn-retry {
+  padding: var(--space-sm, 8px) var(--space-lg, 20px);
+  background: var(--color-primary, #6366f1);
+  color: white;
+  border: none;
+  border-radius: var(--radius-sm, 8px);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.btn-retry:hover {
+  background: var(--color-primary-dark, #4f46e5);
+}
+
+/* Alerts */
+.alert {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md, 16px);
+  padding: var(--space-md, 16px);
+  border-radius: var(--radius-sm, 8px);
+  margin-bottom: var(--space-lg, 20px);
+}
+
+.alert-success {
+  background: var(--color-success-bg, #ecfdf5);
+  color: var(--color-success, #059669);
+  border: 1px solid var(--color-success-border, #a7f3d0);
+}
+
+.alert-error {
+  background: var(--color-error-bg, #fef2f2);
+  color: var(--color-error, #dc2626);
+  border: 1px solid var(--color-error-border, #fecaca);
+}
+
+.alert span {
+  flex: 1;
+}
+
+.alert-dismiss {
+  background: none;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+  opacity: 0.6;
+  transition: opacity 0.2s ease;
+}
+
+.alert-dismiss:hover {
+  opacity: 1;
+}
+
+/* Create Section */
+.create-section {
+  margin-bottom: var(--space-xl, 24px);
+}
+
+/* Empty State */
+.empty-state {
+  text-align: center;
+  padding: var(--space-xxl, 32px);
+  background: var(--color-background, #f9fafb);
+  border-radius: var(--radius-md, 12px);
+}
+
+.empty-icon {
+  font-size: 48px;
+  margin-bottom: var(--space-md, 16px);
+}
+
+.empty-state h3 {
+  font-size: 20px;
+  color: var(--color-text-primary, #1f2937);
+  margin: 0 0 var(--space-sm, 8px) 0;
+}
+
+.empty-state p {
+  color: var(--color-text-secondary, #6b7280);
+  margin: 0;
+}
+
+/* Households List */
+.households-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md, 16px);
+}
+
+/* Household Card */
+.household-card {
+  background: var(--color-surface, #ffffff);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: var(--radius-md, 12px);
+  padding: var(--space-lg, 20px);
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.household-card:hover {
+  border-color: rgba(99, 102, 241, 0.3);
+}
+
+.household-card.is-active {
+  border-color: var(--color-primary, #6366f1);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
+}
+
+.household-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: var(--space-md, 16px);
+}
+
+.household-info {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm, 8px);
+  flex-wrap: wrap;
+}
+
+.household-name {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--color-text-primary, #1f2937);
+  margin: 0;
+}
+
+/* Role Badges */
+.role-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  border-radius: 4px;
+  letter-spacing: 0.5px;
+}
+
+.role-admin {
+  background: var(--color-error-bg, #fef2f2);
+  color: var(--color-error, #dc2626);
+}
+
+.role-parent {
+  background: var(--color-success-bg, #ecfdf5);
+  color: var(--color-success, #059669);
+}
+
+.role-child {
+  background: var(--color-info-bg, #eff6ff);
+  color: var(--color-info, #2563eb);
+}
+
+.active-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  border-radius: 4px;
+  background: var(--color-primary, #6366f1);
+  color: white;
+  letter-spacing: 0.5px;
+}
+
+/* Stats */
+.household-stats {
+  display: flex;
+  gap: var(--space-lg, 20px);
+  margin-bottom: var(--space-md, 16px);
+}
+
+.stat {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs, 4px);
+  font-size: 14px;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.stat-icon {
+  font-size: 16px;
+}
+
+/* Actions */
+.household-actions {
+  display: flex;
+  gap: var(--space-sm, 8px);
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.leave-hint {
+  font-size: 12px;
+  color: var(--color-text-secondary, #6b7280);
+  font-style: italic;
+}
+
+/* Buttons */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-sm, 8px) var(--space-lg, 20px);
+  font-family: var(--font-body, 'Outfit', sans-serif);
+  font-size: 14px;
+  font-weight: 600;
+  border-radius: var(--radius-sm, 8px);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: none;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: linear-gradient(
+    135deg,
+    var(--color-primary, #6366f1) 0%,
+    var(--color-secondary, #ec4899) 100%
+  );
+  color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(99, 102, 241, 0.3);
+}
+
+.btn-outline {
+  background: transparent;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  color: var(--color-text-primary, #1f2937);
+}
+
+.btn-outline:hover:not(:disabled) {
+  background: var(--color-background, #f9fafb);
+}
+
+.btn-sm {
+  padding: var(--space-xs, 4px) var(--space-md, 16px);
+  font-size: 13px;
+}
+
+.btn-warning {
+  background: var(--color-warning, #f59e0b);
+  color: white;
+}
+
+.btn-warning:hover:not(:disabled) {
+  background: var(--color-warning-dark, #d97706);
+}
+
+.btn-danger {
+  background: var(--color-error, #ef4444);
+  color: white;
+}
+
+.btn-danger:hover:not(:disabled) {
+  background: var(--color-error-dark, #dc2626);
+}
+
+/* Modal Form */
+.modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg, 20px);
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs, 4px);
+}
+
+.form-group label {
+  font-weight: 600;
+  color: var(--color-text-primary, #1f2937);
+}
+
+.form-group input {
+  padding: var(--space-sm, 8px) var(--space-md, 16px);
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: var(--radius-sm, 8px);
+  font-size: 16px;
+  transition: border-color 0.2s ease;
+}
+
+.form-group input:focus {
+  outline: none;
+  border-color: var(--color-primary, #6366f1);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
+}
+
+.form-hint {
+  font-size: 13px;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+/* Modal Content */
+.modal-content {
+  text-align: center;
+  padding: var(--space-md, 16px) 0;
+}
+
+.warning-icon,
+.danger-icon {
+  font-size: 48px;
+  margin-bottom: var(--space-md, 16px);
+}
+
+.warning-text,
+.danger-text {
+  font-size: 16px;
+  color: var(--color-text-primary, #1f2937);
+  margin: 0 0 var(--space-sm, 8px) 0;
+}
+
+.warning-detail,
+.danger-detail {
+  font-size: 14px;
+  color: var(--color-text-secondary, #6b7280);
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* Modal Actions */
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-sm, 8px);
+  margin-top: var(--space-lg, 20px);
+}

--- a/apps/frontend/src/app/pages/manage-households/manage-households.html
+++ b/apps/frontend/src/app/pages/manage-households/manage-households.html
@@ -1,0 +1,274 @@
+<!-- Loading State -->
+@if (loading()) {
+  <div class="loading-container" role="status" aria-live="polite">
+    <div class="spinner" aria-hidden="true"></div>
+    <p>Loading your households...</p>
+  </div>
+}
+
+<!-- Error State (full page) -->
+@if (error() && !loading() && households().length === 0) {
+  <div class="error-container" role="alert" aria-live="assertive">
+    <div class="error-icon" aria-hidden="true">!</div>
+    <h2>Oops!</h2>
+    <p>{{ error() }}</p>
+    <button class="btn-retry" (click)="loadHouseholds()">Try Again</button>
+  </div>
+}
+
+<!-- Main Content -->
+@if (!loading()) {
+  <app-page title="Manage Households" maxWidth="narrow">
+    <!-- Success Message -->
+    @if (successMessage()) {
+      <div class="alert alert-success" role="status" aria-live="polite">
+        <span>{{ successMessage() }}</span>
+        <button class="alert-dismiss" (click)="dismissSuccess()" aria-label="Dismiss">x</button>
+      </div>
+    }
+
+    <!-- Error Message (inline) -->
+    @if (error() && households().length > 0) {
+      <div class="alert alert-error" role="alert" aria-live="assertive">
+        <span>{{ error() }}</span>
+        <button class="alert-dismiss" (click)="dismissError()" aria-label="Dismiss">x</button>
+      </div>
+    }
+
+    <!-- Create Button -->
+    <div class="create-section">
+      <button class="btn btn-primary" (click)="openCreateModal()">+ Create New Household</button>
+    </div>
+
+    <!-- Households List -->
+    @if (households().length === 0) {
+      <div class="empty-state">
+        <div class="empty-icon">🏠</div>
+        <h3>No Households Yet</h3>
+        <p>Create your first household to get started!</p>
+      </div>
+    } @else {
+      <div class="households-list">
+        @for (household of households(); track household.id) {
+          <div class="household-card" [class.is-active]="household.id === activeHouseholdId()">
+            <div class="household-header">
+              <div class="household-info">
+                <h3 class="household-name">{{ household.name }}</h3>
+                <span [class]="getRoleBadgeClass(household.role)">
+                  {{ household.role }}
+                </span>
+                @if (household.id === activeHouseholdId()) {
+                  <span class="active-badge">Active</span>
+                }
+              </div>
+            </div>
+
+            <div class="household-stats">
+              @if (household.memberCount !== undefined) {
+                <span class="stat">
+                  <span class="stat-icon">👥</span>
+                  {{ household.memberCount }} members
+                </span>
+              }
+              @if (household.childrenCount !== undefined) {
+                <span class="stat">
+                  <span class="stat-icon">👶</span>
+                  {{ household.childrenCount }} children
+                </span>
+              }
+            </div>
+
+            <div class="household-actions">
+              @if (household.id !== activeHouseholdId()) {
+                <button
+                  class="btn btn-outline btn-sm"
+                  (click)="switchToHousehold(household)"
+                  aria-label="Switch to {{ household.name }}"
+                >
+                  Switch to
+                </button>
+              }
+
+              @if (isAdmin(household)) {
+                <button
+                  class="btn btn-outline btn-sm"
+                  (click)="openEditModal(household)"
+                  aria-label="Edit {{ household.name }}"
+                >
+                  Edit
+                </button>
+              }
+
+              @if (canLeaveHousehold(household)) {
+                <button
+                  class="btn btn-outline btn-sm btn-warning"
+                  (click)="openLeaveModal(household)"
+                  aria-label="Leave {{ household.name }}"
+                >
+                  Leave
+                </button>
+              } @else if (isAdmin(household)) {
+                <span class="leave-hint" title="You are the only admin"> Only admin </span>
+              }
+
+              @if (isAdmin(household)) {
+                <button
+                  class="btn btn-outline btn-sm btn-danger"
+                  (click)="openDeleteModal(household)"
+                  aria-label="Delete {{ household.name }}"
+                >
+                  Delete
+                </button>
+              }
+            </div>
+          </div>
+        }
+      </div>
+    }
+  </app-page>
+}
+
+<!-- Create Household Modal -->
+<app-modal
+  [open]="showCreateModal()"
+  (closeModal)="closeCreateModal()"
+  title="Create New Household"
+>
+  <form class="modal-form" (submit)="createHousehold(); $event.preventDefault()">
+    <div class="form-group">
+      <label for="create-name">Household Name</label>
+      <input
+        type="text"
+        id="create-name"
+        name="name"
+        [(ngModel)]="createHouseholdName"
+        placeholder="e.g., Smith Family"
+        maxlength="100"
+        required
+      />
+      <small class="form-hint">Give your household a name (1-100 characters)</small>
+    </div>
+
+    <div class="modal-actions">
+      <button
+        type="button"
+        class="btn btn-outline"
+        (click)="closeCreateModal()"
+        [disabled]="actionInProgress()"
+      >
+        Cancel
+      </button>
+      <button
+        type="submit"
+        class="btn btn-primary"
+        [disabled]="actionInProgress() || !createHouseholdName.trim()"
+      >
+        {{ actionInProgress() ? 'Creating...' : 'Create' }}
+      </button>
+    </div>
+  </form>
+</app-modal>
+
+<!-- Edit Household Modal -->
+<app-modal [open]="showEditModal()" (closeModal)="closeEditModal()" title="Edit Household">
+  <form class="modal-form" (submit)="saveHousehold(); $event.preventDefault()">
+    <div class="form-group">
+      <label for="edit-name">Household Name</label>
+      <input
+        type="text"
+        id="edit-name"
+        name="name"
+        [(ngModel)]="editHouseholdName"
+        placeholder="Household name"
+        maxlength="100"
+        required
+      />
+    </div>
+
+    <div class="modal-actions">
+      <button
+        type="button"
+        class="btn btn-outline"
+        (click)="closeEditModal()"
+        [disabled]="actionInProgress()"
+      >
+        Cancel
+      </button>
+      <button
+        type="submit"
+        class="btn btn-primary"
+        [disabled]="actionInProgress() || !editHouseholdName.trim()"
+      >
+        {{ actionInProgress() ? 'Saving...' : 'Save' }}
+      </button>
+    </div>
+  </form>
+</app-modal>
+
+<!-- Leave Household Modal -->
+<app-modal [open]="showLeaveModal()" (closeModal)="closeLeaveModal()" title="Leave Household">
+  <div class="modal-content">
+    <div class="warning-icon">⚠️</div>
+    <p class="warning-text">
+      Are you sure you want to leave <strong>{{ selectedHousehold()?.name }}</strong
+      >?
+    </p>
+    <p class="warning-detail">
+      You will lose access to all tasks, rewards, and data in this household. You can be re-invited
+      by an admin if you change your mind.
+    </p>
+  </div>
+
+  <div class="modal-actions">
+    <button
+      type="button"
+      class="btn btn-outline"
+      (click)="closeLeaveModal()"
+      [disabled]="actionInProgress()"
+    >
+      Cancel
+    </button>
+    <button
+      type="button"
+      class="btn btn-warning"
+      (click)="leaveHousehold()"
+      [disabled]="actionInProgress()"
+    >
+      {{ actionInProgress() ? 'Leaving...' : 'Leave Household' }}
+    </button>
+  </div>
+</app-modal>
+
+<!-- Delete Household Modal -->
+<app-modal [open]="showDeleteModal()" (closeModal)="closeDeleteModal()" title="Delete Household">
+  <div class="modal-content">
+    <div class="danger-icon">🗑️</div>
+    <p class="danger-text">
+      Are you sure you want to permanently delete <strong>{{ selectedHousehold()?.name }}</strong
+      >?
+    </p>
+    <p class="danger-detail">
+      <strong>This action cannot be undone.</strong> All members, children, tasks, rewards, and
+      progress data will be permanently deleted.
+    </p>
+  </div>
+
+  <div class="modal-actions">
+    <button
+      type="button"
+      class="btn btn-outline"
+      (click)="closeDeleteModal()"
+      [disabled]="actionInProgress()"
+    >
+      Cancel
+    </button>
+    <button
+      type="button"
+      class="btn btn-danger"
+      (click)="deleteHousehold()"
+      [disabled]="actionInProgress()"
+    >
+      {{ actionInProgress() ? 'Deleting...' : 'Delete Permanently' }}
+    </button>
+  </div>
+</app-modal>

--- a/apps/frontend/src/app/pages/manage-households/manage-households.ts
+++ b/apps/frontend/src/app/pages/manage-households/manage-households.ts
@@ -1,0 +1,274 @@
+import { Component, ChangeDetectionStrategy, signal, inject, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { HouseholdService, type HouseholdListItem } from '../../services/household.service';
+import { HouseholdStore } from '../../stores/household.store';
+import { PageComponent } from '../../components/page/page';
+import { Modal } from '../../components/modals/modal/modal';
+
+/**
+ * Manage Households Page
+ *
+ * Allows users to:
+ * - View all households they belong to
+ * - Create new households
+ * - Edit household names (admin only)
+ * - Leave households (unless only admin)
+ * - Delete households (admin only)
+ */
+@Component({
+  selector: 'app-manage-households',
+  imports: [FormsModule, PageComponent, Modal],
+  templateUrl: './manage-households.html',
+  styleUrl: './manage-households.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ManageHouseholds implements OnInit {
+  private readonly householdService = inject(HouseholdService);
+  private readonly householdStore = inject(HouseholdStore);
+
+  // State signals
+  protected readonly loading = signal(true);
+  protected readonly error = signal<string | null>(null);
+  protected readonly successMessage = signal<string | null>(null);
+  protected readonly actionInProgress = signal(false);
+
+  // Data
+  protected readonly households = this.householdStore.households;
+  protected readonly activeHouseholdId = this.householdStore.activeHouseholdId;
+
+  // Modal states
+  protected readonly showCreateModal = signal(false);
+  protected readonly showEditModal = signal(false);
+  protected readonly showLeaveModal = signal(false);
+  protected readonly showDeleteModal = signal(false);
+
+  // Form data
+  protected createHouseholdName = '';
+  protected editHouseholdName = '';
+  protected selectedHousehold = signal<HouseholdListItem | null>(null);
+
+  async ngOnInit(): Promise<void> {
+    await this.loadHouseholds();
+  }
+
+  /**
+   * Load all households
+   */
+  protected async loadHouseholds(): Promise<void> {
+    try {
+      this.loading.set(true);
+      this.error.set(null);
+      await this.householdStore.loadHouseholds({ forceRefresh: true });
+    } catch (err) {
+      console.error('Failed to load households:', err);
+      this.error.set('Failed to load households. Please try again.');
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  /**
+   * Check if user can leave a household
+   * Cannot leave if user is the only admin
+   */
+  protected canLeaveHousehold(household: HouseholdListItem): boolean {
+    // Can always leave if not an admin
+    if (household.role !== 'admin') return true;
+    // Can leave if there are other admins (adminCount > 1)
+    return (household.adminCount ?? 1) > 1;
+  }
+
+  /**
+   * Check if user is admin of a household
+   */
+  protected isAdmin(household: HouseholdListItem): boolean {
+    return household.role === 'admin';
+  }
+
+  /**
+   * Switch to a different household
+   */
+  protected switchToHousehold(household: HouseholdListItem): void {
+    this.householdStore.setActiveHousehold(household.id);
+    this.showSuccess(`Switched to ${household.name}`);
+  }
+
+  // ==================
+  // Create Household
+  // ==================
+
+  protected openCreateModal(): void {
+    this.createHouseholdName = '';
+    this.showCreateModal.set(true);
+  }
+
+  protected closeCreateModal(): void {
+    this.showCreateModal.set(false);
+  }
+
+  protected async createHousehold(): Promise<void> {
+    if (!this.createHouseholdName.trim()) {
+      this.error.set('Please enter a household name');
+      return;
+    }
+
+    try {
+      this.actionInProgress.set(true);
+      this.error.set(null);
+
+      await this.householdService.createHousehold(this.createHouseholdName.trim());
+      this.closeCreateModal();
+      this.showSuccess('Household created successfully!');
+    } catch (err) {
+      console.error('Failed to create household:', err);
+      this.error.set('Failed to create household. Please try again.');
+    } finally {
+      this.actionInProgress.set(false);
+    }
+  }
+
+  // ==================
+  // Edit Household
+  // ==================
+
+  protected openEditModal(household: HouseholdListItem): void {
+    this.selectedHousehold.set(household);
+    this.editHouseholdName = household.name;
+    this.showEditModal.set(true);
+  }
+
+  protected closeEditModal(): void {
+    this.showEditModal.set(false);
+    this.selectedHousehold.set(null);
+  }
+
+  protected async saveHousehold(): Promise<void> {
+    const household = this.selectedHousehold();
+    if (!household) return;
+
+    if (!this.editHouseholdName.trim()) {
+      this.error.set('Please enter a household name');
+      return;
+    }
+
+    try {
+      this.actionInProgress.set(true);
+      this.error.set(null);
+
+      await this.householdService.updateHousehold(household.id, this.editHouseholdName.trim());
+      this.closeEditModal();
+      this.showSuccess('Household updated successfully!');
+    } catch (err) {
+      console.error('Failed to update household:', err);
+      this.error.set('Failed to update household. Please try again.');
+    } finally {
+      this.actionInProgress.set(false);
+    }
+  }
+
+  // ==================
+  // Leave Household
+  // ==================
+
+  protected openLeaveModal(household: HouseholdListItem): void {
+    this.selectedHousehold.set(household);
+    this.showLeaveModal.set(true);
+  }
+
+  protected closeLeaveModal(): void {
+    this.showLeaveModal.set(false);
+    this.selectedHousehold.set(null);
+  }
+
+  protected async leaveHousehold(): Promise<void> {
+    const household = this.selectedHousehold();
+    if (!household) return;
+
+    try {
+      this.actionInProgress.set(true);
+      this.error.set(null);
+
+      await this.householdService.leaveHousehold(household.id);
+      this.closeLeaveModal();
+      this.showSuccess(`Left ${household.name}`);
+    } catch (err: unknown) {
+      console.error('Failed to leave household:', err);
+      const errorObj = err as { message?: string };
+      if (errorObj.message?.includes('ONLY_ADMIN')) {
+        this.error.set(
+          'You are the only admin. Transfer admin role to another member or delete the household.',
+        );
+      } else {
+        this.error.set('Failed to leave household. Please try again.');
+      }
+    } finally {
+      this.actionInProgress.set(false);
+    }
+  }
+
+  // ==================
+  // Delete Household
+  // ==================
+
+  protected openDeleteModal(household: HouseholdListItem): void {
+    this.selectedHousehold.set(household);
+    this.showDeleteModal.set(true);
+  }
+
+  protected closeDeleteModal(): void {
+    this.showDeleteModal.set(false);
+    this.selectedHousehold.set(null);
+  }
+
+  protected async deleteHousehold(): Promise<void> {
+    const household = this.selectedHousehold();
+    if (!household) return;
+
+    try {
+      this.actionInProgress.set(true);
+      this.error.set(null);
+
+      await this.householdService.deleteHousehold(household.id);
+      this.closeDeleteModal();
+      this.showSuccess(`Deleted ${household.name}`);
+    } catch (err) {
+      console.error('Failed to delete household:', err);
+      this.error.set('Failed to delete household. Please try again.');
+    } finally {
+      this.actionInProgress.set(false);
+    }
+  }
+
+  // ==================
+  // Helpers
+  // ==================
+
+  private showSuccess(message: string): void {
+    this.successMessage.set(message);
+    setTimeout(() => this.successMessage.set(null), 3000);
+  }
+
+  protected dismissSuccess(): void {
+    this.successMessage.set(null);
+  }
+
+  protected dismissError(): void {
+    this.error.set(null);
+  }
+
+  /**
+   * Get role badge class
+   */
+  protected getRoleBadgeClass(role: string): string {
+    switch (role) {
+      case 'admin':
+        return 'role-badge role-admin';
+      case 'parent':
+        return 'role-badge role-parent';
+      case 'child':
+        return 'role-badge role-child';
+      default:
+        return 'role-badge';
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Create a new page for managing all households the user belongs to.

## Features
- **Household List**: Display all households with name, role badge, member count, children count
- **Create Household**: Modal form to create new households
- **Edit Household**: Admin-only feature to rename households
- **Leave Household**: Leave a household with confirmation (disabled if only admin)
- **Delete Household**: Admin-only permanent deletion with strong warning
- **Switch Households**: Quickly switch active household
- **Active Indicator**: Current household is highlighted

## UI/UX
- Role badges with color coding (admin: red, parent: green, child: blue)
- Active household badge
- Loading state with spinner
- Empty state with guidance
- Success/error messages with auto-dismiss
- Modal dialogs for all actions
- Accessible with ARIA labels and keyboard navigation

## Route
`/households` - accessible from parent/admin layout

## Test plan
- [ ] Page loads and displays all user's households
- [ ] Can create a new household via modal
- [ ] Can edit household name (admin only)
- [ ] Can leave household (unless only admin)
- [ ] Can delete household with confirmation (admin only)
- [ ] Active household is highlighted
- [ ] Can switch active household
- [ ] Loading and error states work correctly

## Part of Feature
Manage Households page (#479)

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)