### PR TITLE
feat(frontend): add Manage Households link to settings page (#476)

### DIFF
--- a/apps/frontend/src/app/pages/settings/settings.html
+++ b/apps/frontend/src/app/pages/settings/settings.html
@@ -146,6 +146,12 @@
             <span class="link-arrow">→</span>
           </a>
 
+          <a routerLink="/households" class="settings-link">
+            <span class="link-icon">🏠</span>
+            <span class="link-text">Manage Households</span>
+            <span class="link-arrow">→</span>
+          </a>
+
           <a routerLink="/invitations" class="settings-link">
             <span class="link-icon">✉️</span>
             <span class="link-text">Invitations</span>


### PR DESCRIPTION
## Summary

- Adds a "Manage Households" link to the Settings page in the Household section
- Uses house emoji 🏠 as the icon for visual consistency with other links
- Links to `/households` route (already added in PR #484)

## Changes

- Updated `apps/frontend/src/app/pages/settings/settings.html`
- Added new link between "Household Settings" and "Invitations"

## Test plan

- [x] Link appears in Settings page under Household section
- [x] Navigation works correctly to `/households`
- [ ] CI tests pass

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)