### PR TITLE
test(backend): add backend tests for leave/delete household endpoints (#477)

### DIFF
--- a/apps/backend/src/middleware/auth.test.ts
+++ b/apps/backend/src/middleware/auth.test.ts
@@ -59,7 +59,7 @@ describe('authenticateUser Middleware', () => {
       await authenticateUser(request, reply);
 
       assert.strictEqual(reply.getStatus(), 401);
-      assert.strictEqual(reply.getBody().error, 'Missing or invalid authorization header');
+      assert.strictEqual(reply.getBody().message, 'Missing or invalid authorization header');
     });
 
     test('should return 401 when header does not start with Bearer', async () => {
@@ -80,7 +80,7 @@ describe('authenticateUser Middleware', () => {
       await authenticateUser(request, reply);
 
       assert.strictEqual(reply.getStatus(), 401);
-      assert.strictEqual(reply.getBody().error, 'Invalid token');
+      assert.strictEqual(reply.getBody().message, 'Invalid token');
     });
 
     test('should return 401 for expired token', async () => {
@@ -91,7 +91,7 @@ describe('authenticateUser Middleware', () => {
       await authenticateUser(request, reply);
 
       assert.strictEqual(reply.getStatus(), 401);
-      assert.strictEqual(reply.getBody().error, 'Token expired');
+      assert.strictEqual(reply.getBody().message, 'Token expired');
     });
 
     test('should return 401 for token with wrong secret', async () => {
@@ -116,7 +116,7 @@ describe('authenticateUser Middleware', () => {
       await authenticateUser(request, reply);
 
       assert.strictEqual(reply.getStatus(), 401);
-      assert.strictEqual(reply.getBody().error, 'Invalid token type');
+      assert.strictEqual(reply.getBody().message, 'Invalid token type');
     });
   });
 

--- a/apps/backend/src/middleware/auth.ts
+++ b/apps/backend/src/middleware/auth.ts
@@ -30,7 +30,9 @@ export async function authenticateUser(request: FastifyRequest, reply: FastifyRe
 
     if (!authHeader || !authHeader.startsWith('Bearer ')) {
       return reply.code(401).send({
-        error: 'Missing or invalid authorization header',
+        statusCode: 401,
+        error: 'Unauthorized',
+        message: 'Missing or invalid authorization header',
       });
     }
 
@@ -43,7 +45,9 @@ export async function authenticateUser(request: FastifyRequest, reply: FastifyRe
     if (decoded.type !== 'access') {
       request.log.warn('Attempted to use non-access token for authentication');
       return reply.code(401).send({
-        error: 'Invalid token type',
+        statusCode: 401,
+        error: 'Unauthorized',
+        message: 'Invalid token type',
       });
     }
 
@@ -59,21 +63,27 @@ export async function authenticateUser(request: FastifyRequest, reply: FastifyRe
     // Handle JWT-specific errors
     if (error instanceof jwt.TokenExpiredError) {
       return reply.code(401).send({
-        error: 'Token expired',
+        statusCode: 401,
+        error: 'Unauthorized',
+        message: 'Token expired',
       });
     }
 
     if (error instanceof jwt.JsonWebTokenError) {
       request.log.warn({ error: (error as Error).message }, 'Invalid token');
       return reply.code(401).send({
-        error: 'Invalid token',
+        statusCode: 401,
+        error: 'Unauthorized',
+        message: 'Invalid token',
       });
     }
 
     // Log error but don't expose internal details
     request.log.error(error, 'Authentication error');
     return reply.code(500).send({
-      error: 'Authentication failed',
+      statusCode: 500,
+      error: 'Internal Server Error',
+      message: 'Authentication failed',
     });
   }
 }

--- a/apps/backend/src/middleware/household-membership.ts
+++ b/apps/backend/src/middleware/household-membership.ts
@@ -71,6 +71,7 @@ export async function validateHouseholdMembership(
         'User attempted to access household they are not a member of',
       );
       return reply.status(403).send({
+        statusCode: 403,
         error: 'Forbidden',
         message: 'You are not a member of this household',
       });
@@ -86,6 +87,7 @@ export async function validateHouseholdMembership(
   } catch (error) {
     request.log.error(error, 'Failed to validate household membership');
     return reply.status(500).send({
+      statusCode: 500,
       error: 'Internal Server Error',
       message: 'Membership validation failed',
     });
@@ -102,6 +104,7 @@ export async function requireHouseholdAdmin(request: FastifyRequest, reply: Fast
   if (!role) {
     request.log.error('requireHouseholdAdmin called without household context');
     return reply.status(500).send({
+      statusCode: 500,
       error: 'Internal Server Error',
       message: 'Household context missing',
     });
@@ -113,6 +116,7 @@ export async function requireHouseholdAdmin(request: FastifyRequest, reply: Fast
       'User attempted admin-only action without admin role',
     );
     return reply.status(403).send({
+      statusCode: 403,
       error: 'Forbidden',
       message: 'Admin role required for this action',
     });
@@ -131,6 +135,7 @@ export async function requireHouseholdParent(request: FastifyRequest, reply: Fas
   if (!role) {
     request.log.error('requireHouseholdParent called without household context');
     return reply.status(500).send({
+      statusCode: 500,
       error: 'Internal Server Error',
       message: 'Household context missing',
     });
@@ -142,6 +147,7 @@ export async function requireHouseholdParent(request: FastifyRequest, reply: Fas
       'User attempted parent-level action without sufficient role',
     );
     return reply.status(403).send({
+      statusCode: 403,
       error: 'Forbidden',
       message: 'Parent or admin role required for this action',
     });


### PR DESCRIPTION
## Summary

- Add comprehensive tests for DELETE /api/households/:id/members/me (Leave Household)
  - Member can leave household  
  - Only admin cannot leave (returns ONLY_ADMIN error code)
  - Requires authentication
  - Rejects non-members

- Add comprehensive tests for DELETE /api/households/:id (Delete Household)
  - Only admin can delete
  - Verifies cascade deletion of members and children
  - Requires authentication
  - Rejects non-members

Also fixes middleware error responses to include statusCode field:
- auth.ts: Add statusCode to all error responses
- household-membership.ts: Add statusCode to all error responses  
- auth.test.ts: Update tests to check message field instead of error

## Test Plan

- [x] All new leave/delete household tests pass locally
- [x] All auth middleware tests pass locally
- [x] All children tests pass locally
- [ ] CI passes

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)