### PR TITLE
feat(frontend): replace child dropdown with tabs/buttons on tasks filter (#462)

### DIFF
--- a/apps/frontend/src/app/pages/tasks/tasks.css
+++ b/apps/frontend/src/app/pages/tasks/tasks.css
@@ -46,45 +46,54 @@
   outline-offset: 2px;
 }
 
-/* Person Filter Dropdown */
-.person-filter {
+/* Person Filter Tabs */
+.person-tabs {
+  display: flex;
+  gap: var(--space-sm);
   margin-bottom: var(--space-lg);
-  padding: var(--space-md);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: var(--space-xs);
+}
+
+.person-tab {
+  flex-shrink: 0;
+  padding: var(--space-sm) var(--space-lg);
   background: var(--color-surface);
-  border-radius: var(--radius-sm);
+  border: 2px solid transparent;
+  border-radius: var(--radius-full);
+  font-family: var(--font-body);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: all 0.2s ease;
   box-shadow: var(--shadow-sm);
 }
 
-.person-filter-label {
-  display: block;
-  font-family: var(--font-body);
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-medium);
-  color: var(--color-text-secondary);
-  margin-bottom: var(--space-xs);
+.person-tab:hover {
+  background: #f1f5f9;
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
 }
 
-.person-select {
-  width: 100%;
-  padding: var(--space-sm) var(--space-md);
-  background: var(--color-background);
-  border: 2px solid #e2e8f0;
-  border-radius: var(--radius-sm);
+.person-tab.active {
+  background: var(--gradient-secondary, var(--gradient-primary));
+  color: white;
+  border-color: transparent;
+  box-shadow: var(--shadow-md);
+}
+
+.person-tab:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.no-members-message {
   font-family: var(--font-body);
   font-size: var(--font-size-base);
-  color: var(--color-text-primary);
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.person-select:hover {
-  border-color: var(--color-primary);
-}
-
-.person-select:focus {
-  outline: none;
-  border-color: var(--color-primary);
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
+  color: var(--color-text-secondary);
+  padding: var(--space-md);
 }
 
 /* Loading State */

--- a/apps/frontend/src/app/pages/tasks/tasks.html
+++ b/apps/frontend/src/app/pages/tasks/tasks.html
@@ -15,21 +15,25 @@
     }
   </div>
 
-  <!-- Person Filter Dropdown (only shown when filter = 'person') -->
+  <!-- Person Filter Tabs (only shown when filter = 'person') -->
   @if (activeFilter() === 'person') {
-    <div class="person-filter">
-      <label for="person-select" class="person-filter-label">Select Person:</label>
-      <select
-        id="person-select"
-        class="person-select"
-        [value]="selectedPersonId() || ''"
-        (change)="onPersonChange($event)"
-      >
-        <option value="">Choose a person...</option>
-        @for (member of members(); track member.id) {
-          <option [value]="member.id">{{ member.name }}</option>
-        }
-      </select>
+    <div class="person-tabs" role="tablist" aria-label="Filter by person">
+      @for (member of members(); track member.id) {
+        <button
+          type="button"
+          role="tab"
+          class="person-tab"
+          [class.active]="selectedPersonId() === member.id"
+          [attr.aria-selected]="selectedPersonId() === member.id"
+          [attr.aria-label]="'View tasks for ' + member.name"
+          (click)="onPersonSelect(member.id)"
+        >
+          {{ member.name }}
+        </button>
+      }
+      @if (members().length === 0) {
+        <p class="no-members-message">No children in this household.</p>
+      }
     </div>
   }
 

--- a/apps/frontend/src/app/pages/tasks/tasks.spec.ts
+++ b/apps/frontend/src/app/pages/tasks/tasks.spec.ts
@@ -364,19 +364,44 @@ describe('Tasks Component', () => {
   });
 
   describe('Person Filter', () => {
-    it('should update selected person when dropdown changes', () => {
+    it('should update selected person when tab is clicked', () => {
       fixture.detectChanges();
-      const event = { target: { value: 'child-1' } } as unknown as Event;
-      component['onPersonChange'](event);
+      component['onPersonSelect']('child-1');
       expect(component['selectedPersonId']()).toBe('child-1');
     });
 
     it('should reload tasks when person selection changes', () => {
       fixture.detectChanges();
       vi.clearAllMocks();
-      const event = { target: { value: 'child-1' } } as unknown as Event;
-      component['onPersonChange'](event);
+      component['onPersonSelect']('child-1');
       expect(mockTaskService.getTasks).toHaveBeenCalled();
+    });
+
+    it('should update URL query params when person is selected', () => {
+      fixture.detectChanges();
+      component['onPersonSelect']('child-1');
+      expect(mockRouter.navigate).toHaveBeenCalledWith([], {
+        relativeTo: mockActivatedRoute,
+        queryParams: { filter: 'all', child: 'child-1' },
+        queryParamsHandling: 'merge',
+        replaceUrl: true,
+      });
+    });
+
+    it('should not reload tasks if same person is selected', () => {
+      fixture.detectChanges();
+      component['selectedPersonId'].set('child-1');
+      vi.clearAllMocks();
+      component['onPersonSelect']('child-1');
+      expect(mockTaskService.getTasks).not.toHaveBeenCalled();
+    });
+
+    it('should load child from URL query params on init', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mockRoute = mockActivatedRoute as { snapshot: any };
+      mockRoute.snapshot.queryParams = { filter: 'person', child: 'child-1' };
+      fixture.detectChanges();
+      expect(component['selectedPersonId']()).toBe('child-1');
     });
   });
 


### PR DESCRIPTION
## Summary

Replace the child dropdown with tab/pill buttons on the tasks filter page for better usability.

### Changes

- Replace dropdown with tab/pill buttons for child selection
- One-click selection instead of dropdown interaction
- All children visible at a glance with clear active state
- Add URL query parameter sync (`?filter=person&child=<id>`)
- Add proper accessibility attributes (`role="tablist"`, `aria-selected`)
- Handle many children with horizontal scrolling
- Add empty state message when no children exist
- Update tests for new tab selection behavior

### Before/After

**Before:** Child selection used a dropdown menu requiring two clicks

**After:** Children displayed as pill buttons with single-click selection:
```
[All] [Emma] [Oliver] [Sophie]
       ^^^^^ (active/selected state)
```

## Test Plan

- [x] All 463 frontend tests pass locally
- [x] Build succeeds
- [ ] CI passes

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)