### PR TITLE
fix(frontend): resolve timezone and locale issues in date/format utils

### DIFF
--- a/apps/frontend/src/app/utils/date.ts
+++ b/apps/frontend/src/app/utils/date.ts
@@ -212,6 +212,7 @@ export function formatRelativeDate(date: Date | string, locale?: string): string
 /**
  * Formats a date to ISO date string (YYYY-MM-DD).
  * Useful for API calls and form values.
+ * Uses local date components to avoid timezone conversion issues.
  *
  * @param date - Date to format
  * @returns ISO date string in YYYY-MM-DD format
@@ -223,7 +224,10 @@ export function formatRelativeDate(date: Date | string, locale?: string): string
  */
 export function toISODateString(date: Date | string): string {
   const d = parseDate(date);
-  return d.toISOString().split('T')[0];
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }
 
 /**

--- a/apps/frontend/src/app/utils/format.ts
+++ b/apps/frontend/src/app/utils/format.ts
@@ -44,7 +44,8 @@ export function formatPoints(
       formattedNumber = String(points);
     }
   } else {
-    formattedNumber = points.toLocaleString();
+    // Use en-US locale for consistent comma-separated formatting
+    formattedNumber = points.toLocaleString('en-US');
   }
 
   if (showSuffix) {


### PR DESCRIPTION
## Summary

- **toISODateString**: Uses local date components instead of `toISOString()` to avoid timezone conversion that shifted dates to previous day in certain timezones
- **formatPoints**: Explicitly uses `en-US` locale for consistent comma-separated thousand separators regardless of system locale

## Test plan

- [x] All 108 date.spec.ts and format.spec.ts tests pass
- [x] All 804 frontend tests pass
- [x] Type check passes

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)