### PR TITLE
feat(frontend): add streak counter and progress summary to child dashboard

### DIFF
--- a/apps/frontend/src/app/components/progress-summary/progress-summary.css
+++ b/apps/frontend/src/app/components/progress-summary/progress-summary.css
@@ -1,0 +1,127 @@
+.progress-summary {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3, 0.75rem);
+  padding: var(--space-4, 1rem);
+  border-radius: var(--radius-lg, 0.75rem);
+  background: var(--surface-secondary, #f8f9fa);
+}
+
+/* Header */
+.progress-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2, 0.5rem);
+}
+
+.progress-icon {
+  font-size: 1.25rem;
+}
+
+.progress-title {
+  margin: 0;
+  flex: 1;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary, #212529);
+}
+
+.progress-percent {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-primary, #212529);
+}
+
+/* Progress Bar */
+.progress-bar-wrapper {
+  height: 0.75rem;
+  border-radius: var(--radius-full, 9999px);
+  background: var(--surface-tertiary, #e9ecef);
+  overflow: hidden;
+}
+
+.progress-bar {
+  height: 100%;
+  border-radius: var(--radius-full, 9999px);
+  transition: width 0.5s ease-out;
+  min-width: 0;
+}
+
+.progress-bar.progress-excellent {
+  background: linear-gradient(90deg, #28a745 0%, #20c997 100%);
+}
+
+.progress-bar.progress-good {
+  background: linear-gradient(90deg, #17a2b8 0%, #20c997 100%);
+}
+
+.progress-bar.progress-fair {
+  background: linear-gradient(90deg, #ffc107 0%, #fd7e14 100%);
+}
+
+.progress-bar.progress-low {
+  background: linear-gradient(90deg, #dc3545 0%, #fd7e14 100%);
+}
+
+/* Stats */
+.progress-stats {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-4, 1rem);
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1, 0.25rem);
+}
+
+.stat-value {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-primary, #212529);
+}
+
+.stat-label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--text-secondary, #6c757d);
+}
+
+/* Message */
+.progress-message {
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-align: center;
+}
+
+.progress-message.progress-excellent {
+  color: #28a745;
+}
+
+.progress-message.progress-good {
+  color: #17a2b8;
+}
+
+.progress-message.progress-fair {
+  color: #fd7e14;
+}
+
+.progress-message.progress-low {
+  color: #dc3545;
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+  .progress-stats {
+    flex-direction: column;
+    gap: var(--space-2, 0.5rem);
+  }
+
+  .stat {
+    flex-direction: row;
+    align-items: baseline;
+    gap: var(--space-2, 0.5rem);
+  }
+}

--- a/apps/frontend/src/app/components/progress-summary/progress-summary.html
+++ b/apps/frontend/src/app/components/progress-summary/progress-summary.html
@@ -1,0 +1,40 @@
+<div class="progress-summary" role="region" [attr.aria-label]="title() + ' progress'">
+  <!-- Header -->
+  <div class="progress-header">
+    @if (icon()) {
+      <span class="progress-icon" aria-hidden="true">{{ icon() }}</span>
+    }
+    <h3 class="progress-title">{{ title() }}</h3>
+    <span class="progress-percent" [attr.aria-label]="progressPercent() + ' percent complete'">
+      {{ progressPercent() }}%
+    </span>
+  </div>
+
+  <!-- Progress Bar -->
+  <div class="progress-bar-wrapper">
+    <div
+      class="progress-bar"
+      [class]="progressClass()"
+      [style.width.%]="progressPercent()"
+      role="progressbar"
+      [attr.aria-valuenow]="progressPercent()"
+      aria-valuemin="0"
+      aria-valuemax="100"
+    ></div>
+  </div>
+
+  <!-- Stats -->
+  <div class="progress-stats">
+    <div class="stat">
+      <span class="stat-value">{{ progress().completedTasks }}</span>
+      <span class="stat-label">of {{ progress().totalTasks }} tasks</span>
+    </div>
+    <div class="stat">
+      <span class="stat-value">{{ progress().pointsEarned }}</span>
+      <span class="stat-label">points earned</span>
+    </div>
+  </div>
+
+  <!-- Message -->
+  <p class="progress-message" [class]="progressClass()">{{ progressMessage() }}</p>
+</div>

--- a/apps/frontend/src/app/components/progress-summary/progress-summary.ts
+++ b/apps/frontend/src/app/components/progress-summary/progress-summary.ts
@@ -1,0 +1,66 @@
+import { Component, input, computed, ChangeDetectionStrategy } from '@angular/core';
+
+/**
+ * Progress data for a time period
+ */
+export interface ProgressData {
+  totalTasks: number;
+  completedTasks: number;
+  completionRate: number;
+  pointsEarned: number;
+}
+
+/**
+ * Progress Summary Component
+ *
+ * Displays week or month progress with a visual progress bar
+ * and task/points statistics.
+ *
+ * @example
+ * ```html
+ * <app-progress-summary
+ *   title="This Week"
+ *   [progress]="weekProgress"
+ * />
+ * ```
+ */
+@Component({
+  selector: 'app-progress-summary',
+  imports: [],
+  templateUrl: './progress-summary.html',
+  styleUrl: './progress-summary.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProgressSummary {
+  /** Title for the progress section (e.g., "This Week", "This Month") */
+  title = input.required<string>();
+
+  /** Progress data to display */
+  progress = input.required<ProgressData>();
+
+  /** Optional icon/emoji to display */
+  icon = input<string>('');
+
+  /** Rounded completion percentage */
+  progressPercent = computed(() => Math.round(this.progress().completionRate));
+
+  /** Get progress bar color class based on completion rate */
+  progressClass = computed(() => {
+    const rate = this.progress().completionRate;
+    if (rate >= 80) return 'progress-excellent';
+    if (rate >= 60) return 'progress-good';
+    if (rate >= 40) return 'progress-fair';
+    return 'progress-low';
+  });
+
+  /** Get encouraging message based on completion rate */
+  progressMessage = computed(() => {
+    const rate = this.progress().completionRate;
+    if (rate === 100) return 'Perfect!';
+    if (rate >= 80) return 'Excellent!';
+    if (rate >= 60) return 'Good progress!';
+    if (rate >= 40) return 'Keep going!';
+    if (rate > 0) return 'Getting started!';
+    return 'Ready to begin?';
+  });
+}

--- a/apps/frontend/src/app/components/streak-counter/streak-counter.css
+++ b/apps/frontend/src/app/components/streak-counter/streak-counter.css
@@ -1,0 +1,120 @@
+.streak-counter {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2, 0.5rem);
+  padding: var(--space-4, 1rem);
+  border-radius: var(--radius-lg, 0.75rem);
+  background: var(--surface-secondary, #f8f9fa);
+  text-align: center;
+}
+
+.streak-counter.has-streak {
+  background: linear-gradient(135deg, #fff4e6 0%, #ffe8cc 100%);
+}
+
+.streak-counter.new-record {
+  background: linear-gradient(135deg, #fffde7 0%, #fff59d 100%);
+  box-shadow: 0 0 0 2px var(--color-warning, #ffc107);
+}
+
+/* Fire Icons */
+.streak-fires {
+  display: flex;
+  gap: var(--space-1, 0.25rem);
+  font-size: 1.5rem;
+  min-height: 2rem;
+}
+
+.fire-icon {
+  animation: flicker 1s ease-in-out infinite alternate;
+}
+
+.fire-icon.inactive {
+  opacity: 0.3;
+  filter: grayscale(100%);
+  animation: none;
+}
+
+@keyframes flicker {
+  from {
+    transform: scale(1) rotate(-2deg);
+  }
+  to {
+    transform: scale(1.1) rotate(2deg);
+  }
+}
+
+/* Main Streak Number */
+.streak-main {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1, 0.25rem);
+}
+
+.streak-number {
+  font-size: 3rem;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--text-primary, #212529);
+}
+
+.streak-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-secondary, #6c757d);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Message */
+.streak-message {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--text-secondary, #6c757d);
+}
+
+/* Longest Streak Badge */
+.longest-streak {
+  margin-top: var(--space-2, 0.5rem);
+  padding: var(--space-1, 0.25rem) var(--space-3, 0.75rem);
+  border-radius: var(--radius-full, 9999px);
+  background: var(--surface-tertiary, #e9ecef);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary, #6c757d);
+}
+
+.longest-streak.is-current {
+  background: var(--color-warning, #ffc107);
+  color: var(--text-primary, #212529);
+}
+
+.record-badge {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1, 0.25rem);
+}
+
+.record-badge::before {
+  content: '🏆';
+}
+
+.record-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1, 0.25rem);
+}
+
+/* Responsive adjustments */
+@media (max-width: 480px) {
+  .streak-number {
+    font-size: 2.5rem;
+  }
+
+  .streak-fires {
+    font-size: 1.25rem;
+  }
+}

--- a/apps/frontend/src/app/components/streak-counter/streak-counter.html
+++ b/apps/frontend/src/app/components/streak-counter/streak-counter.html
@@ -1,0 +1,39 @@
+<div
+  class="streak-counter"
+  [class.has-streak]="currentStreak() > 0"
+  [class.new-record]="isNewRecord()"
+  role="region"
+  aria-label="Streak information"
+>
+  <!-- Fire Icons -->
+  <div class="streak-fires" aria-hidden="true">
+    @for (_ of [].constructor(fireCount()); track $index) {
+      <span class="fire-icon">🔥</span>
+    }
+    @if (fireCount() === 0) {
+      <span class="fire-icon inactive">🔥</span>
+    }
+  </div>
+
+  <!-- Current Streak -->
+  <div class="streak-main">
+    <span class="streak-number" [attr.aria-label]="currentStreak() + ' day streak'">
+      {{ currentStreak() }}
+    </span>
+    <span class="streak-label">{{ currentStreak() === 1 ? 'Day' : 'Days' }}</span>
+  </div>
+
+  <!-- Message -->
+  <p class="streak-message">{{ streakMessage() }}</p>
+
+  <!-- Longest Streak Badge -->
+  @if (showLongest() && longestStreak() > 0) {
+    <div class="longest-streak" [class.is-current]="isNewRecord()">
+      @if (isNewRecord()) {
+        <span class="record-badge">New Record!</span>
+      } @else {
+        <span class="record-label">Best: {{ longestStreak() }} days</span>
+      }
+    </div>
+  }
+</div>

--- a/apps/frontend/src/app/components/streak-counter/streak-counter.ts
+++ b/apps/frontend/src/app/components/streak-counter/streak-counter.ts
@@ -1,0 +1,58 @@
+import { Component, input, computed, ChangeDetectionStrategy } from '@angular/core';
+
+/**
+ * Streak Counter Component
+ *
+ * Displays a child's current streak and longest streak with visual feedback.
+ * Shows a fire emoji and encouraging messages based on streak length.
+ *
+ * @example
+ * ```html
+ * <app-streak-counter [currentStreak]="5" [longestStreak]="10" />
+ * ```
+ */
+@Component({
+  selector: 'app-streak-counter',
+  imports: [],
+  templateUrl: './streak-counter.html',
+  styleUrl: './streak-counter.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class StreakCounter {
+  /** Current consecutive days with 100% task completion */
+  currentStreak = input.required<number>();
+
+  /** Longest streak ever achieved */
+  longestStreak = input.required<number>();
+
+  /** Whether to show the longest streak badge */
+  showLongest = input<boolean>(true);
+
+  /** Get an encouraging message based on streak length */
+  streakMessage = computed(() => {
+    const streak = this.currentStreak();
+    if (streak === 0) return 'Start your streak today!';
+    if (streak === 1) return 'Great start! Keep it going!';
+    if (streak < 3) return "You're on a roll!";
+    if (streak < 7) return 'Amazing consistency!';
+    if (streak < 14) return "You're unstoppable!";
+    if (streak < 30) return 'Incredible dedication!';
+    return 'Legendary streak!';
+  });
+
+  /** Get the number of fire emojis to show (max 5) */
+  fireCount = computed(() => {
+    const streak = this.currentStreak();
+    if (streak === 0) return 0;
+    if (streak < 3) return 1;
+    if (streak < 7) return 2;
+    if (streak < 14) return 3;
+    if (streak < 30) return 4;
+    return 5;
+  });
+
+  /** Check if current streak equals or beats longest streak */
+  isNewRecord = computed(() => {
+    return this.currentStreak() > 0 && this.currentStreak() >= this.longestStreak();
+  });
+}

--- a/apps/frontend/src/app/pages/child-dashboard/child-dashboard.css
+++ b/apps/frontend/src/app/pages/child-dashboard/child-dashboard.css
@@ -82,6 +82,26 @@
   margin: 0;
 }
 
+/* Analytics Section */
+.analytics-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.progress-cards {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+@media (min-width: 480px) {
+  .progress-cards {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
 /* Points Section */
 .points-section {
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);

--- a/apps/frontend/src/app/pages/child-dashboard/child-dashboard.html
+++ b/apps/frontend/src/app/pages/child-dashboard/child-dashboard.html
@@ -23,6 +23,31 @@
       <h1 class="greeting">Hi {{ childName() }}! 👋</h1>
     </header>
 
+    <!-- Streak and Progress Section -->
+    @if (analytics()) {
+      <section class="analytics-section">
+        <!-- Streak Counter -->
+        <app-streak-counter
+          [currentStreak]="analytics()!.currentStreak"
+          [longestStreak]="analytics()!.longestStreak"
+        />
+
+        <!-- Week/Month Progress -->
+        <div class="progress-cards">
+          <app-progress-summary
+            title="This Week"
+            icon="📅"
+            [progress]="analytics()!.weekProgress"
+          />
+          <app-progress-summary
+            title="This Month"
+            icon="📆"
+            [progress]="analytics()!.monthProgress"
+          />
+        </div>
+      </section>
+    }
+
     <!-- Available Single Tasks -->
     <app-available-tasks-section />
 

--- a/apps/frontend/src/app/pages/child-dashboard/child-dashboard.ts
+++ b/apps/frontend/src/app/pages/child-dashboard/child-dashboard.ts
@@ -11,6 +11,8 @@ import { firstValueFrom } from 'rxjs';
 import { AnalyticsService } from '../../services/analytics.service';
 import { TaskService, type MyTaskAssignment } from '../../services/task.service';
 import { AvailableTasksSectionComponent } from '../../components/available-tasks-section/available-tasks-section';
+import { StreakCounter } from '../../components/streak-counter/streak-counter';
+import { ProgressSummary } from '../../components/progress-summary/progress-summary';
 import type { ChildAnalytics } from '@st44/types';
 
 /**
@@ -26,7 +28,7 @@ import type { ChildAnalytics } from '@st44/types';
  */
 @Component({
   selector: 'app-child-dashboard',
-  imports: [AvailableTasksSectionComponent],
+  imports: [AvailableTasksSectionComponent, StreakCounter, ProgressSummary],
   templateUrl: './child-dashboard.html',
   styleUrl: './child-dashboard.css',
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
## Summary

Enhances the child dashboard with analytics visualization as part of #170:

- **StreakCounter component**: Displays current and longest streak with animated fire emojis and encouraging messages
- **ProgressSummary component**: Shows week/month task completion with progress bar and statistics  
- **Child Dashboard integration**: Uses already-fetched analytics data to display streak and progress info

## Components Added

### StreakCounter
- Shows current streak with fire emojis (1-5 based on streak length)
- Displays encouraging messages based on streak progress
- Highlights when setting new records

### ProgressSummary
- Shows completion percentage with color-coded progress bar
- Displays tasks completed and points earned
- Encouraging messages based on completion rate

## Screenshots

The child dashboard now displays:
1. Streak counter at the top with fire emojis
2. Two progress cards (This Week / This Month) in a responsive grid

## Test plan

- [x] All 804 frontend tests pass
- [x] Build succeeds (only CSS budget warnings)
- [x] Type check passes
- [x] Components use proper accessibility attributes (role, aria-label)

Part of #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)