### PR TITLE
fix: remove header modification from onResponse hook

### DIFF
--- a/apps/backend/src/middleware/request-logger.ts
+++ b/apps/backend/src/middleware/request-logger.ts
@@ -162,8 +162,8 @@ export async function requestLoggerPlugin(fastify: FastifyInstance): Promise<voi
         responseTimeMs,
       };
 
-      // Add response time header
-      reply.header('X-Response-Time', `${responseTimeMs}ms`);
+      // NOTE: Cannot set headers in onResponse hook (response already sent)
+      // Response time is logged in the context instead
 
       // Log with appropriate level based on status and timing
       if (reply.statusCode >= 500) {


### PR DESCRIPTION
## Summary

Fixes "Reply was already sent" errors in backend tests (#504) by removing the `reply.header('X-Response-Time', ...)` call from the `onResponse` hook in `request-logger.ts`.

## Problem

In Fastify, the `onResponse` hook fires **after** the response has already been sent to the client. Any attempt to modify the response (including setting headers via `reply.header()`) will throw `FST_ERR_REP_ALREADY_SENT`.

This was causing flaky test failures where successful requests (e.g., `/api/auth/register`, `/api/auth/login`) would complete with `statusCode 200/201`, but then log an error about the reply already being sent.

## Solution

- Removed the `reply.header('X-Response-Time', ...)` call from the `onResponse` hook
- The response time is still logged in the context object for observability
- Added explanatory comment about Fastify's response lifecycle

## Test Plan

- [x] Ran `npm test` in apps/backend - auth tests pass without "Reply was already sent" errors
- [x] Confirmed household-membership tests no longer show FST_ERR_REP_ALREADY_SENT errors
- [x] Response time still logged in context for monitoring

Closes #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)