### PR TITLE
fix(frontend): correct save button styling in household settings

### DIFF
--- a/apps/frontend/src/app/components/household-settings/household-settings.css
+++ b/apps/frontend/src/app/components/household-settings/household-settings.css
@@ -175,33 +175,52 @@
   font-family: monospace;
 }
 
+/* Form Actions */
+.form-actions {
+  display: flex;
+  justify-content: flex-start;
+  padding-top: 0.5rem;
+}
+
 /* Button */
 .btn {
   padding: 0.75rem 1.5rem;
   font-size: 1rem;
   font-weight: 500;
   border: none;
-  border-radius: 4px;
+  border-radius: 8px;
   cursor: pointer;
-  transition: all 0.2s;
+  transition:
+    transform 0.2s,
+    box-shadow 0.2s;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
 }
 
-.btn--primary {
-  background-color: #4299e1;
+.btn-primary {
+  background: var(--gradient-primary, linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%));
   color: white;
+  box-shadow: 0 4px 12px rgba(99, 102, 241, 0.3);
 }
 
-.btn--primary:hover:not(:disabled) {
-  background-color: #3182ce;
+.btn-primary:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(99, 102, 241, 0.4);
 }
 
-.btn--primary:disabled {
-  background-color: #cbd5e0;
+.btn-primary:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.btn:disabled {
+  opacity: 0.5;
   cursor: not-allowed;
 }
 
 .btn:focus-visible {
-  outline: 3px solid #4299e1;
+  outline: 3px solid #6366f1;
   outline-offset: 2px;
 }
 
@@ -269,14 +288,13 @@
     border-width: 2px;
   }
 
-  .btn--primary {
-    border: 2px solid #2c5282;
+  .btn-primary {
+    border: 2px solid #4f46e5;
   }
 }
 
 /* Focus Management */
-.btn:focus-visible,
 .form-input:focus-visible {
-  outline: 3px solid #4299e1;
+  outline: 3px solid #6366f1;
   outline-offset: 2px;
 }

--- a/apps/frontend/src/app/components/household-settings/household-settings.html
+++ b/apps/frontend/src/app/components/household-settings/household-settings.html
@@ -50,18 +50,20 @@
           }
 
           @if (isAdmin()) {
-            <button
-              type="submit"
-              class="btn btn--primary"
-              [disabled]="householdForm.invalid || isSaving()"
-              [attr.aria-busy]="isSaving()"
-            >
-              @if (isSaving()) {
-                <span>Saving...</span>
-              } @else {
-                <span>Save Changes</span>
-              }
-            </button>
+            <div class="form-actions">
+              <button
+                type="submit"
+                class="btn btn-primary"
+                [disabled]="householdForm.invalid || isSaving()"
+                [attr.aria-busy]="isSaving()"
+              >
+                @if (isSaving()) {
+                  <span>Saving...</span>
+                } @else {
+                  <span>Save Changes</span>
+                }
+              </button>
+            </div>
           }
         </form>
       </section>


### PR DESCRIPTION
## Summary
Fix the "Save Changes" button in Household Settings page which had incorrect styling:
- Full width instead of auto width
- Wrong color (blue instead of primary gradient)

## Changes
- Wrap button in `.form-actions` container to prevent full-width stretch
- Change button class from `btn--primary` to `btn-primary` (global style)
- Update colors to use `--gradient-primary` (indigo) for consistency with rest of app
- Add proper hover/active states with transform and shadow effects
- Update high contrast mode border color to match new theme

## Before/After
| Before | After |
|--------|-------|
| Full width, flat blue (#4299e1) | Auto width, gradient (indigo → violet) |

## Test plan
- [x] Frontend build passes
- [x] Frontend tests pass (888 passed)
- [ ] CI passes
- [ ] Visual verification on /household/settings page

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)