### PR TITLE
fix(frontend): display user name initials correctly in sidebar avatar

### DIFF
--- a/apps/frontend/src/app/components/navigation/sidebar-nav/sidebar-nav.spec.ts
+++ b/apps/frontend/src/app/components/navigation/sidebar-nav/sidebar-nav.spec.ts
@@ -9,7 +9,10 @@ describe('SidebarNav', () => {
   let fixture: ComponentFixture<SidebarNav>;
 
   const mockUser: SidebarUser = {
-    name: 'Sarah Johnson',
+    name: 'Sarah',
+    firstName: 'Sarah',
+    lastName: 'Johnson',
+    email: 'sarah@example.com',
     avatar: 'SJ',
     household: 'The Johnson Family',
   };
@@ -129,7 +132,7 @@ describe('SidebarNav', () => {
     const userName = fixture.nativeElement.querySelector('.sidebar-user-info h4');
     const householdSwitcher = fixture.nativeElement.querySelector('app-household-switcher');
 
-    expect(userName?.textContent).toContain('Sarah Johnson');
+    expect(userName?.textContent).toContain('Sarah');
     expect(householdSwitcher).toBeTruthy();
   });
 
@@ -150,10 +153,13 @@ describe('SidebarNav', () => {
     expect(component.userInitials()).toBe('SJ');
   });
 
-  it('should handle single name for initials', () => {
+  it('should handle single name for initials (email fallback)', () => {
     const singleNameUser: SidebarUser = {
       name: 'Mike',
-      avatar: 'MI',
+      firstName: null,
+      lastName: null,
+      email: 'mike@example.com',
+      avatar: 'M',
       household: 'Test Family',
     };
 
@@ -161,7 +167,24 @@ describe('SidebarNav', () => {
     componentRef.setInput('user', singleNameUser);
     fixture.detectChanges();
 
-    expect(component.userInitials()).toBe('MI');
+    expect(component.userInitials()).toBe('M');
+  });
+
+  it('should compute initials from firstName/lastName when available', () => {
+    const userWithNames: SidebarUser = {
+      name: 'John',
+      firstName: 'John',
+      lastName: 'Doe',
+      email: 'john@example.com',
+      avatar: 'JD',
+      household: 'Test Family',
+    };
+
+    componentRef.setInput('activeScreen', 'home');
+    componentRef.setInput('user', userWithNames);
+    fixture.detectChanges();
+
+    expect(component.userInitials()).toBe('JD');
   });
 
   it('should have correct accessibility attributes on nav', () => {
@@ -200,7 +223,7 @@ describe('SidebarNav', () => {
     fixture.detectChanges();
 
     const avatar = fixture.nativeElement.querySelector('.sidebar-avatar');
-    expect(avatar.getAttribute('aria-label')).toBe('Avatar for Sarah Johnson');
+    expect(avatar.getAttribute('aria-label')).toBe('Avatar for Sarah');
   });
 
   it('should update active state when activeScreen changes', () => {
@@ -225,10 +248,13 @@ describe('SidebarNav', () => {
     fixture.detectChanges();
 
     let userName = fixture.nativeElement.querySelector('.sidebar-user-info h4');
-    expect(userName?.textContent).toContain('Sarah Johnson');
+    expect(userName?.textContent).toContain('Sarah');
 
     const newUser: SidebarUser = {
-      name: 'Mike Smith',
+      name: 'Mike',
+      firstName: 'Mike',
+      lastName: 'Smith',
+      email: 'mike@example.com',
       avatar: 'MS',
       household: 'The Smith Family',
     };
@@ -238,6 +264,6 @@ describe('SidebarNav', () => {
 
     userName = fixture.nativeElement.querySelector('.sidebar-user-info h4');
 
-    expect(userName?.textContent).toContain('Mike Smith');
+    expect(userName?.textContent).toContain('Mike');
   });
 });

--- a/apps/frontend/src/app/components/navigation/sidebar-nav/sidebar-nav.stories.ts
+++ b/apps/frontend/src/app/components/navigation/sidebar-nav/sidebar-nav.stories.ts
@@ -43,7 +43,10 @@ const meta: Meta<SidebarNav> = {
 export default meta;
 
 const defaultUser: SidebarUser = {
-  name: 'Sarah Johnson',
+  name: 'Sarah',
+  firstName: 'Sarah',
+  lastName: 'Johnson',
+  email: 'sarah@example.com',
   avatar: 'SJ',
   household: 'The Johnson Family',
 };
@@ -89,14 +92,17 @@ export const Progress: StoryObj<SidebarNav> = {
 };
 
 /**
- * User with single name
+ * User with single name (no lastName)
  */
 export const SingleNameUser: StoryObj<SidebarNav> = {
   args: {
     activeScreen: 'home',
     user: {
       name: 'Mike',
-      avatar: 'MI',
+      firstName: 'Mike',
+      lastName: null,
+      email: 'mike@example.com',
+      avatar: 'M',
       household: 'The Smith Family',
     },
   },
@@ -109,7 +115,10 @@ export const LongHouseholdName: StoryObj<SidebarNav> = {
   args: {
     activeScreen: 'home',
     user: {
-      name: 'Alexandra Martinez',
+      name: 'Alexandra',
+      firstName: 'Alexandra',
+      lastName: 'Martinez',
+      email: 'alexandra@example.com',
       avatar: 'AM',
       household: 'The Martinez-Rodriguez Family Household',
     },

--- a/apps/frontend/src/app/components/navigation/sidebar-nav/sidebar-nav.ts
+++ b/apps/frontend/src/app/components/navigation/sidebar-nav/sidebar-nav.ts
@@ -7,6 +7,9 @@ import { HouseholdSwitcherComponent } from '../../household-switcher/household-s
  */
 export interface SidebarUser {
   name: string;
+  firstName: string | null;
+  lastName: string | null;
+  email: string | null;
   avatar: string;
   household: string;
 }
@@ -56,14 +59,30 @@ export class SidebarNav {
   ];
 
   /**
-   * Compute initials from user name
+   * Compute initials from user name fields
    */
   userInitials = computed(() => {
-    const name = this.user().name;
+    const user = this.user();
+    const firstName = user.firstName;
+    const lastName = user.lastName;
+
+    // Use firstName/lastName if available
+    if (firstName && lastName) {
+      return `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
+    }
+
+    // Fall back to splitting the name (for display name)
+    const name = user.name;
     const parts = name.split(' ');
     if (parts.length >= 2) {
-      return `${parts[0][0]}${parts[1][0]}`.toUpperCase();
+      return `${parts[0].charAt(0)}${parts[1].charAt(0)}`.toUpperCase();
     }
+
+    // Fall back to first letter of email if available
+    if (user.email) {
+      return user.email.charAt(0).toUpperCase();
+    }
+
     return name.substring(0, 2).toUpperCase();
   });
 

--- a/apps/frontend/src/app/layouts/main-layout/main-layout.ts
+++ b/apps/frontend/src/app/layouts/main-layout/main-layout.ts
@@ -67,8 +67,15 @@ export class MainLayout implements OnInit, OnDestroy {
   // Computed values
   protected readonly sidebarUser = computed<SidebarUser>(() => {
     const user = this.authService.currentUser();
+    const firstName = user?.firstName || null;
+    const lastName = user?.lastName || null;
+    // Use first name if available, otherwise fall back to email prefix
+    const displayName = firstName || user?.email?.split('@')[0] || 'User';
     return {
-      name: user?.email?.split('@')[0] || 'User',
+      name: displayName,
+      firstName,
+      lastName,
+      email: user?.email || null,
       avatar: '',
       household: this.householdName(),
     };


### PR DESCRIPTION
## Summary

- Update `SidebarUser` interface to include `firstName`, `lastName`, and `email` fields
- Modify main-layout to pass user's first/last name to sidebar component
- Update sidebar-nav `userInitials` computed property to prioritize firstName/lastName
- Add fallback logic: firstName+lastName → split name → email initial → first chars

## Changes

The sidebar was showing the email prefix (e.g., "jo" from "john.doe@example.com") instead of the user's actual initials. This fix:

1. Extended the `SidebarUser` interface with proper name fields
2. Updated `main-layout.ts` to pass the user's first name, last name, and email
3. Updated `sidebar-nav.ts` to compute initials correctly with proper fallback chain
4. Updated all tests and storybook stories to use the new interface

## Test Plan

- [x] Frontend tests pass (889 tests)
- [x] Backend tests pass (742 tests)
- [x] Build succeeds
- [x] Manual verification needed: Log in with a user that has firstName/lastName set

Closes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)