### PR TITLE
fix(frontend): update Today's Tasks empty state message for parents

### DIFF
--- a/apps/frontend/src/app/pages/home/home.html
+++ b/apps/frontend/src/app/pages/home/home.html
@@ -73,9 +73,9 @@
           </div>
         } @else {
           <div class="empty-state" role="status">
-            <div class="empty-icon" aria-hidden="true">✨</div>
-            <h3>All done!</h3>
-            <p>You've completed all your tasks for today.</p>
+            <div class="empty-icon" aria-hidden="true">📋</div>
+            <h3>No tasks for today</h3>
+            <p>No tasks have been scheduled for today. Create tasks in the Tasks section.</p>
           </div>
         }
       </section>


### PR DESCRIPTION
## Summary

Updated the empty state message in Today's Tasks section on the Home page to be more appropriate for parent/admin users.

## Changes

The previous message "All done! You've completed all your tasks for today" was misleading because:
1. Parents don't have personal tasks assigned to them
2. This section shows children's tasks for the household
3. The message implied the parent completed tasks when no tasks exist

Updated to:
- **Icon**: 📋 (clipboard) - more appropriate for "no tasks"
- **Title**: "No tasks for today"
- **Description**: "No tasks have been scheduled for today. Create tasks in the Tasks section."

## Test Plan

- [x] Frontend build succeeds
- [x] Home page tests pass (11 tests)
- [x] Manual verification: Visit /home with no tasks for today

Closes #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)