### PR TITLE
feat(invitations): add cleanup functionality for old invitations

### DIFF
--- a/apps/frontend/src/app/components/invitations-sent-list/invitations-sent-list.css
+++ b/apps/frontend/src/app/components/invitations-sent-list/invitations-sent-list.css
@@ -15,6 +15,11 @@
   color: var(--text-color, #333);
 }
 
+.header-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
 /* Messages */
 .alert {
   padding: 0.75rem 1rem;
@@ -168,6 +173,15 @@
 
 .btn-danger:hover:not(:disabled) {
   background-color: #c82333;
+}
+
+.btn-warning {
+  background-color: #ffc107;
+  color: #212529;
+}
+
+.btn-warning:hover:not(:disabled) {
+  background-color: #e0a800;
 }
 
 /* Responsive */

--- a/apps/frontend/src/app/components/invitations-sent-list/invitations-sent-list.html
+++ b/apps/frontend/src/app/components/invitations-sent-list/invitations-sent-list.html
@@ -1,15 +1,28 @@
 <div class="invitations-sent-list">
   <div class="header">
     <h3>Sent Invitations</h3>
-    <button
-      type="button"
-      class="btn btn-secondary btn-sm"
-      (click)="loadInvitations()"
-      [disabled]="isLoading()"
-      aria-label="Refresh invitations list"
-    >
-      Refresh
-    </button>
+    <div class="header-actions">
+      @if (hasOldInvitations()) {
+        <button
+          type="button"
+          class="btn btn-warning btn-sm"
+          (click)="cleanupInvitations()"
+          [disabled]="isLoading()"
+          aria-label="Remove cancelled and expired invitations"
+        >
+          Clean up old
+        </button>
+      }
+      <button
+        type="button"
+        class="btn btn-secondary btn-sm"
+        (click)="loadInvitations()"
+        [disabled]="isLoading()"
+        aria-label="Refresh invitations list"
+      >
+        Refresh
+      </button>
+    </div>
   </div>
 
   <!-- Success message -->

--- a/apps/frontend/src/app/services/invitation.service.ts
+++ b/apps/frontend/src/app/services/invitation.service.ts
@@ -105,4 +105,14 @@ export class InvitationService {
   async cancelInvitation(householdId: string, invitationId: string): Promise<void> {
     return this.api.delete<void>(`/households/${householdId}/invitations/${invitationId}`);
   }
+
+  /**
+   * Cleanup cancelled and expired invitations (admin only)
+   * @returns Number of deleted invitations
+   */
+  async cleanupInvitations(householdId: string): Promise<{ deleted: number; message: string }> {
+    return this.api.delete<{ deleted: number; message: string }>(
+      `/households/${householdId}/invitations/cleanup`,
+    );
+  }
 }


### PR DESCRIPTION
## Summary

Adds a "Clean up old" button to the Sent Invitations list that removes all cancelled, declined, and expired invitations in one action.

## Changes

### Backend
- Add `DELETE /api/households/:householdId/invitations/cleanup` endpoint
- Removes invitations with status `cancelled`, `declined`, or expired `pending`
- Admin-only access (returns 403 for non-admins)

### Frontend
- Add `cleanupInvitations()` method to `InvitationService`
- Add "Clean up old" button to `invitations-sent-list` component
- Button only appears when there are old invitations to clean up
- Confirmation dialog before cleanup action
- Success message shows count of deleted invitations

## Test Plan

- [x] Backend tests pass (742 tests)
- [x] Frontend tests pass (889 tests)
- [x] Build succeeds
- [x] Manual verification needed:
  - [ ] Create invitations, cancel some, let some expire
  - [ ] Verify "Clean up old" button appears
  - [ ] Click cleanup and verify invitations are removed
  - [ ] Verify non-admin users cannot see/use the cleanup feature

Closes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)