### PR TITLE
fix(frontend): auto-refresh sent invitations list after sending invitation

### DIFF
--- a/apps/frontend/src/app/components/household-settings/household-settings.ts
+++ b/apps/frontend/src/app/components/household-settings/household-settings.ts
@@ -5,6 +5,7 @@ import {
   inject,
   OnInit,
   ChangeDetectionStrategy,
+  viewChild,
 } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -37,6 +38,9 @@ export class HouseholdSettingsComponent implements OnInit {
   private readonly router = inject(Router);
   private readonly householdService = inject(HouseholdService);
   private readonly authService = inject(AuthService);
+
+  // ViewChild for invitations list to refresh after sending
+  private readonly invitationsSentList = viewChild(InvitationsSentListComponent);
 
   household = signal<HouseholdListItem | null>(null);
   members = signal<HouseholdMemberResponse[]>([]);
@@ -149,7 +153,10 @@ export class HouseholdSettingsComponent implements OnInit {
   }
 
   async onInvitationSent() {
-    // Refresh members list
+    // Refresh the sent invitations list
+    this.invitationsSentList()?.loadInvitations();
+
+    // Also refresh members list for consistency
     const householdId = this.household()?.id;
     if (householdId) {
       // Note: New member won't appear until they accept, but refresh for consistency


### PR DESCRIPTION
## Summary

Automatically refresh the sent invitations list after successfully sending a new invitation.

## Changes

- Use `viewChild()` to get reference to `InvitationsSentListComponent`
- Call `loadInvitations()` on the component when `invitationSent` event is emitted

## Problem

Previously, when a user sent an invitation on the Household Settings page, the "Sent Invitations" list did not update. Users had to manually refresh the page to see the newly sent invitation, which was confusing and made users unsure if the invitation was actually sent.

## Solution

Used Angular's `viewChild()` signal query to get a reference to the child `InvitationsSentListComponent` and trigger its `loadInvitations()` method when an invitation is successfully sent.

## Test Plan

- [x] Frontend build succeeds
- [x] All frontend tests pass (889 tests)
- [x] Manual verification needed:
  - [ ] Go to /household/settings
  - [ ] Send an invitation
  - [ ] Verify the invitation appears in the list immediately

Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)