### PR TITLE
fix(frontend): load children when opening edit task modal

### DIFF
--- a/apps/frontend/src/app/pages/tasks/tasks.ts
+++ b/apps/frontend/src/app/pages/tasks/tasks.ts
@@ -417,6 +417,10 @@ export class Tasks implements OnInit {
   protected onTaskEdit(taskId: string): void {
     const task = this.tasks().find((t) => t.id === taskId);
     if (task) {
+      // Ensure children are loaded for the edit modal
+      if (this.members().length === 0) {
+        this.loadMembers();
+      }
       this.editingTask.set(task);
       this.editModalOpen.set(true);
     }


### PR DESCRIPTION
## Summary

Fix the edit task modal showing "No children in this household yet" even when children exist.

## Problem

When editing a task from the Tasks page while on the "All" filter, the children dropdown showed "No children" because:
1. Children are only loaded when the "By Person" filter is active
2. The edit modal uses the same `members()` signal
3. When opening edit from "All" filter, `members()` is empty

## Solution

Call `loadMembers()` when opening the edit modal if children haven't been loaded yet.

## Changes

- Add check for empty `members()` in `onTaskEdit()`
- Call `loadMembers()` before opening the edit modal

## Test Plan

- [x] Frontend build succeeds
- [x] All frontend tests pass (889 tests)
- [x] Manual verification needed:
  - [ ] Navigate to /tasks
  - [ ] Stay on "All" filter (don't switch to "By Person")
  - [ ] Click edit on any task
  - [ ] Verify children appear in the assignment dropdown

Closes #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)