### PR TITLE
fix(frontend): hide task completion UI for parent and admin roles

### DIFF
--- a/apps/frontend/src/app/pages/tasks/tasks.html
+++ b/apps/frontend/src/app/pages/tasks/tasks.html
@@ -68,7 +68,7 @@
         @for (task of filteredTasks(); track task.id) {
           <app-task-card
             [task]="task"
-            [showCompleteButton]="!isParent()"
+            [showCompleteButton]="!isParentOrAdmin()"
             [clickable]="true"
             [showReassignButton]="activeFilter() !== 'all'"
             (complete)="onTaskComplete($event)"

--- a/apps/frontend/src/app/pages/tasks/tasks.spec.ts
+++ b/apps/frontend/src/app/pages/tasks/tasks.spec.ts
@@ -105,6 +105,10 @@ describe('Tasks Component', () => {
       currentUser: currentUserSignal.asReadonly(),
       isAuthenticated: isAuthenticatedSignal.asReadonly(),
       hasRole: vi.fn((role: string) => currentUserSignal()?.role === role),
+      hasAnyRole: vi.fn((roles: string[]) => {
+        const userRole = currentUserSignal()?.role;
+        return userRole !== undefined && roles.includes(userRole);
+      }),
       // Store writable signal for test manipulation
       _currentUserSignal: currentUserSignal,
     } as unknown as Partial<AuthService> & {

--- a/apps/frontend/src/app/pages/tasks/tasks.ts
+++ b/apps/frontend/src/app/pages/tasks/tasks.ts
@@ -133,12 +133,15 @@ export class Tasks implements OnInit {
   });
 
   /**
-   * Check if current user is a parent
+   * Check if current user is a parent or admin (not a child)
+   * Parents and admins don't complete tasks, only children do
    */
-  protected readonly isParent = computed(() => this.authService.hasRole('parent'));
+  protected readonly isParentOrAdmin = computed(() =>
+    this.authService.hasAnyRole(['parent', 'admin']),
+  );
 
   /**
-   * Filter tabs configuration - excludes 'My Tasks' for parents
+   * Filter tabs configuration - excludes 'My Tasks' for parents/admins
    */
   protected readonly filterTabs = computed(() => {
     const allTabs: { id: TaskFilter; label: string }[] = [
@@ -148,8 +151,8 @@ export class Tasks implements OnInit {
       { id: 'completed', label: 'Completed' },
     ];
 
-    // Parents don't have tasks assigned to them, so hide "My Tasks"
-    if (this.isParent()) {
+    // Parents/admins don't have tasks assigned to them, so hide "My Tasks"
+    if (this.isParentOrAdmin()) {
       return allTabs.filter((tab) => tab.id !== 'mine');
     }
 


### PR DESCRIPTION
## Summary

Fix incorrect UI elements shown to parent and admin users on the Tasks page.

## Problems Fixed

1. **#516**: Task cards showed a clickable checkbox for parents/admins (filter=all)
2. **#514**: "My Tasks" tab was visible for parent/admin roles

## Changes

- Rename `isParent` computed property to `isParentOrAdmin`
- Use `hasAnyRole(['parent', 'admin'])` instead of `hasRole('parent')`
- Apply to both:
  - `showCompleteButton` prop on task cards
  - `filterTabs` computed property (hides "My Tasks")

## Root Cause

The original code only checked for 'parent' role, but 'admin' users also don't complete tasks.

## Test Plan

- [x] Frontend build succeeds
- [x] All frontend tests pass (889 tests)
- [x] Manual verification needed:
  - [ ] Log in as admin, go to /tasks, verify no checkbox on task cards
  - [ ] Log in as admin, go to /tasks, verify no "My Tasks" tab
  - [ ] Log in as parent, same checks
  - [ ] Log in as child, verify checkbox IS visible

Closes #516, closes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)