### PR TITLE
fix(frontend): change Tasks page header from 'All Tasks' to 'Tasks'

### DIFF
--- a/apps/frontend/src/app/pages/tasks/tasks.html
+++ b/apps/frontend/src/app/pages/tasks/tasks.html
@@ -1,4 +1,4 @@
-<app-page title="All Tasks" maxWidth="medium">
+<app-page title="Tasks" maxWidth="medium">
   <!-- Filter Tabs -->
   <div class="filter-tabs">
     @for (tab of filterTabs(); track tab.id) {


### PR DESCRIPTION
## Summary

- Simplifies Tasks page header from "All Tasks" to "Tasks"
- Matches navigation pattern used across other pages (Settings, Progress, Rewards)
- Filter tabs provide filtering context, making "All Tasks" redundant

## Test Plan

- [x] All frontend tests pass (889 tests)
- [x] Verified page renders correctly with new header

Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)