### PR TITLE
fix(frontend): handle ISO timestamp dates in chart date formatting

### DIFF
--- a/apps/frontend/src/app/components/children-trends/children-trends.ts
+++ b/apps/frontend/src/app/components/children-trends/children-trends.ts
@@ -64,7 +64,10 @@ export class ChildrenTrends {
 
   /** Format date to short day name */
   private formatDayLabel(dateStr: string): string {
-    const date = new Date(dateStr + 'T12:00:00');
+    // Handle both YYYY-MM-DD and full ISO timestamp formats
+    // Extract just the date portion if it's an ISO timestamp
+    const dateOnly = dateStr.includes('T') ? dateStr.split('T')[0] : dateStr;
+    const date = new Date(dateOnly + 'T12:00:00'); // Use noon to avoid timezone issues
     return date.toLocaleDateString('en-US', { weekday: 'short' });
   }
 }

--- a/apps/frontend/src/app/components/daily-points-chart/daily-points-chart.ts
+++ b/apps/frontend/src/app/components/daily-points-chart/daily-points-chart.ts
@@ -52,7 +52,10 @@ export class DailyPointsChart {
 
   /** Format date to short day name (Mon, Tue, etc.) */
   private formatDayLabel(dateStr: string): string {
-    const date = new Date(dateStr + 'T12:00:00'); // Use noon to avoid timezone issues
+    // Handle both YYYY-MM-DD and full ISO timestamp formats
+    // Extract just the date portion if it's an ISO timestamp
+    const dateOnly = dateStr.includes('T') ? dateStr.split('T')[0] : dateStr;
+    const date = new Date(dateOnly + 'T12:00:00'); // Use noon to avoid timezone issues
     return date.toLocaleDateString('en-US', { weekday: 'short' });
   }
 }


### PR DESCRIPTION
## Summary

- Fixed 'Invalid date' display in Children Progress chart on home page
- Fixed same issue in Daily Points chart on child dashboard
- Root cause: Analytics API returns dates as full ISO timestamps, but formatDayLabel was appending 'T12:00:00' to already complete timestamps

## Changes

- **children-trends.ts**: Extract date portion before formatting
- **daily-points-chart.ts**: Same fix

## Test Plan

- [x] All frontend tests pass (889 tests)
- [x] Build succeeds

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)