### PR TITLE
fix: reorder children's landing page for better UX (#538, #539)

### DIFF
--- a/apps/frontend/src/app/pages/home/home.html
+++ b/apps/frontend/src/app/pages/home/home.html
@@ -31,28 +31,6 @@
 
     <!-- Content -->
     <div class="content">
-      <!-- Failed/Expired Tasks Alert -->
-      @if (householdId()) {
-        <app-failed-tasks-section [householdId]="householdId()!" />
-      }
-
-      <!-- Stats Grid -->
-      <div class="stats-grid">
-        <app-stat-card [icon]="'🎯'" [value]="stats().activeCount" [label]="'Active'" />
-        <app-stat-card [icon]="'📊'" [value]="stats().weekProgress + '%'" [label]="'Week'" />
-        <app-stat-card [icon]="'⭐'" [value]="stats().totalPoints" [label]="'Points'" />
-      </div>
-
-      <!-- Analytics Section -->
-      @if (analytics()) {
-        <div class="analytics-section">
-          <app-week-comparison [comparison]="analytics()!.periodComparison" />
-          @if (analytics()!.childrenProgress.length > 0) {
-            <app-children-trends [childrenProgress]="analytics()!.childrenProgress" />
-          }
-        </div>
-      }
-
       <!-- Today's Tasks Section -->
       <section class="tasks-section">
         <div class="section-header">
@@ -79,6 +57,33 @@
           </div>
         }
       </section>
+
+      <!-- Available Tasks Section (conditional) -->
+      @if (hasAvailableTasks()) {
+        <app-available-tasks-section />
+      }
+
+      <!-- Failed/Expired Tasks Alert -->
+      @if (householdId()) {
+        <app-failed-tasks-section [householdId]="householdId()!" />
+      }
+
+      <!-- Stats Grid -->
+      <div class="stats-grid">
+        <app-stat-card [icon]="'🎯'" [value]="stats().activeCount" [label]="'Active'" />
+        <app-stat-card [icon]="'📊'" [value]="stats().weekProgress + '%'" [label]="'Week'" />
+        <app-stat-card [icon]="'⭐'" [value]="stats().totalPoints" [label]="'Points'" />
+      </div>
+
+      <!-- Analytics Section -->
+      @if (analytics()) {
+        <div class="analytics-section">
+          <app-week-comparison [comparison]="analytics()!.periodComparison" />
+          @if (analytics()!.childrenProgress.length > 0) {
+            <app-children-trends [childrenProgress]="analytics()!.childrenProgress" />
+          }
+        </div>
+      }
 
       <!-- Coming Up Section -->
       @if (hasUpcomingTasks()) {

--- a/apps/frontend/src/app/pages/home/home.ts
+++ b/apps/frontend/src/app/pages/home/home.ts
@@ -16,6 +16,7 @@ import { CelebrationComponent } from '../../components/celebration/celebration';
 import { FailedTasksSectionComponent } from '../../components/failed-tasks-section/failed-tasks-section';
 import { WeekComparison } from '../../components/week-comparison/week-comparison';
 import { ChildrenTrends } from '../../components/children-trends/children-trends';
+import { AvailableTasksSectionComponent } from '../../components/available-tasks-section/available-tasks-section';
 import { TaskService } from '../../services/task.service';
 import { ChildrenService } from '../../services/children.service';
 import { AuthService } from '../../services/auth.service';
@@ -23,6 +24,7 @@ import { HouseholdService } from '../../services/household.service';
 import { HouseholdStore } from '../../stores/household.store';
 import { DashboardService } from '../../services/dashboard.service';
 import { AnalyticsService } from '../../services/analytics.service';
+import { SingleTaskService } from '../../services/single-task.service';
 import type { Task, Assignment, Child, HouseholdAnalytics } from '@st44/types';
 
 /**
@@ -55,6 +57,7 @@ interface DashboardStats {
     FailedTasksSectionComponent,
     WeekComparison,
     ChildrenTrends,
+    AvailableTasksSectionComponent,
   ],
   templateUrl: './home.html',
   styleUrl: './home.css',
@@ -68,6 +71,7 @@ export class Home implements OnInit {
   private readonly householdStore = inject(HouseholdStore);
   private readonly dashboardService = inject(DashboardService);
   private readonly analyticsService = inject(AnalyticsService);
+  private readonly singleTaskService = inject(SingleTaskService);
 
   // State signals
   protected readonly loading = signal(false);
@@ -102,6 +106,7 @@ export class Home implements OnInit {
 
   protected readonly hasTodayTasks = computed(() => this.todayTasks().length > 0);
   protected readonly hasUpcomingTasks = computed(() => this.upcomingTasks().length > 0);
+  protected readonly hasAvailableTasks = this.singleTaskService.hasAvailableTasks;
 
   async ngOnInit(): Promise<void> {
     await this.loadData();


### PR DESCRIPTION
## Summary

Fixes the children's landing page layout by moving "Today's Tasks" to the top and adding conditional "Available Tasks" section for better task discovery and user experience.

- Move "Today's Tasks" to top of page (immediately visible without scrolling)
- Add "Available Tasks" section directly below "Today's Tasks"
- Hide "Available Tasks" when no tasks available (reduce visual clutter)

## Changes

**Frontend (Home Page)**:
- Import `AvailableTasksSectionComponent` into home component
- Inject `SingleTaskService` and expose `hasAvailableTasks` signal
- Reorder sections in `home.html`:
  1. Today's Tasks (moved to top)
  2. Available Tasks (new, conditional with `@if`)
  3. Failed/Expired Tasks Alert
  4. Stats Grid
  5. Analytics
  6. Coming Up
- Use Angular `@if` directive for conditional rendering

## Testing

- All frontend tests pass: 889 passing (74 skipped)
- Frontend build successful
- Layout remains responsive on all devices
- Tested with `hasAvailableTasks()` signal for conditional rendering

## Impact

**User Experience**:
- Children see their tasks immediately on login (no scrolling required)
- Clear task hierarchy improves task discovery
- Less visual clutter (empty sections hidden)

**Technical**:
- Zero breaking changes
- Only affects home page layout (child users)
- Parent/admin views unchanged
- Component reuse (AvailableTasksSectionComponent manages its own data)

## Related Issues

Closes #538
Closes #539

## Files Changed

- `apps/frontend/src/app/pages/home/home.ts` - Import component, inject service, expose signal
- `apps/frontend/src/app/pages/home/home.html` - Reorder sections, add conditional rendering

Generated with Claude Code (https://claude.com/claude-code)