### PR TITLE
fix: resolve Stats API test failures (issue #547)

### DIFF
--- a/apps/backend/src/routes/stats.test.ts
+++ b/apps/backend/src/routes/stats.test.ts
@@ -197,7 +197,7 @@ describe('Stats API', () => {
     test('should return leaderboard for week period', async () => {
       const response = await app.inject({
         method: 'GET',
-        url: '/api/stats/leaderboard?period=week',
+        url: `/api/stats/leaderboard?period=week&householdId=${householdId}`,
         headers: { Authorization: `Bearer ${parentToken}` },
       });
 
@@ -220,7 +220,7 @@ describe('Stats API', () => {
     test('should return leaderboard for month period', async () => {
       const response = await app.inject({
         method: 'GET',
-        url: '/api/stats/leaderboard?period=month',
+        url: `/api/stats/leaderboard?period=month&householdId=${householdId}`,
         headers: { Authorization: `Bearer ${parentToken}` },
       });
 
@@ -232,7 +232,7 @@ describe('Stats API', () => {
     test('should return leaderboard for alltime period', async () => {
       const response = await app.inject({
         method: 'GET',
-        url: '/api/stats/leaderboard?period=alltime',
+        url: `/api/stats/leaderboard?period=alltime&householdId=${householdId}`,
         headers: { Authorization: `Bearer ${parentToken}` },
       });
 
@@ -306,7 +306,7 @@ describe('Stats API', () => {
     test('should return achievements with specific userId', async () => {
       const response = await app.inject({
         method: 'GET',
-        url: `/api/stats/achievements?userId=${childId}`,
+        url: `/api/stats/achievements?userId=${childId}&householdId=${householdId}`,
         headers: { Authorization: `Bearer ${parentToken}` },
       });
 
@@ -338,7 +338,7 @@ describe('Stats API', () => {
     test('should unlock first_task achievement after completing a task', async () => {
       const response = await app.inject({
         method: 'GET',
-        url: '/api/stats/achievements',
+        url: `/api/stats/achievements?householdId=${householdId}`,
         headers: { Authorization: `Bearer ${childToken}` },
       });
 

--- a/apps/backend/src/routes/stats.ts
+++ b/apps/backend/src/routes/stats.ts
@@ -174,6 +174,7 @@ async function getDashboardStats(
 
   if (!userId) {
     return reply.status(401).send({
+      statusCode: 401,
       error: 'Unauthorized',
       message: 'Authentication required',
     });
@@ -184,6 +185,7 @@ async function getDashboardStats(
 
     if (!householdId) {
       return reply.status(404).send({
+        statusCode: 404,
         error: 'Not Found',
         message: 'No household found for user',
       });
@@ -305,6 +307,7 @@ async function getDashboardStats(
   } catch (error) {
     request.log.error(error, 'Failed to get dashboard stats');
     return reply.status(500).send({
+      statusCode: 500,
       error: 'Internal Server Error',
       message: 'Failed to retrieve dashboard statistics',
     });
@@ -323,6 +326,7 @@ async function getLeaderboard(
 
   if (!userId) {
     return reply.status(401).send({
+      statusCode: 401,
       error: 'Unauthorized',
       message: 'Authentication required',
     });
@@ -333,6 +337,7 @@ async function getLeaderboard(
 
     if (!householdId) {
       return reply.status(404).send({
+        statusCode: 404,
         error: 'Not Found',
         message: 'No household found for user',
       });
@@ -384,6 +389,7 @@ async function getLeaderboard(
   } catch (error) {
     request.log.error(error, 'Failed to get leaderboard');
     return reply.status(500).send({
+      statusCode: 500,
       error: 'Internal Server Error',
       message: 'Failed to retrieve leaderboard',
     });
@@ -412,6 +418,7 @@ async function getAchievements(
 
     if (!householdId) {
       return reply.status(404).send({
+        statusCode: 404,
         error: 'Not Found',
         message: 'No household found for user',
       });
@@ -430,6 +437,7 @@ async function getAchievements(
 
       if (childResult.rows.length === 0) {
         return reply.status(404).send({
+          statusCode: 404,
           error: 'Not Found',
           message: 'User not found in household',
         });
@@ -523,6 +531,7 @@ async function getAchievements(
   } catch (error) {
     request.log.error(error, 'Failed to get achievements');
     return reply.status(500).send({
+      statusCode: 500,
       error: 'Internal Server Error',
       message: 'Failed to retrieve achievements',
     });


### PR DESCRIPTION
## Summary
Fixed two root causes of Stats API test failures:

1. **Error Response Schema Mismatch**: Error responses were missing the required `statusCode` field that CommonErrors schema expects
2. **Test Household Context**: Tests were not specifying householdId parameter, causing API to use wrong household

## Changes
- Added `statusCode` field to all error responses (401, 404, 500) in `apps/backend/src/routes/stats.ts`
- Added `householdId` query parameter to leaderboard and achievement tests in `apps/backend/src/routes/stats.test.ts`

## Test Results
All 16 Stats API tests now pass:
- ✅ Dashboard stats (5 tests)
- ✅ Leaderboard (5 tests)  
- ✅ Achievements (6 tests)

## Root Cause Analysis

### Issue 1: Schema Mismatch
The CommonErrors schema (from `@st44/types/generators`) requires all error responses to include three fields:
- `statusCode` (number)
- `error` (string)
- `message` (string)

Error responses in stats.ts were only sending `error` and `message`, causing Fastify serialization errors like `"statusCode" is required!`

### Issue 2: Wrong Household Context
Tests created a separate test household with child profiles and task completions, but API calls didn't specify `householdId` parameter. The `getUserHouseholdId()` helper defaulted to the user's first household (from registration), not the test household, resulting in 404 errors.

Closes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)