### PR TITLE
fix: household selection now persists across login sessions

### DIFF
--- a/apps/frontend/src/app/services/auth.service.ts
+++ b/apps/frontend/src/app/services/auth.service.ts
@@ -110,11 +110,6 @@ export class AuthService {
             lastName: response.lastName,
           });
           this.isAuthenticated.set(true);
-
-          // If user has household, set it as active immediately
-          if (response.householdId) {
-            this.householdStore.setActiveHousehold(response.householdId);
-          }
         }),
       );
   }
@@ -138,11 +133,6 @@ export class AuthService {
             lastName: response.lastName,
           });
           this.isAuthenticated.set(true);
-
-          // If user has household, set it as active immediately
-          if (response.householdId) {
-            this.householdStore.setActiveHousehold(response.householdId);
-          }
         }),
       );
   }


### PR DESCRIPTION
## Summary

Fixes #553 - Household selection now persists across login sessions.

## Problem

When a parent/admin user with multiple households logs in, the backend returns a `householdId` in the login response (always the first household from the database). The auth service was setting this as the active household, overwriting the user's stored preference in localStorage.

## Solution

Removed the code in `AuthService` that sets the household from the backend response:
- Lines 114-117 in `login()` 
- Lines 142-145 in `loginWithGoogle()`

Now the auth service relies entirely on `HouseholdStore.autoActivateHousehold()`, which correctly:
1. Checks if a household ID is stored in localStorage
2. Validates that the stored household still exists for the user
3. Keeps the stored household if valid
4. Only falls back to the first household if no valid stored ID exists

## Changes

- **apps/frontend/src/app/services/auth.service.ts**: Removed household setting logic from login methods

## Testing

- ✅ All 889 frontend tests pass
- ✅ Type checking passes
- ✅ No backend changes required

## Impact

- Fixes poor UX for parent/admin users with multiple households
- Users no longer need to reselect their preferred household on every login
- Household preference persists across login sessions via localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)