### PR TITLE
fix: standardize tasks page width to 1200px

### DIFF
--- a/apps/frontend/src/app/pages/tasks/tasks.html
+++ b/apps/frontend/src/app/pages/tasks/tasks.html
@@ -1,4 +1,4 @@
-<app-page title="Tasks" maxWidth="medium">
+<app-page title="Tasks" maxWidth="wide">
   <!-- Filter Tabs -->
   <div class="filter-tabs">
     @for (tab of filterTabs(); track tab.id) {


### PR DESCRIPTION
## Summary
- Changed tasks page from `maxWidth="medium"` (800px) to `maxWidth="wide"` (1200px)
- Ensures consistent width across all main pages (tasks, family, home)

## Changes
- Updated `apps/frontend/src/app/pages/tasks/tasks.html:1`
- Single line template change: `maxWidth="medium"` → `maxWidth="wide"`

## Testing
- Pure CSS/template change
- No logic modifications
- No tests required

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)