### PR TITLE
fix: QR auth API mismatch - send childId in URL path (#564)

### DIFF
--- a/apps/frontend/src/app/services/qr-auth.service.ts
+++ b/apps/frontend/src/app/services/qr-auth.service.ts
@@ -33,7 +33,7 @@ export class QrAuthService {
    * @returns Observable with QR token response
    */
   generateQrToken(childId: string): Observable<QrTokenResponse> {
-    return this.http.post<QrTokenResponse>(`${this.apiUrl}/generate`, { childId });
+    return this.http.post<QrTokenResponse>(`${this.apiUrl}/generate/${childId}`, {});
   }
 
   /**
@@ -42,7 +42,7 @@ export class QrAuthService {
    * @returns Observable with QR token response
    */
   regenerateQrToken(childId: string): Observable<QrTokenResponse> {
-    return this.http.post<QrTokenResponse>(`${this.apiUrl}/regenerate`, { childId });
+    return this.http.post<QrTokenResponse>(`${this.apiUrl}/regenerate/${childId}`, {});
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes QR code generation failures in production caused by API contract mismatch.

Closes #564

## Problem

When clicking "QR Code" button for a child, the modal shows:
> ⚠️ Failed to generate QR code. Please try again.

Network logs show:
- `POST /api/qr-auth/generate` → 404
- `POST /api/qr-auth/regenerate` → 404

## Root Cause

**Frontend** was sending `childId` in request body:
```typescript
generateQrToken(childId: string) {
  return this.http.post(`${this.apiUrl}/generate`, { childId });  // ❌
}
```

**Backend** expects `childId` in URL path:
```typescript
fastify.post('/generate/:childId', ...)  // ✅
```

## Changes

Updated `apps/frontend/src/app/services/qr-auth.service.ts`:

**Before:**
```typescript
generateQrToken(childId: string): Observable<QrTokenResponse> {
  return this.http.post<QrTokenResponse>(`${this.apiUrl}/generate`, { childId });
}

regenerateQrToken(childId: string): Observable<QrTokenResponse> {
  return this.http.post<QrTokenResponse>(`${this.apiUrl}/regenerate`, { childId });
}
```

**After:**
```typescript
generateQrToken(childId: string): Observable<QrTokenResponse> {
  return this.http.post<QrTokenResponse>(`${this.apiUrl}/generate/${childId}`, {});
}

regenerateQrToken(childId: string): Observable<QrTokenResponse> {
  return this.http.post<QrTokenResponse>(`${this.apiUrl}/regenerate/${childId}`, {});
}
```

## Testing

- ✅ Frontend builds successfully
- ⏳ Will test in production after deployment:
  1. Navigate to Family page
  2. Click "QR Code" for Julie
  3. Should display QR code (not error message)
  4. QR code should be valid for login

## Impact

This fully restores QR auth functionality broken since initial deployment (#238).

🤖 Generated with [Claude Code](https://claude.com/claude-code)