### PR TITLE
fix: QR Code modal close event binding mismatch

### DIFF
--- a/apps/frontend/src/app/components/modals/qr-code-modal/qr-code-modal.html
+++ b/apps/frontend/src/app/components/modals/qr-code-modal/qr-code-modal.html
@@ -1,4 +1,4 @@
-<app-modal [open]="open()" (closeRequested)="handleClose()">
+<app-modal [open]="open()" (closeModal)="handleClose()">
   <h2 slot="title">QR Code Login</h2>
   <div slot="content">
     <app-qr-code-display [childId]="childId()" [childName]="childName()" />


### PR DESCRIPTION
## Summary

Fixes critical bug where QR Code modal cannot be closed via any method (close button, backdrop click, or ESC key).

## Root Cause

Event binding mismatch between base Modal component and QR Code modal wrapper:
- Base `Modal` component emits `closeModal` event
- `QrCodeModal` template was listening for `closeRequested` instead
- This prevented the event from propagating to the parent component

## Changes

- Updated `qr-code-modal.html` event binding from `(closeRequested)` to `(closeModal)`

## Testing

✅ All 883 frontend tests passing
✅ Event wiring verified: Modal → QrCodeModal → Family page

## Manual Testing Needed

- [ ] Close button (X) closes the modal
- [ ] Clicking backdrop closes the modal  
- [ ] Escape key closes the modal
- [ ] Modal can be reopened and closed multiple times
- [ ] No console errors

## Impact

- **Bug Fix**: High-priority UX bug
- **Risk**: Minimal - single line change to correct event binding
- **Regression Risk**: Low - all tests pass, simple event name fix

Closes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)